### PR TITLE
Output spaces instead of non-breaking spaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 * fix #26 (Focus lost on first go to point)
 * fix #33 (Top module name should be set properly)
 * fix #39 (UnhandledPromiseRejectionWarning)
+* fix #59 (Output spaces instead of non-breaking spaces)
 * fix #60 (Clear the goals when not in proof mode)
 
 Note: PR and issue numbers below refer to the previous VsCoq repository

--- a/client/src/prettify-symbols-mode.ts
+++ b/client/src/prettify-symbols-mode.ts
@@ -69,7 +69,7 @@ export function prettyTextToString(txt: text.AnnotatedText) : string {
   const str: string = enabled ? text.textToDisplayString(txt) : text.textToString(txt);
   // `coqtop` loves outputting non-breaking spaces instead of normal whitespace, so we replace
   // them here with spaces to allow the user to copy any output and use it directly as input.
-  return str.replace(/\u00a0/g, " ");
+  return str.replace(/\u00a0+/g, " ");
 }
 
 export function load() : vscode.Disposable {

--- a/client/src/prettify-symbols-mode.ts
+++ b/client/src/prettify-symbols-mode.ts
@@ -66,10 +66,10 @@ function onPrettifySymbolsModeEnabledChange(isEnabled: boolean) {
 }
 
 export function prettyTextToString(txt: text.AnnotatedText) : string {
-  if(enabled)
-    return text.textToDisplayString(txt);
-  else
-    return text.textToString(txt);
+  const str: string = enabled ? text.textToDisplayString(txt) : text.textToString(txt);
+  // `coqtop` loves outputting non-breaking spaces instead of normal whitespace, so we replace
+  // them here with spaces to allow the user to copy any output and use it directly as input.
+  return str.replace(/\u00a0/g, " ");
 }
 
 export function load() : vscode.Disposable {

--- a/client/src/prettify-symbols-mode.ts
+++ b/client/src/prettify-symbols-mode.ts
@@ -67,9 +67,9 @@ function onPrettifySymbolsModeEnabledChange(isEnabled: boolean) {
 
 export function prettyTextToString(txt: text.AnnotatedText) : string {
   const str: string = enabled ? text.textToDisplayString(txt) : text.textToString(txt);
-  // `coqtop` loves outputting non-breaking spaces instead of normal whitespace, so we replace
-  // them here with spaces to allow the user to copy any output and use it directly as input.
-  return str.replace(/\u00a0+/g, " ");
+  // `coqtop` loves outputting non-breaking spaces instead of normal whitespace, so we replace them
+  // here with tabs and spaces to allow the user to copy any output and use it directly as input.
+  return str.replace(/\u00a0{4}/, "\t").replace(/\u00a0/g, " ");
 }
 
 export function load() : vscode.Disposable {


### PR DESCRIPTION
A rebase of @varkor's https://github.com/siegebell/vscoq/pull/164. Fixes #58.

The code is all @varkor; I only rebased it and tested it on the example in #58 (I had tested the original code before).

The fix seems reasonable to me, tho I'm no JS expert.