### PR TITLE
Remove external opening of proof view

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,6 @@ default: compile
 clean:
 	rm -rf html_views/node_modules server/node_modules client/node_modules
 	rm -rf client/server client/html_views
-	rm -rf html_views/jquery
 
 html_views/node_modules:
 	cd html_views && npm install
@@ -16,14 +15,7 @@ client/node_modules:
 
 node_modules: html_views/node_modules server/node_modules client/node_modules
 
-html_views/jquery:
-	mkdir -p html_views/jquery
-	wget https://code.jquery.com/jquery-2.2.4.min.js -O html_views/jquery/jquery-2.2.4.min.js
-	wget https://jqueryui.com/resources/download/jquery-ui-1.12.1.zip
-	unzip -p jquery-ui-1.12.1.zip jquery-ui-1.12.1/jquery-ui.min.js > html_views/jquery/jquery-ui.min.js
-	rm jquery-ui-1.12.1.zip
-
-compile: node_modules html_views/jquery
+compile: node_modules
 	cd server && npm run compile
 	cd html_views && npm run compile
 	cd client && npm run compile

--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ original author of this extension is @siegebell.
 * Smarter editing: does not roll back the state when editing whitespace or comments
 * Works with [prettify-symbols-mode](https://marketplace.visualstudio.com/items?itemName=siegebell.prettify-symbols-mode)
 * Supports \_CoqProject
-* The proof-view can be opened in an external web browser
 * LtacProf results treeview
 
 ## Requirements

--- a/client/package.json
+++ b/client/package.json
@@ -113,31 +113,6 @@
 					"default": "first-interaction",
 					"description": "Create the proof view when a Coq script is opened, the user first interacts with coqtop, or else let the user do it manually."
 				},
-				"coq.externalViewUrlCommand": {
-					"anyOf": [
-						{
-							"enum": [
-								"firefox ${url}",
-								"chrome ${url}",
-								"'/Applications/Google Chrome.app/Contents/MacOS/Google Chrome' ${url}"
-							]
-						},
-						{
-							"type": "string"
-						}
-					],
-					"default": "${url}",
-					"description": "The command to execute to view a url."
-				},
-				"coq.externalViewScheme": {
-					"type": "string",
-					"enum": [
-						"file",
-						"http"
-					],
-					"default": "http",
-					"description": "Choose to host external proof-views either via the file system or a web service. \"file\": let the filesystem host the webpage (file:///); \"http\": run a webserver to host the webpage. Some external viewers (like Window's 'start' and OSX's 'open') do not preserve query parameters when viewing \"file\" schemes, so you may try \"http\" instead."
-				},
 				"coq.format.enable": {
 					"type": "boolean",
 					"default": true,
@@ -346,11 +321,6 @@
 			{
 				"command": "extension.coq.proofView.open",
 				"title": "Open proof view",
-				"category": "Coq"
-			},
-			{
-				"command": "extension.coq.proofView.openExternal",
-				"title": "Open proof view in external browser",
 				"category": "Coq"
 			},
 			{

--- a/client/src/CoqDocument.ts
+++ b/client/src/CoqDocument.ts
@@ -474,20 +474,12 @@ export class CoqDocument implements vscode.Disposable {
     }
   }
 
-  public async viewGoalState(editor: TextEditor, external: boolean) {
+  public async viewGoalState(editor: TextEditor) {
     try {
-      if(external) {
-        await this.view.showExternal(this.project.settings.externalViewScheme, (url:string) => {
-          const command = this.project.settings.externalViewUrlCommand.replace(/\$\{url\}/g, url);
-          const parts = require('string-argv')(command) as string[];
-          return {module: parts[0], args: parts.slice(1)};
-        });
-      } else {
-        if (editor.viewColumn)
-          await this.view.show(adjacentPane(editor.viewColumn))
-        else
-          await this.view.show(vscode.ViewColumn.One)
-      };
+      if (editor.viewColumn)
+        await this.view.show(adjacentPane(editor.viewColumn))
+      else
+        await this.view.show(vscode.ViewColumn.One)
     } catch (err) {}
   }
 

--- a/client/src/CoqView.ts
+++ b/client/src/CoqView.ts
@@ -57,7 +57,6 @@ export interface CoqView extends vscode.Disposable {
   readonly resize : vscode.Event<number>;
 
   show(pane: vscode.ViewColumn, state?: proto.CommandResult) : Promise<void>;
-  showExternal(scheme: "file"|"http", command?: (url:string)=>{module: string, args: string[]}) : Promise<void>;
 
   isVisible() : boolean;
 

--- a/client/src/HtmlCoqView.ts
+++ b/client/src/HtmlCoqView.ts
@@ -8,10 +8,8 @@ import * as proto from './protocol'
 import * as path from 'path';
 import * as docs from './CoqProject';
 import * as nasync from './nodejs-async';
-import * as webServer from './WebServer';
 import * as psm from './prettify-symbols-mode';
 
-const opener = require('opener');
 import mustache = require('mustache');
 
 interface ControllerEvent {
@@ -60,10 +58,6 @@ function proofViewHtmlPath() {
   return proofViewFile('Coq.html');
 }
 
-
-function coqViewToFileUri(uri: vscode.Uri) {
-  return `vscode-resource://${uri.path}?${uri.query}#${uri.fragment}`;
-}
 
 /**
  * Displays a Markdown-HTML file which contains javascript to connect to this view
@@ -159,25 +153,6 @@ export class HtmlCoqView implements view.CoqView {
     this.initializePanel(pane);
 
     this.visible = true;
-  }
-
-  public async showExternal(scheme: "file"|"http", command? : (url:string)=>{module: string, args: string[]}) : Promise<void> {
-    let url : string;
-    if(scheme === "file") {
-      url = decodeURIComponent(coqViewToFileUri(this.coqViewUri).toString());
-    } else {
-            // this.coqViewUri = vscode.Uri.parse(`coq-view://${proofViewHtmlPath().path.replace(/%3A/, ':')}?host=${serverAddress.address}&port=${serverAddress.port}`);
-      const uri = await webServer.serveDirectory("proof-view/", proofViewFile('..').fsPath, "**/*.{html,css,js}");
-      if(!uri)
-        return Promise.reject("Cannot find proof view script");
-      url = decodeURIComponent(uri.with({path: uri.path + 'goals/Coq.html', query: this.coqViewUri.query, fragment: this.coqViewUri.fragment }).toString());
-    }
-    if(!command)
-      return Promise.resolve(opener(url));
-    else {
-      const c = command(url);
-      return Promise.resolve(opener(c.args.join(' '), {command: c.module}));
-    }
   }
 
   public dispose() {

--- a/client/src/HtmlLtacProf.ts
+++ b/client/src/HtmlLtacProf.ts
@@ -7,7 +7,6 @@ import * as WebSocket from 'ws';
 import * as http from 'http';
 import {extensionContext} from './extension'
 
-const opener = require('opener');
 
 
 function coqViewToFileUri(uri: vscode.Uri) {
@@ -112,10 +111,6 @@ export class HtmlLtacProf {
     await vscode.commands.executeCommand('vscode.previewHtml', this.coqViewUri, vscode.ViewColumn.Two, "LtacProf");
     // if(preserveFocus && focusedDoc)
     //   await vscode.window.showTextDocument(focusedDoc);
-  }
-
-  public showExternal() : Promise<void> {
-    return Promise.resolve(opener(decodeURIComponent(coqViewToFileUri(this.coqViewUri).toString()), {command:"firefox"}));
   }
 
   dispose() {

--- a/client/src/MDCoqView.ts
+++ b/client/src/MDCoqView.ts
@@ -162,10 +162,6 @@ export class MDCoqView implements view.CoqView {
     await vscode.window.showTextDocument(this.editor.document,vscode.ViewColumn.Two);
   }
 
-  public showExternal() : Promise<void> {
-    return Promise.reject('external view is unsupported');
-  }
-
   public isVisible() : boolean {
     return this.visible;
   }

--- a/client/src/SimpleCoqView.ts
+++ b/client/src/SimpleCoqView.ts
@@ -60,10 +60,6 @@ export class SimpleCoqView implements view.CoqView {
     await this.out.show(vscode.ViewColumn.Two,true);
   }
 
-  public showExternal() : Promise<void> {
-    return Promise.reject('external view is unsupported');
-  }
-
   public isVisible() : boolean {
     return this.visible;
   }

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -64,7 +64,6 @@ export function activate(context: ExtensionContext) {
   regTCmd('query.prompt.print', queryPrint);
   regTCmd('proofView.viewStateAt', viewProofStateAt); 
   regTCmd('proofView.open', viewCurrentProofState); 
-  regTCmd('proofView.openExternal', viewProofStateExternal);
   regCmd('proofView.customizeProofViewStyle', customizeProofViewStyle);
   regProjectCmd('ltacProf.getResults', project.ltacProfGetResults);
   regCmd('display.toggle.implicitArguments', () => project.setDisplayOption(proto.DisplayOption.ImplicitArguments, proto.SetDisplayOption.Toggle)); 
@@ -192,13 +191,7 @@ function viewProofStateAt(editor: TextEditor, edit: TextEditorEdit) {
 
 function viewCurrentProofState(editor: TextEditor, edit: TextEditorEdit) {
   return withDocAsync(editor, async (doc) =>
-    doc.viewGoalState(editor,false)
-  )
-}
-
-function viewProofStateExternal(editor: TextEditor, edit: TextEditorEdit) {
-  return withDocAsync(editor, async (doc) =>
-    doc.viewGoalState(editor,true)
+    doc.viewGoalState(editor)
   )
 }
 


### PR DESCRIPTION
It was no longer working since the switch to webview, and was adding
a lot of complexity.

Closes #22