### PR TITLE
Bump version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vscoq",
-  "version": "0.3.0",
+  "version": "0.3.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "email": "siegebell@gmail.com",
     "url": "http://people.csail.mit.edu/cj/"
   },
-  "version": "0.3.0",
+  "version": "0.3.2",
   "publisher": "maximedenes",
   "license": "MIT",
   "icon": "images/logo.png",


### PR DESCRIPTION
The last release did not perform a version bump; hence VsCode tries upgrading the build product using the Marketplace release.

I'm not a JS programmer and I'm not sure of the proper way to do it. I also upgraded `package-lock.json` even tho `make` didn't.

I suppose this (done properly) should be part of the release workflow.