### PR TITLE
Do not reset Coq when going back past the beginning of document

### DIFF
--- a/server/src/stm/STM.ts
+++ b/server/src/stm/STM.ts
@@ -373,9 +373,7 @@ export class CoqStateMachine {
       return null;
     try {
       await this.validateState(false);
-      if(this.focusedSentence === this.root)
-        this.resetCoqtop();
-      else
+      if (this.focusedSentence !== this.root)
         await this.cancelSentence(this.focusedSentence);
       return null;
     } catch (error) {


### PR DESCRIPTION
Coq should be reset only when explicitly asked, ans this behavior was
also triggering some bugs.