### PR TITLE
Interrupt with SIGINT only

### DIFF
--- a/server/src/coqtop/CoqTop8.ts
+++ b/server/src/coqtop/CoqTop8.ts
@@ -238,7 +238,7 @@ export class CoqTop extends IdeSlave8 implements coqtop.CoqTop {
   public /* override */ async coqInterrupt() : Promise<boolean> {
     if(!this.coqtopProc)
       return false;
-    else if(!super.coqInterrupt()) {
+    else {
       this.console.log('--------------------------------');
       this.console.log('Sending SIGINT');
       this.coqtopProc.kill("SIGINT");

--- a/server/src/coqtop/IdeSlave8.ts
+++ b/server/src/coqtop/IdeSlave8.ts
@@ -205,24 +205,7 @@ export class IdeSlave extends coqtop.IdeSlave {
 
   /** @returns true if an interrupt message was sent via the xml protocol */
   public async coqInterrupt() : Promise<boolean> {
-    if(!this.isConnected())
-      return false;
-    else if(this.useInterruptMessage) {
-      this.parser.once('response: value', (value:coqProto.ValueReturn) => {
-        this.console.log('interrupted');
-      });
-      this.console.log('interrupt');
-      
-      this.console.log('--------------------------------');
-      this.console.log('Call Interrupt()');
-      this.writeMain('<call val="Interrupt"><unit/></call>');
-      return true;
-    } else {
-      return false;
-      // this.console.log('--------------------------------');
-      // this.console.log('Sending SIGINT');
-      // this.coqtopProc.kill("SIGINT");
-    }
+    return false;
   }
 
   protected async checkState() : Promise<void> {


### PR DESCRIPTION
Workaround #123 with a patch by the bug-reporter @jad-hamza. He didn't submit a PR, with [this argument on Gitter](https://gitter.im/coq-community/vscoq?at=5e6bef91034f6b7b24dd7c2d):*
> I don't think it's the right way to do it, I completely removed the XML part, I thought that could be discussed in the issue

Now a month passed, no progress has been made, and this patch improves things over master (I tried interrupting a failing `cbv`, and it works). So I suppose a proper discussion can be done either on this PR or after merging it. EDIT: in doubt, this PR might make things better enough to be worth merging anyway.

*Discussion starts [earlier](https://gitter.im/coq-community/vscoq?at=5e6b5b3517d3e74234782e8f).