### PR TITLE
Auto-focus ProofView when its content updated

### DIFF
--- a/client/src/HtmlCoqView.ts
+++ b/client/src/HtmlCoqView.ts
@@ -160,8 +160,10 @@ export class HtmlCoqView implements view.CoqView {
   }
 
   private async sendMessage(message: ProofViewProtocol) {
-    if (this.panel !== null)
+    if (this.panel !== null) {
+      this.panel.reveal(this.panel.viewColumn, true);
       this.panel.webview.postMessage(message);
+    }
   }
 
   private async updateClient(state: proto.CommandResult) {


### PR DESCRIPTION
This should satisfy most people regarding #82 :

When user navigate through any proof script, the proof status is updated, and thus the corresponding ProofView should focus automatically (or to call the `reveal` method).

Notice that I did not take care of the ProofView position for the moment; it should remain on its original view column. If that happens to be in the same column as the source script, the user should be aware and solve this problem by herself easily.