### PR TITLE
[Snippets] Remove "Solve All Obligations with ..."

### DIFF
--- a/client/snippets/coq.json
+++ b/client/snippets/coq.json
@@ -136,10 +136,6 @@
     "prefix": "Solve All Obligations",
     "body": ["Solve All Obligations."]
   },
-  "Solve All Obligations with...": {
-    "prefix": "Solve All Obligations with",
-    "body": ["Solve All Obligations with ${1:expr}."]
-  },
   "Admit Obligations": {
     "prefix": "Admit Obligations",
     "body": ["Admit Obligations."]


### PR DESCRIPTION
Every time I try to `match`, ending with `with`, vscoq pulls out this
snippet. It's very annoying, and the value of this snippet is greatly
outweighed by its interference with a very common construct.