### PR TITLE
Migrate links

### DIFF
--- a/CoqProtocol.md
+++ b/CoqProtocol.md
@@ -1,4 +1,4 @@
-#*This documentation is moving to the [project wiki](https://github.com/siegebell/vscoq/wiki)*.
+#*This documentation is moving to the [project wiki](https://github.com/coq-community/vscoq/wiki)*.
 
 
 #CoqTop XML Protocol#

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 A plugin for the [Coq Proof Assistant 8.5 and 8.6](https://coq.inria.fr/) in [Visual Studio Code](https://code.visualstudio.com/).
 
-* [Setup instructions](https://github.com/siegebell/vscoq/wiki/Setup)
-* [Tips](https://github.com/siegebell/vscoq/wiki/Tips)
+* [Setup instructions](https://github.com/coq-community/vscoq/wiki/Setup)
+* [Tips](https://github.com/coq-community/vscoq/wiki/Tips)
 
 ## Features
 * Asynchronous proofs

--- a/client/README.md
+++ b/client/README.md
@@ -1,7 +1,7 @@
 A plugin for the [Coq Proof Assistant 8.5 and 8.6](https://coq.inria.fr/) in [Visual Studio Code](https://code.visualstudio.com/).
 
-* [Setup instructions](https://github.com/siegebell/vscoq/wiki/Setup)
-* [Tips](https://github.com/siegebell/vscoq/wiki/Tips)
+* [Setup instructions](https://github.com/coq-community/vscoq/wiki/Setup)
+* [Tips](https://github.com/coq-community/vscoq/wiki/Tips)
 
 ## Features
 * Asynchronous proofs

--- a/client/package.json
+++ b/client/package.json
@@ -24,9 +24,9 @@
 	"activationEvents": [
 		"onLanguage:coq"
 	],
-	"readme": "https://github.com/siegebell/vscoq/blob/master/README.md",
-	"bugs": "https://github.com/siegebell/vscoq/issues",
-	"homepage": "https://github.com/siegebell/vscoq/blob/master/README.md",
+	"readme": "https://github.com/coq-community/vscoq/blob/master/README.md",
+	"bugs": "https://github.com/coq-community/vscoq/issues",
+	"homepage": "https://github.com/coq-community/vscoq/blob/master/README.md",
 	"main": "./out/src/extension",
 	"contributes": {
 		"languages": [
@@ -595,7 +595,7 @@
 	},
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/siegebell/vscoq.git"
+		"url": "https://github.com/coq-community/vscoq.git"
 	},
 	"__metadata": {
 		"id": "ddfd0191-e75d-4ac2-870d-81db351b747f",

--- a/html_views/package.json
+++ b/html_views/package.json
@@ -27,6 +27,6 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/siegebell/vscoq.git"
+    "url": "https://github.com/coq-community/vscoq.git"
   }
 }

--- a/server/package.json
+++ b/server/package.json
@@ -41,6 +41,6 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/siegebell/vscoq.git"
+    "url": "https://github.com/coq-community/vscoq.git"
   }
 }


### PR DESCRIPTION
Per https://github.com/coq-community/vscoq/issues/7#issuecomment-525792440, I've migrated the wiki to this repo, and am updating the links accordingly.