### PR TITLE
Add utf8 syntax highlighting

### DIFF
--- a/client/syntaxes/coq.tmLanguage
+++ b/client/syntaxes/coq.tmLanguage
@@ -143,7 +143,7 @@
 
         <dict>
             <key>match</key>
-            <string>:|\||=|&lt;|&gt;|\*|\+|-|\{|\}</string>
+            <string>:|\||=|&lt;|&gt;|\*|\+|-|\{|\}|≠|∨|∧|↔|¬|→|≤|≥</string>
             <key>comment</key>
             <string>Operators</string>
             <key>name</key>
@@ -152,7 +152,7 @@
 
         <dict>
             <key>match</key>
-            <string>\b(forall|exists|Type|Set|Prop)\b</string>
+            <string>\b(forall|exists|Type|Set|Prop)\b|∀|∃</string>
             <key>comment</key>
             <string>Type keywords</string>
             <key>name</key>
@@ -179,7 +179,7 @@
 
         <dict>
             <key>match</key>
-            <string>\b(match|lazymatch|multimatch|fun|with|returns|end|let|in|if|then|else)\b</string>
+            <string>\b(match|lazymatch|multimatch|fun|with|returns|end|let|in|if|then|else)\b|λ</string>
             <key>comment</key>
             <string>Gallina keywords</string>
             <key>name</key>


### PR DESCRIPTION
See: https://coq.inria.fr/library/Coq.Unicode.Utf8.html

The weirdness with `∀` `∃` and `λ` being outside the parens is because those chars do not create word boundaries for `\b`.