### PR TITLE
Fix queries for Coq >= 8.7.0

### DIFF
--- a/client/src/CoqLanguageServer.ts
+++ b/client/src/CoqLanguageServer.ts
@@ -239,13 +239,16 @@ export class CoqLanguageServer implements vscode.Disposable {
     return this.server.sendRequest(proto.GetSentencePrefixTextRequest.type, { uri: uri, position: pos }, token || this.cancelRequest.token);
   }
 
-  public async query(uri: string, query: "locate"|"check"|"print"|"search"|"about"|"searchAbout", term: string): Promise<proto.CoqTopQueryResult> {
+  public async query(uri: string, query: "locate"|"check"|"print"|"search"|"about"|"searchAbout", term: string, routeId:Number): Promise<void> {
     await this.server.onReady();
-    return this.server.sendRequest(proto.QueryRequest.type, <proto.CoqTopQueryParams>{
+    const params : proto.CoqTopQueryParams =
+      {
       uri: uri,
       queryFunction: query,
-      query: term
-    }, this.cancelRequest.token);
+      query: term,
+      routeId
+      };
+    return this.server.sendRequest(proto.QueryRequest.type, params , this.cancelRequest.token);
   }
 
   public async setDisplayOptions(uri: string, options: { item: proto.DisplayOption, value: proto.SetDisplayOption }[]): Promise<void> {
@@ -387,8 +390,8 @@ export class CoqDocumentLanguageServer implements vscode.Disposable {
     return this.server.ltacProfGetResults(this.uri, offset);
   }
 
-  public query(query: proto.QueryFunction, term: string): Thenable<proto.CoqTopQueryResult> {
-    return this.server.query(this.uri, query, term);
+  public query(query: proto.QueryFunction, term: string, routeId: Number): Thenable<void> {
+    return this.server.query(this.uri, query, term, routeId);
   }
 
   public setDisplayOptions(options: { item: proto.DisplayOption, value: proto.SetDisplayOption }[]): Thenable<void> {

--- a/client/src/protocol.ts
+++ b/client/src/protocol.ts
@@ -148,7 +148,7 @@ export interface UnfocusedGoalStack {
   // subgoals that appear before the focus
   before: Goal[];
   // reference to the more-focused background goals
-  next?: UnfocusedGoalStack 
+  next?: UnfocusedGoalStack
   // subgoals that appear after the focus
   after: Goal[];
 }
@@ -179,7 +179,7 @@ export type ProofViewResult = ProofView & ProofViewTag
 export type InterruptedResult = CommandInterrupted & InterruptedTag
 export type CommandResult =
   NotRunningResult |
-  BusyResult |
+  (BusyResult & FocusPosition) |
   (FailureResult & FocusPosition) |
   (ProofViewResult & FocusPosition) |
   (InterruptedResult & FocusPosition) |
@@ -207,79 +207,76 @@ export interface LtacProfResults {
 }
 
 
-export namespace InterruptCoqRequest { 
+export namespace InterruptCoqRequest {
   export const type = new RequestType<CoqTopParams, void, void, void>('coqtop/interrupt');
-} 
-export namespace QuitCoqRequest { 
+}
+export namespace QuitCoqRequest {
   export const type = new RequestType<CoqTopParams, void, void, void>('coqtop/quitCoq')
-} 
-export namespace ResetCoqRequest { 
+}
+export namespace ResetCoqRequest {
   export const type = new RequestType<CoqTopParams, void, void, void>('coqtop/resetCoq')
-} 
-export namespace StepForwardRequest { 
+}
+export namespace StepForwardRequest {
   export const type = new RequestType<CoqTopParams, CommandResult, void, void>('coqtop/stepForward')
-} 
-export namespace StepBackwardRequest { 
+}
+export namespace StepBackwardRequest {
   export const type = new RequestType<CoqTopParams, CommandResult, void, void>('coqtop/stepBackward')
-} 
-export namespace InterpretToPointRequest { 
+}
+export namespace InterpretToPointRequest {
   export const type = new RequestType<CoqTopInterpretToPointParams, CommandResult, void, void>('coqtop/interpretToPoint')
-} 
-export namespace InterpretToEndRequest { 
+}
+export namespace InterpretToEndRequest {
   export const type = new RequestType<InterpretToEndParams, CommandResult, void, void>('coqtop/interpretToEnd')
-} 
-export namespace GoalRequest { 
+}
+export namespace GoalRequest {
   export const type = new RequestType<CoqTopParams, CommandResult, void, void>('coqtop/goal')
 }
 export interface CachedGoalParams extends CoqTopParams {
   position: vscode.Position,
   direction: "preceding"|"subsequent",
 }
-export namespace CachedGoalRequest { 
+export namespace CachedGoalRequest {
   export const type = new RequestType<CachedGoalParams, CommandResult, void, void>('coqtop/cachedGoal')
 }
-export namespace FinishComputationsRequest { 
+export namespace FinishComputationsRequest {
   export const type = new RequestType<CoqTopParams, void, void, void>('coqtop/finishComputations')
 }
-export namespace QueryRequest { 
-  export const type = new RequestType<CoqTopQueryParams, CoqTopQueryResult, void, void>('coqtop/query')
+export namespace QueryRequest {
+  export const type = new RequestType<CoqTopQueryParams, void, void, void>('coqtop/query')
 }
 export type QueryFunction = "locate"|"check"|"print"|"search"|"about"|"searchAbout";
 export interface CoqTopQueryParams extends CoqTopParams {
   queryFunction: QueryFunction;
   query: string;
+  routeId: Number;
 }
-export interface CoqTopQueryResult {
-  searchResults: AnnotatedText;
-}
-
 export interface CoqTopResizeWindowParams extends CoqTopParams {
   columns: number;
 }
-export namespace ResizeWindowRequest { 
+export namespace ResizeWindowRequest {
   export const type = new RequestType<CoqTopResizeWindowParams, void, void, void>('coqtop/resizeWindow')
-} 
+}
 
 export interface CoqTopSetDisplayOptionsParams extends CoqTopParams {
   options: {item: DisplayOption, value: SetDisplayOption}[]
 }
-export namespace SetDisplayOptionsRequest { 
+export namespace SetDisplayOptionsRequest {
   export const type = new RequestType<CoqTopSetDisplayOptionsParams, void, void, void>('coqtop/setDisplayOptions')
-} 
+}
 
 export interface CoqTopLtacProfResultsParams extends CoqTopParams {
   offset?: number;
 }
-export namespace LtacProfResultsRequest { 
+export namespace LtacProfResultsRequest {
   export const type = new RequestType<CoqTopLtacProfResultsParams, void, void, void>('coqtop/ltacProfResults')
 }
 
-export namespace GetSentencePrefixTextRequest { 
+export namespace GetSentencePrefixTextRequest {
   export const type = new RequestType<DocumentPositionParams, string, void, void>('coqtop/getSentencePrefixText')
-} 
+}
 
 export enum HighlightType {
-  StateError=0, Parsing=1, Processing=2, Incomplete=3, Processed=4, Axiom=5 
+  StateError=0, Parsing=1, Processing=2, Incomplete=3, Processed=4, Axiom=5
 }
 
 // export interface Highlight {
@@ -297,42 +294,43 @@ export interface Highlights {
 
 export type NotifyHighlightParams = NotificationParams & Highlights;
 
-export namespace UpdateHighlightsNotification { 
+export namespace UpdateHighlightsNotification {
   export const type = new NotificationType<NotifyHighlightParams,void>('coqtop/updateHighlights')
-} 
+}
 
 export interface NotifyMessageParams extends NotificationParams {
   level: string;
   message: AnnotatedText;
+  routeId: Number;
 }
-export namespace CoqMessageNotification { 
+export namespace CoqMessageNotification {
   export const type = new NotificationType<NotifyMessageParams,void>('coqtop/message')
-} 
+}
 
-export namespace CoqResetNotification { 
+export namespace CoqResetNotification {
   export const type = new NotificationType<NotificationParams,void>('coqtop/wasReset')
 }
 
-export namespace CoqtopStartNotification { 
+export namespace CoqtopStartNotification {
   export const type = new NotificationType<NotificationParams,void>('coqtop/coqtopStarted')
-} 
+}
 
 export enum CoqtopStopReason { UserRequest, Anomaly, InternalError }
 export interface NotifyCoqtopStopParams extends NotificationParams {
   reason: CoqtopStopReason;
   message?: string;
 }
-export namespace CoqtopStopNotification { 
+export namespace CoqtopStopNotification {
   export const type = new NotificationType<NotifyCoqtopStopParams,void>('coqtop/coqtopStopped')
-} 
+}
 
 export interface DocumentPositionParams extends NotificationParams {
   position: vscode.Position;
 }
 
-export namespace CoqStmFocusNotification { 
+export namespace CoqStmFocusNotification {
   export const type = new NotificationType<DocumentPositionParams,void>('coqtop/stmFocus')
-} 
+}
 
 
 export enum ComputingStatus {Finished, Computing, Interrupted}
@@ -340,15 +338,15 @@ export enum ComputingStatus {Finished, Computing, Interrupted}
 //   status: ComputingStatus;
 //   computeTimeMS: number;
 // }
-// export namespace CoqComputingStatusNotification { 
+// export namespace CoqComputingStatusNotification {
 //   export const type: NotificationType<NotifyComputingStatusParams> =
 //   { get method() { return 'coqtop/computingStatus' }
-//   , _:undefined }; 
-// } 
+//   , _:undefined };
+// }
 
 export interface NotifyLtacProfResultsParams extends NotificationParams {
   results: LtacProfResults
 }
-export namespace CoqLtacProfResultsNotification { 
+export namespace CoqLtacProfResultsNotification {
   export const type = new NotificationType<NotifyLtacProfResultsParams,void>('coqtop/ltacProfResults')
-} 
+}

--- a/server/src/coqtop/CoqTop.ts
+++ b/server/src/coqtop/CoqTop.ts
@@ -85,7 +85,7 @@ export type GoalResult = NoProofResult | ProofModeResult
 
 export interface EventCallbacks {
   onFeedback? : (feedback: coqProto.StateFeedback) => void;
-  onMessage? : (msg: coqProto.Message) => void;
+  onMessage? : (msg: coqProto.Message, routeId: coqProto.RouteId, stateId?: coqProto.StateId) => void;
   onClosed?: (isError: boolean, message?: string) => void;
 }
 
@@ -125,7 +125,7 @@ export abstract class IdeSlave {
     return { dispose: () => { this.callbacks.onFeedback = undefined; } }
   }
 
-  public onMessage(handler: (msg: coqProto.Message) => void)
+  public onMessage(handler: (msg: coqProto.Message, routeId: coqProto.RouteId, stateId: coqProto.StateId) => void)
   {
     this.callbacks.onMessage = handler;
     return { dispose: () => { this.callbacks.onMessage = undefined; } }
@@ -149,7 +149,7 @@ export abstract class IdeSlave {
   public abstract coqEditAt(stateId: number) : Promise<EditAtResult>;
   public abstract coqLtacProfilingResults(stateId?: number, routeId?: number) : Promise<void>;
   public abstract coqResizeWindow(columns: number) : Promise<void>;
-  public abstract coqQuery(query: string, stateId?: number, routeId?: number) : Promise<AnnotatedText>;
+  public abstract coqQuery(query: string, stateId?: number, routeId?: number) : Promise<void>;
   public abstract coqGetOptions(options: CoqOptions) : Promise<void>;
   public abstract coqSetOptions(options: CoqOptions) : Promise<void>;
 }
@@ -178,7 +178,7 @@ export abstract class CoqTop extends IdeSlave {
   public abstract coqEditAt(stateId: number) : Promise<EditAtResult>;
   public abstract coqLtacProfilingResults(stateId?: number, routeId?: number) : Promise<void>;
   public abstract coqResizeWindow(columns: number) : Promise<void>;
-  public abstract coqQuery(query: string, stateId?: number, routeId?: number) : Promise<AnnotatedText>;
+  public abstract coqQuery(query: string, stateId?: number, routeId?: number) : Promise<void>;
   public abstract coqGetOptions(options: CoqOptions) : Promise<void>;
   public abstract coqSetOptions(options: CoqOptions) : Promise<void>;
 }

--- a/server/src/coqtop/coq-proto.ts
+++ b/server/src/coqtop/coq-proto.ts
@@ -248,7 +248,7 @@ export type CoqValue =
 export type Add_rty = Pair<StateId,Pair<Union<{},StateId>,AnnotatedText>>;
 export type Goal_rty = Goals
 export type EditAt_rty = Union<{},Pair<StateId,Pair<StateId,StateId>>>;
-export type Query_rty = AnnotatedText;
+export type Query_rty = {};
 export type Evars_rty = string[]|undefined;
 export type Hints_rty = Pair<(Pair<string,string>[])[],Pair<string,string>[]>|undefined;
 export type Status_rty = CoqStatus;
@@ -297,7 +297,7 @@ export type ReturnValue = AddReturn|Goals|EditAtJumpFocusReturn|HintsReturn|Inte
 export function GetValue(x: 'Add', value: ValueReturn) : AddReturn;
 export function GetValue(x: 'Edit_at', value: ValueReturn) : EditAtJumpFocusReturn|null;
 export function GetValue(x: 'Goal', value: ValueReturn) : Goals|null;
-export function GetValue(x: 'Query', value: ValueReturn) : AnnotatedText;
+export function GetValue(x: 'Query', value: ValueReturn) : void;
 export function GetValue(x: 'Evars', value: ValueReturn) : string[];
 export function GetValue(x: 'Hints', value: ValueReturn) : HintsReturn;
 export function GetValue(x: 'Status', value: ValueReturn) : CoqStatus;

--- a/server/src/coqtop/xml-protocol/coq-xml.ts
+++ b/server/src/coqtop/xml-protocol/coq-xml.ts
@@ -5,7 +5,8 @@ import * as coqProto from '../coq-proto';
 import {StateId, EditId, Pair, StateFeedback, LtacProfTactic, LtacProfResults,
   UnionL, UnionR, Union, OptionState, Subgoal, Goals, Location, MessageLevel,
   Message, FailValue, UnfocusedGoalStack, SentenceStatus, FeedbackContent,
-  ValueReturn} from '../coq-proto';
+  ValueReturn,
+  RouteId} from '../coq-proto';
 import * as text from '../../util/AnnotatedText';
 import * as util from 'util';
 import {Deserialize} from './deserialize.base';
@@ -13,7 +14,7 @@ import {Deserialize} from './deserialize.base';
 export interface EventCallbacks {
   onValue?: (x: ValueReturn) => void;
   onFeedback? : (feedback: StateFeedback) => void;
-  onMessage? : (msg: Message) => void;
+  onMessage? : (msg: Message, routeId: RouteId, stateId?: StateId) => void;
   onOther? : (tag:string, x: any) => void;
   onError? : (x: any) => void;
 }
@@ -52,7 +53,7 @@ export class XmlStream extends events.EventEmitter {
       if(callbacks.onFeedback)
         this.on('response: feedback', (x:coqProto.StateFeedback) => callbacks.onFeedback(x));
       if(callbacks.onMessage)
-        this.on('response: message', (x:coqProto.Message) => callbacks.onMessage(x));
+        this.on('response: message', (x:coqProto.Message,routeId:coqProto.RouteId,stateId?:coqProto.StateId) => callbacks.onMessage(x,routeId,stateId));
       if(callbacks.onOther)
         this.on('response', (tag:string, x:any) => callbacks.onOther(tag,x));
       if(callbacks.onError)

--- a/server/src/document.ts
+++ b/server/src/document.ts
@@ -34,7 +34,7 @@ export interface TextDocumentItem {
 
 
 export interface MessageCallback {
-  sendMessage(level: string, message: AnnotatedText) : void;
+  sendMessage(level: string, message: AnnotatedText, routeId: coqProto.RouteId) : void;
 }
 export interface ResetCallback {
   sendReset() : void;
@@ -291,8 +291,8 @@ export class CoqDocument implements TextDocument {
   }
 
 
-  private onCoqMessage(level: coqProto.MessageLevel, message: AnnotatedText) {
-    this.callbacks.sendMessage(coqProto.MessageLevel[level], message);
+  private onCoqMessage(level: coqProto.MessageLevel, message: AnnotatedText, routeId: coqProto.RouteId) {
+    this.callbacks.sendMessage(coqProto.MessageLevel[level], message, routeId);
   }
 
   private onCoqStateLtacProf(range: Range, results: coqProto.LtacProfResults) {
@@ -320,7 +320,7 @@ export class CoqDocument implements TextDocument {
         clearSentence: (x1) => this.onClearSentence(x1),
         updateStmFocus: (x1) => this.onUpdateStmFocus(x1),
         error: (x1,x2,x3) => this.onCoqStateError(x1,x2,x3),
-        message: (x1,x2) => this.onCoqMessage(x1,x2),
+        message: (x1,x2,x3) => this.onCoqMessage(x1,x2,x3),
         ltacProfResults: (x1,x2) => this.onCoqStateLtacProf(x1,x2),
         coqDied: (reason: thmProto.CoqtopStopReason, error?: string) => this.onCoqDied(reason, error),
       });
@@ -916,21 +916,21 @@ export class CoqDocument implements TextDocument {
       this.stm.finishComputations();
   }
 
-  public async query(query: "locate"|"check"|"print"|"search"|"about"|"searchAbout", term: string) {
+  public async query(query: "locate"|"check"|"print"|"search"|"about"|"searchAbout", term: string, routeId: coqProto.RouteId) {
     if(!this.isStmRunning())
       return "Coq is not running";
     switch(query) {
       case "locate":
         try {
-          return await this.stm.doQuery(`Locate ${term}.`);
+          return await this.stm.doQuery(`Locate ${term}.`, routeId);
         } catch(err) {
-          return await this.stm.doQuery(`Locate "${term}".`);
+          return await this.stm.doQuery(`Locate "${term}".`, routeId);
         }
-      case "check":       return await this.stm.doQuery(`Check ${term}.`)
-      case "print":       return await this.stm.doQuery(`Print ${term}.`)
-      case "search":      return await this.stm.doQuery(`Search ${term}.`)
-      case "about":       return await this.stm.doQuery(`About ${term}.`)
-      case "searchAbout": return await this.stm.doQuery(`SearchAbout ${term}.`)
+      case "check":       return await this.stm.doQuery(`Check ${term}.`, routeId)
+      case "print":       return await this.stm.doQuery(`Print ${term}.`, routeId)
+      case "search":      return await this.stm.doQuery(`Search ${term}.`, routeId)
+      case "about":       return await this.stm.doQuery(`About ${term}.`, routeId)
+      case "searchAbout": return await this.stm.doQuery(`SearchAbout ${term}.`, routeId)
     }
   }
 

--- a/server/src/protocol.ts
+++ b/server/src/protocol.ts
@@ -1,6 +1,7 @@
 'use strict';
 import { RequestType, NotificationType } from 'vscode-jsonrpc';
 import * as vscode from 'vscode-languageserver-types';
+import { RouteId } from './coqtop/coq-proto';
 
 export interface DocumentFilter {
   language?: string,
@@ -242,17 +243,14 @@ export namespace FinishComputationsRequest {
   export const type = new RequestType<CoqTopParams, void, void, void>('coqtop/finishComputations')
 }
 export namespace QueryRequest {
-  export const type = new RequestType<CoqTopQueryParams, CoqTopQueryResult, void, void>('coqtop/query')
+  export const type = new RequestType<CoqTopQueryParams, void, void, void>('coqtop/query')
 }
 export type QueryFunction = "locate"|"check"|"print"|"search"|"about"|"searchAbout";
 export interface CoqTopQueryParams extends CoqTopParams {
   queryFunction: QueryFunction;
   query: string;
+  routeId: RouteId;
 }
-export interface CoqTopQueryResult {
-  searchResults: AnnotatedText;
-}
-
 export interface CoqTopResizeWindowParams extends CoqTopParams {
   columns: number;
 }
@@ -304,6 +302,7 @@ export namespace UpdateHighlightsNotification {
 export interface NotifyMessageParams extends NotificationParams {
   level: string;
   message: AnnotatedText;
+  routeId: RouteId;
 }
 export namespace CoqMessageNotification {
   export const type = new NotificationType<NotifyMessageParams,void>('coqtop/message')

--- a/server/test/STM.ts
+++ b/server/test/STM.ts
@@ -38,7 +38,7 @@ class MockCoqTop extends coqtop.CoqTop {
   async coqEditAt(stateId: number) { return {} };
   async coqLtacProfilingResults(stateId?: number, routeId?: number) {};
   async coqResizeWindow(columns: number) {};
-  async coqQuery(query: string, stateId?: number, routeId?: number) { return "" };
+  async coqQuery(query: string, stateId?: number, routeId?: number) { return; };
   async coqGetOptions(options) {};
   async coqSetOptions(options) {};
 }


### PR DESCRIPTION
Queries are now asynchronous and routed. This patch effectively drops
support for older Coq versions, we will need to update the
documentation.

Fixes #10.