### PR TITLE
ProofView panel onDidDispose event

### DIFF
--- a/client/src/HtmlCoqView.ts
+++ b/client/src/HtmlCoqView.ts
@@ -127,6 +127,11 @@ export class HtmlCoqView implements view.CoqView {
         }
       );
 
+      this.panel.onDidDispose(() => {
+        this.visible = false;
+        this.panel = null;
+      });
+
       let doc = await vscode.workspace.openTextDocument(this.coqViewUri);
 
       let csspath = path.join(extensionContext.extensionPath,  'out', VIEW_PATH, 'proof-view.css');


### PR DESCRIPTION
A fix to #62 

The HtmlCoqView controls the ProofView via its `panel` field, which might be closed by user unexpectedly.

By implementing the onDispose event of this WebviewPanel and updating HtmlCoqView's visibility state properly, VSCoq could re-create a new ProofView when user navigate through the coq proof again (e.g. stepForward).