### PR TITLE
Do not show info panel when info feedback is received

### DIFF
--- a/client/src/CoqDocument.ts
+++ b/client/src/CoqDocument.ts
@@ -181,7 +181,6 @@ export class CoqDocument implements vscode.Disposable {
           this.project.infoOut.appendLine(psm.prettyTextToString(params.message));
           return;
         case 'info':
-          this.project.infoOut.show(true);
           this.project.infoOut.appendLine(psm.prettyTextToString(params.message));
           return;
         case 'notice':


### PR DESCRIPTION
Such feedback is usually useless (foo is defined) and prevents the user
from reading the more important "problems" panel.