### PR TITLE
Clear goals on not in proof mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 * fix #26 (Focus lost on first go to point)
 * fix #33 (Top module name should be set properly)
 * fix #39 (UnhandledPromiseRejectionWarning)
+* fix #60 (Clear the goals when not in proof mode)
 
 Note: PR and issue numbers below refer to the previous VsCoq repository
 (https://github.com/siegebell/vscoq).

--- a/html_views/src/goals/StateModel.ts
+++ b/html_views/src/goals/StateModel.ts
@@ -168,31 +168,27 @@ export class StateModel {
       this.clearErrorMessage();
       $('#stdout').text('');
 
-      if(state.type === 'failure')
+      $('#states').empty();
+      if (state.type === 'failure')
         this.setErrorMessage(state.message);
-      else if(state.type === 'not-running')
+      else if (state.type === 'not-running')
         this.setMessage('Not running.');
-      else if(state.type === 'no-proof') {
-        $('#states').empty();
+      else if (state.type === 'no-proof')
         this.setMessage('Not in proof mode.');
-      }
-      else if(state.type === 'interrupted')
+      else if (state.type === 'interrupted')
         this.setMessage("Interrupted.");
-      else if(state.type === 'proof-view') {
+      else if (state.type === 'proof-view') {
         if (countAllGoals(state) == 0) {
-          $('#states').empty();
           this.setMessage("No more subgoals.");
         } else if (state.goals) {
           if(state.goals.length > 0) {
             this.setMessage("");
             $('#states')
-            .empty()
             .append(
               [ createHypotheses(state.goals[0].hypotheses)
               , createFocusedGoals(state.goals)
             ])
           } else {
-            $('#states').empty();
             this.setMessage("There are unfocused goals.");
           }
         }

--- a/html_views/src/goals/StateModel.ts
+++ b/html_views/src/goals/StateModel.ts
@@ -172,8 +172,10 @@ export class StateModel {
         this.setErrorMessage(state.message);
       else if(state.type === 'not-running')
         this.setMessage('Not running.');
-      else if(state.type === 'no-proof')
+      else if(state.type === 'no-proof') {
+        $('#states').empty();
         this.setMessage('Not in proof mode.');
+      }
       else if(state.type === 'interrupted')
         this.setMessage("Interrupted.");
       else if(state.type === 'proof-view') {

--- a/html_views/src/goals/StateModel.ts
+++ b/html_views/src/goals/StateModel.ts
@@ -169,15 +169,15 @@ export class StateModel {
       $('#stdout').text('');
 
       $('#states').empty();
-      if (state.type === 'failure')
+      if(state.type === 'failure')
         this.setErrorMessage(state.message);
-      else if (state.type === 'not-running')
+      else if(state.type === 'not-running')
         this.setMessage('Not running.');
-      else if (state.type === 'no-proof')
+      else if(state.type === 'no-proof')
         this.setMessage('Not in proof mode.');
-      else if (state.type === 'interrupted')
+      else if(state.type === 'interrupted')
         this.setMessage("Interrupted.");
-      else if (state.type === 'proof-view') {
+      else if(state.type === 'proof-view') {
         if (countAllGoals(state) == 0) {
           this.setMessage("No more subgoals.");
         } else if (state.goals) {


### PR DESCRIPTION
(Tested) rebase of https://github.com/siegebell/vscoq/pull/146, minus cosmetic changes. Fixes #60.

Quoting @varkor's description:
> It can be counter-intuitive to persist goals that are no longer relevant, when not in proof mode. This clears any current goals when not in proof mode, which fixes #145.

> I think this might also fix #150 (although it's hard to be sure without being able to test it).