### PR TITLE
Fix #74: Document desynchronized after undo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.3.1
+* fix #74 (document desynchronized after undo)
+
 ## 0.3.0
 * development moved to Coq Community
 * support for Coq >= 8.7.0

--- a/server/src/document.ts
+++ b/server/src/document.ts
@@ -81,7 +81,7 @@ export class CoqDocument implements TextDocument {
   public async applyTextEdits(changes: TextDocumentContentChangeEvent[], newVersion: number) {
     // sort the edits such that later edits are processed first
     let sortedChanges =
-      changes.sort((change1,change2) =>
+      changes.slice().sort((change1,change2) =>
         textUtil.positionIsAfter(change1.range.start, change2.range.start) ? -1 : 1)
 
     this.document.applyTextChanges(newVersion, changes);

--- a/server/src/sentence-model/SentenceCollection.ts
+++ b/server/src/sentence-model/SentenceCollection.ts
@@ -156,7 +156,7 @@ export class SentenceCollection implements vscode.TextDocument {
 
     // sort the edits such that later edits are processed first
     let sortedChanges =
-      changes.sort((change1,change2) =>
+      changes.slice().sort((change1,change2) =>
         textUtil.positionIsAfter(change1.range.start, change2.range.start) ? -1 : 1)
 
     this.applyChangesToDocumentText(changes);
@@ -174,7 +174,7 @@ export class SentenceCollection implements vscode.TextDocument {
     for(let sentIdx = this.sentences.length-1; sentIdx >= 0; --sentIdx) {
       const sent = this.sentences[sentIdx];
 
-      const preserved = sent.applyTextChanges(sortedChanges,deltas,this.documentText);
+      const preserved = sent.applyTextChanges(changes,deltas,this.documentText);
       if(!preserved) {
         invalidatedSentences.push(sentIdx);
       }


### PR DESCRIPTION
Text edits have to be performed in order, otherwise offsets are incorrect.