### PR TITLE
Fix and simplify inheritance of CSS properties from VSCode

### DIFF
--- a/html_views/src/goals/Coq.html
+++ b/html_views/src/goals/Coq.html
@@ -12,7 +12,7 @@
     }
   </script>
 </head>
-<body onload="load()" class="prettifySymbolsMode vscode-dark">
+<body onload="load()" class="prettifySymbolsMode">
   <div id="toolbar">
     <button value="R" onclick="location.reload(true)">Refresh</button>
     <!--<button title="Toggle prettify-symbols-mode" value="P" id="togglePrettifySymbols" onclick="togglePrettifySymbolsMode()">Prettify</button>-->

--- a/html_views/src/goals/default-proof-view.css
+++ b/html_views/src/goals/default-proof-view.css
@@ -12,7 +12,6 @@ html, body {
 }
 body {
   background-color: var(--background-color);
-  color: var(--color, hsl(0, 0%, 80%));
   font-family: var(--font-family, 'Segoe WPC','Segoe UI', SFUIText-Light, HelveticaNeue-Light, sans-serif, 'Droid Sans Fallback');
   font-weight: var(--font-weight);
   font-size: var(--font-size, 12pt);
@@ -20,11 +19,16 @@ body {
 body.vscode-light {
   color: var(--color, hsl(0, 0%, 20%));
 }
+body.vscode-dark {
+  color: var(--color, hsl(0, 0%, 80%));
+}
 #messages {
-  color: hsl(0, 0%, 80%);
   padding: 0 10pt;
-  font-family: var(--code-font-family);
-  font-size: var(--code-font-size);
+  font-family: var(--vscode-editor-font-family);
+  font-size: var(--vscode-editor-font-size);
+}
+.vscode-dark #messages {
+  color: hsl(0, 0%, 80%);
 }
 .vscode-light #messages {
   color: hsl(0, 0%, 20%);
@@ -33,14 +37,16 @@ body.vscode-light {
   padding-left: 4pt;
 }
 #error {
-  color: red;
   white-space: pre-wrap;
-  font-family: var(--code-font-family);
-  font-size: var(--code-font-size);
+  font-family: var(--vscode-editor-font-family);
+  font-size: var(--vscode-editor-font-size);
   padding: 0 10pt;
 }
 .vscode-dark #error {
   color: pink;
+}
+.vscode-light #error {
+  color: red;
 }
 .hidden {
   display: none;
@@ -56,9 +62,12 @@ body.vscode-light {
 }
 
 .hypotheses {
-  border-bottom: 2pt solid hsla(0, 0%, 100%, 0.4);
+  border-bottom: 2pt solid;
   padding: 0pt;
   padding-bottom: 1em;
+}
+.vscode-dark .hypotheses {
+  border-bottom-color: hsla(0, 0%, 100%, 0.4)
 }
 .vscode-light .hypotheses {
   border-bottom-color: hsla(0, 0%, 0%, 0.2);
@@ -67,7 +76,7 @@ body.vscode-light {
   margin-right: 1ex;
   margin-left: 3pt;
 }
-.hypotheses .hypothesis .ident {
+.vscode-dark .hypotheses .hypothesis .ident {
   color: lightseagreen;
 }
 .vscode-light .hypotheses .hypothesis .ident {
@@ -86,13 +95,13 @@ body.vscode-light {
   padding: 2pt 10pt;
   text-indent: 0pt
 }
-.hypotheses li:nth-child(odd) {
+.vscode-dark .hypotheses li:nth-child(odd) {
   background-color: hsla(0, 0%, 0%, 0.05);
 }
-.hypotheses .new {
+.vscode-dark .hypotheses .new {
   background-color: rgba(0,255,0,0.09) !important;
 }
-.hypotheses .changed {
+.vscode-dark .hypotheses .changed {
   background-color: rgba(0,0,255,0.15) !important;
 }
 .vscode-light .hypotheses li:nth-child(odd) {
@@ -126,9 +135,11 @@ body.vscode-light {
   opacity: 1;
 }*/
 .goal .goalId {
-  color: lightblue;
   /*display: block;*/
   margin-right: 1ex;
+}
+.vscode-dark .goal .goalId {
+  color: lightblue;
 }
 .vscode-light .goal .goalId {
   color: darkblue;
@@ -153,22 +164,29 @@ body.vscode-light {
   font-style: italic;
 }
 .charsAdded {
-  background-color: rgba(0,250,0,0.1);
   font-style: italic;
+}
+.vscode-dark .charsAdded {
+  background-color: rgba(0,250,0,0.1);
 }
 span[class~=charsAdded][class~=substitution]::before {
-  background-color: rgba(0,250,0,0.1);
   font-style: italic;
 }
+.vscode-dark span[class~=charsAdded][class~=substitution]::before {
+  background-color: rgba(0,250,0,0.1);
+}
 .charsRemoved {
-  background-color: rgba(250,0,0,0.6);
   text-decoration: line-through;
+}
+.vscode-dark .charsRemoved {
+  background-color: rgba(250,0,0,0.6);
 }
 span[class~=charsRemoved][class~=substitution]::before {
-  background-color: rgba(250,0,0,0.6);
   text-decoration: line-through;
 }
-
+.vscode-dark span[class~=charsRemoved][class~=substitution]::before {
+  background-color: rgba(250,0,0,0.6);
+}
 .vscode-light .charsAdded {
   background-color: rgba(0,250,0,0.2);
 }
@@ -192,9 +210,9 @@ span[class~=charsRemoved][class~=substitution]::before {
 }*/
 
 .hypothesese, .hypothesis, .goal, #stdout, #textMeasurer, #measureTest {
-  font-family: var(--code-font-family);
-  font-weight: var(--code-font-weight);
-  font-size: var(--code-font-size);
+  font-family: var(--vscode-editor-font-family);
+  font-weight: var(--vscode-editor-font-weight);
+  font-size: var(--vscode-editor-font-size);
 }
 
 .goalsList {
@@ -206,12 +224,17 @@ span[class~=charsRemoved][class~=substitution]::before {
   border-top: 0pt;
 }
 .goalsList li {
-  border-top: 1pt solid hsla(0, 0%, 100%, 0.2);
+  border-top: 1pt solid;
   padding: 5pt 10pt;
+}
+.vscode-dark .goalsList li:first-child {
   background-color: hsla(0, 0%, 100%, 0.05);
 }
 .vscode-light .goalsList li:first-child {
   background-color: inherit;
+}
+.vscode-dark .goalsList li {
+  border-top-color: hsla(0, 0%, 100%, 0.2);
 }
 .vscode-light .goalsList li {
   border-top-color: hsla(0, 0%, 0%, 0.2);
@@ -231,11 +254,8 @@ span[class~=charsRemoved][class~=substitution]::before {
 
 #toolbar button {
   display: inline-block;
-  background: hsla(0, 0%, 100%, 0.05);
-  border-color: hsla(0, 0%, 100%, 0.2);
   border-width: 1px;
   height: 100%;
-  color: hsl(0, 0%, 80%);
   padding: 2pt 8pt;
   font-size: inherit;
   font-family: inherit;
@@ -243,13 +263,20 @@ span[class~=charsRemoved][class~=substitution]::before {
 }
 #toolbar button:hover, #toolbar button:active {
   cursor: pointer;
-  background: hsla(0, 0%, 100%, 0.1);
 }
 
+.vscode-dark #toolbar button {
+  background: hsla(0, 0%, 100%, 0.05);
+  border-color: hsla(0, 0%, 100%, 0.2);
+  color: hsl(0, 0%, 80%);
+}
 .vscode-light #toolbar button {
   background: hsla(0, 0%, 0%, 0.05);
   border-color: hsla(0, 0%, 0%, 0.2);
   color: hsl(0, 0%, 20%);
+}
+.vscode-dark #toolbar button:hover, .vscode-light #toolbar button:active {
+  background: hsla(0, 0%, 100%, 0.1);
 }
 .vscode-light #toolbar button:hover, .vscode-light #toolbar button:active {
   background: hsla(0, 0%, 0%, 0.1);

--- a/html_views/src/goals/model.ts
+++ b/html_views/src/goals/model.ts
@@ -61,24 +61,6 @@ function onWindowGetFocus(event: FocusEvent) {
   }
 }
 
-function getVSCodeTheme() : 'vscode-dark'|'vscode-light'|'vscode-high-contrast'|'' {
-  switch($(parent.document.body).attr('class')) {
-    case 'vscode-dark': return 'vscode-dark'
-    case 'vscode-light': return 'vscode-light'
-    case 'vscode-high-contrast': return 'vscode-high-contrast'
-    default:
-      return '';
-  }
-}
-
-const observer = new MutationObserver(function(mutations) {
-    inheritStyles(parent.parent);
-    $(document.body).attr('class',getVSCodeTheme());
-    // mutations.forEach(function(mutationRecord) {
-    //   console.log(`{name: ${mutationRecord.attributeName}, old: ${mutationRecord.oldValue}, new: ${$(mutationRecord.target).attr('class')} }`);
-    // });
-});
-
 function setPrettifySymbolsMode(enabled: boolean) {
   $(document.body)
     .toggleClass("prettifySymbolsMode", enabled);
@@ -88,21 +70,8 @@ declare var vscode : any;
 declare var acquireVsCodeApi : any;
 function load() {
 
-  try {
-    window.onresize = throttleEventHandler(event => computePrintingWidth);
-    window.addEventListener("focus", onWindowGetFocus, true);
-    //observer.observe(parent.document.body, { attributes : true, attributeFilter: ['class'] });
-    //inheritStyles(parent.parent);
-    $(document.body)
-      //.removeClass("vscode-dark")
-      .removeClass("vscode-light")
-      //.addClass(getVSCodeTheme());
-  } catch(error) {
-    $('#stdout').text(error.toString());
-    $('#error').text(error.toString());
-    return;
-  }
-
+  window.onresize = throttleEventHandler(event => computePrintingWidth);
+  window.addEventListener("focus", onWindowGetFocus, true);
   vscode = acquireVsCodeApi();
 
   window.addEventListener('message', event => {
@@ -134,12 +103,6 @@ function unloadCSS() {
 }
 
 function updateSettings(settings: SettingsState) : void {
-  if(settings.fontFamily !== undefined)
-    document.documentElement.style.setProperty(`--code-font-family`, settings.fontFamily);
-  if(settings.fontSize !== undefined)
-    document.documentElement.style.setProperty(`--code-font-size`, settings.fontSize);
-  if(settings.fontWeight !== undefined)
-    document.documentElement.style.setProperty(`--code-font-weight`, settings.fontWeight);
   if(settings.cssFile !== undefined)
     loadCSS(settings.cssFile);
   if(settings.prettifySymbolsMode !== undefined)


### PR DESCRIPTION
This patch also fixes incorrect behavior with light themes. Support for
high contrast themes should still be addressed.