### PR TITLE
Added options to disable italic/striked-out rendering of diffs

### DIFF
--- a/client/src/HtmlCoqView.ts
+++ b/client/src/HtmlCoqView.ts
@@ -28,11 +28,17 @@ interface SettingsUpdate extends SettingsState {
   command: 'settings-update'
 }
 
+export interface ProofViewDiffSettings {
+  addedTextItalic : boolean,
+  removedTextStrikethrough : boolean,
+}
+
 interface SettingsState {
   fontFamily?: string,
   fontSize?: string,
   fontWeight?: string,
   prettifySymbolsMode?: boolean,
+  proofViewDiff? : ProofViewDiffSettings,
 }
 
 
@@ -184,6 +190,7 @@ export class HtmlCoqView implements view.CoqView {
     this.currentSettings.fontFamily = vscode.workspace.getConfiguration("editor").get("fontFamily") as string;
     this.currentSettings.fontSize = `${vscode.workspace.getConfiguration("editor").get("fontSize") as number}pt`;
     this.currentSettings.fontWeight = vscode.workspace.getConfiguration("editor").get("fontWeight") as string;
+    this.currentSettings.proofViewDiff = vscode.workspace.getConfiguration("coq").get("proofViewDiff") as ProofViewDiffSettings;
     this.currentSettings.prettifySymbolsMode = psm.isEnabled();
     await this.sendMessage(Object.assign<SettingsState,{command: 'settings-update'}>(this.currentSettings,{command: 'settings-update'}));
   }

--- a/client/src/HtmlCoqView.ts
+++ b/client/src/HtmlCoqView.ts
@@ -152,6 +152,7 @@ export class HtmlCoqView implements view.CoqView {
       });
 
       this.panel.webview.onDidReceiveMessage(message => this.handleClientMessage(message));
+      await this.updateSettings();
     }
   }
 

--- a/client/src/HtmlCoqView.ts
+++ b/client/src/HtmlCoqView.ts
@@ -29,8 +29,8 @@ interface SettingsUpdate extends SettingsState {
 }
 
 export interface ProofViewDiffSettings {
-  addedTextItalic : boolean,
-  removedTextStrikethrough : boolean,
+  addedTextIsItalic : boolean,
+  removedTextIsStrikedthrough : boolean,
 }
 
 interface SettingsState {

--- a/html_views/src/goals/Coq.html
+++ b/html_views/src/goals/Coq.html
@@ -10,7 +10,7 @@
     }
   </script>
 </head>
-<body class="prettifySymbolsMode" class="proofView_addedTextItalic" class="proofView_removedTextStrikethrough">
+<body class="prettifySymbolsMode" class="proofView_addedTextIsItalic" class="proofView_removedTextIsStrikedthrough">
   <div id="measureTest"></div>
   <canvas id="textMeasurer" style="display: none"></canvas>
   <div id="states">

--- a/html_views/src/goals/Coq.html
+++ b/html_views/src/goals/Coq.html
@@ -10,7 +10,7 @@
     }
   </script>
 </head>
-<body class="prettifySymbolsMode">
+<body class="prettifySymbolsMode" class="proofView_addedTextItalic" class="proofView_removedTextStrikethrough">
   <div id="measureTest"></div>
   <canvas id="textMeasurer" style="display: none"></canvas>
   <div id="states">

--- a/html_views/src/goals/goals.ts
+++ b/html_views/src/goals/goals.ts
@@ -1,6 +1,6 @@
 import * as $ from 'jquery';
 import * as stm from './StateModel'
-import { ControllerEvent, ResizeEvent, SettingsState, ProofViewProtocol } from './protocol'
+import { ControllerEvent, ResizeEvent, SettingsState, ProofViewProtocol, ProofViewDiffSettings } from './protocol'
 
 const stateModel = new stm.StateModel();
 
@@ -62,6 +62,13 @@ function setPrettifySymbolsMode(enabled: boolean) {
     .toggleClass("prettifySymbolsMode", enabled);
 }
 
+function setProofViewDiffOptions(settings: ProofViewDiffSettings) {
+  $(document.body)
+    .toggleClass("proofView_addedTextItalic", settings.addedTextItalic);
+  $(document.body)
+    .toggleClass("proofView_removedTextStrikethrough", settings.removedTextStrikethrough);
+}
+
 declare var acquireVsCodeApi : any;
 const vscode = acquireVsCodeApi();
 
@@ -91,6 +98,8 @@ function goalsLoad(_event :Event) {
 function updateSettings(settings: SettingsState) : void {
   if(settings.prettifySymbolsMode !== undefined)
     setPrettifySymbolsMode(settings.prettifySymbolsMode);
+  if(settings.proofViewDiff !== undefined)
+    setProofViewDiffOptions(settings.proofViewDiff);
   computePrintingWidth();
 }
 

--- a/html_views/src/goals/goals.ts
+++ b/html_views/src/goals/goals.ts
@@ -64,9 +64,9 @@ function setPrettifySymbolsMode(enabled: boolean) {
 
 function setProofViewDiffOptions(settings: ProofViewDiffSettings) {
   $(document.body)
-    .toggleClass("proofView_addedTextItalic", settings.addedTextItalic);
+    .toggleClass("proofView_addedTextIsItalic", settings.addedTextIsItalic);
   $(document.body)
-    .toggleClass("proofView_removedTextStrikethrough", settings.removedTextStrikethrough);
+    .toggleClass("proofView_removedTextIsStrikedthrough", settings.removedTextIsStrikedthrough);
 }
 
 declare var acquireVsCodeApi : any;

--- a/html_views/src/goals/proof-view.css
+++ b/html_views/src/goals/proof-view.css
@@ -128,20 +128,28 @@ body {
   font-style: italic;
 }
 .charsAdded {
-  font-style: italic;
   background-color: var(--vscode-coq-addedCharacter);
+}
+.proofView_addedTextItalic .charsAdded{
+  font-style: italic;
 }
 span[class~=charsAdded][class~=substitution]::before {
+  font-style: var(--vscode-coq-proofViewDiff-addedInTermStyle);
+}
+.proofView_addedTextItalic span[class~=charsAdded][class~=substitution]::before  {
   font-style: italic;
-  background-color: var(--vscode-coq-addedCharacter);
 }
 .charsRemoved {
-  text-decoration: line-through;
   background-color: var(--vscode-coq-removedCharacter);
 }
-span[class~=charsRemoved][class~=substitution]::before {
+.proofView_proofView_removedTextStrikethrough .charsRemoved{
   text-decoration: line-through;
+}
+span[class~=charsRemoved][class~=substitution]::before {
   background-color: var(--vscode-coq-removedCharacter);
+}
+.proofView_proofView_removedTextStrikethrough span[class~=charsRemoved][class~=substitution]::before  {
+  text-decoration: line-through;
 }
 
 .hypothesese, .hypothesis, .goal, #stdout, #textMeasurer, #measureTest {

--- a/html_views/src/goals/proof-view.css
+++ b/html_views/src/goals/proof-view.css
@@ -130,25 +130,25 @@ body {
 .charsAdded {
   background-color: var(--vscode-coq-addedCharacter);
 }
-.proofView_addedTextItalic .charsAdded{
+.proofView_addedTextIsItalic .charsAdded{
   font-style: italic;
 }
 span[class~=charsAdded][class~=substitution]::before {
   font-style: var(--vscode-coq-proofViewDiff-addedInTermStyle);
 }
-.proofView_addedTextItalic span[class~=charsAdded][class~=substitution]::before  {
+.proofView_addedTextIsItalic span[class~=charsAdded][class~=substitution]::before  {
   font-style: italic;
 }
 .charsRemoved {
   background-color: var(--vscode-coq-removedCharacter);
 }
-.proofView_removedTextStrikethrough .charsRemoved{
+.proofView_removedTextIsStrikedthrough .charsRemoved{
   text-decoration: line-through;
 }
 span[class~=charsRemoved][class~=substitution]::before {
   background-color: var(--vscode-coq-removedCharacter);
 }
-.proofView_removedTextStrikethrough span[class~=charsRemoved][class~=substitution]::before  {
+.proofView_removedTextIsStrikedthrough span[class~=charsRemoved][class~=substitution]::before  {
   text-decoration: line-through;
 }
 

--- a/html_views/src/goals/proof-view.css
+++ b/html_views/src/goals/proof-view.css
@@ -142,13 +142,13 @@ span[class~=charsAdded][class~=substitution]::before {
 .charsRemoved {
   background-color: var(--vscode-coq-removedCharacter);
 }
-.proofView_proofView_removedTextStrikethrough .charsRemoved{
+.proofView_removedTextStrikethrough .charsRemoved{
   text-decoration: line-through;
 }
 span[class~=charsRemoved][class~=substitution]::before {
   background-color: var(--vscode-coq-removedCharacter);
 }
-.proofView_proofView_removedTextStrikethrough span[class~=charsRemoved][class~=substitution]::before  {
+.proofView_removedTextStrikethrough span[class~=charsRemoved][class~=substitution]::before  {
   text-decoration: line-through;
 }
 

--- a/html_views/src/goals/protocol.ts
+++ b/html_views/src/goals/protocol.ts
@@ -16,8 +16,8 @@ interface SettingsUpdate extends SettingsState {
 }
 
 export interface ProofViewDiffSettings {
-  addedTextItalic : boolean,
-  removedTextStrikethrough : boolean,
+  addedTextIsItalic : boolean,
+  removedTextIsStrikedthrough : boolean,
 }
 
 export interface SettingsState {

--- a/html_views/src/goals/protocol.ts
+++ b/html_views/src/goals/protocol.ts
@@ -15,11 +15,17 @@ interface SettingsUpdate extends SettingsState {
   command: 'settings-update'
 }
 
+export interface ProofViewDiffSettings {
+  addedTextItalic : boolean,
+  removedTextStrikethrough : boolean,
+}
+
 export interface SettingsState {
   fontFamily?: string,
   fontSize?: string,
   fontWeight?: string,
   prettifySymbolsMode?: boolean,
+  proofViewDiff? : ProofViewDiffSettings,
 }
 
 export type ProofViewProtocol = GoalUpdate | SettingsUpdate;

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
             "interaction"
           ],
           "default": "interaction",
-          "description": "When to start an instance of coqtop: when a Coq script is opened (`open-script`) or else when the user begins interaction (`interaction`; default)."
+          "markdownDescription": "When to start an instance of coqtop: when a Coq script is opened (`open-script`) or else when the user begins interaction (`interaction`; default)."
         },
         "coq.loadCoqProject": {
           "type": "boolean",
@@ -97,12 +97,12 @@
         "coq.interpretToEndOfSentence": {
           "type": "boolean",
           "default": false,
-          "description": "Interpret to point will interpret up to *and including* the sentence at the cursor"
+          "markdownDescription": "Interpret to point will interpret up to *and including* the sentence at the cursor"
         },
         "coq.autoRevealProofStateAtCursor": {
           "type": "boolean",
           "default": false,
-          "description": "If `true`, then auto-update the proof view with the cached state of the sentence the at the cursor. States are only cached when stepping through a proof, so the proof view will not be updated if e.g. the sentence was processed asynchronously and never had direct focus."
+          "markdownDescription": "If `true`, then auto-update the proof view with the cached state of the sentence the at the cursor. States are only cached when stepping through a proof, so the proof view will not be updated if e.g. the sentence was processed asynchronously and never had direct focus."
         },
         "coq.revealProofStateAtCursorDirection": {
           "type": "string",
@@ -126,17 +126,17 @@
         "coq.proofViewDiff.addedTextItalic": {
           "type": "boolean",
           "default": true,
-          "description": "If `true`, in the proof view, the diff will show added characters in italic. Note: the color of added characters can be changed in `#coq.addedCharacter#`."
+          "markdownDescription": "If `true`, in the proof view, the diff will show added characters in italic. Note: the color of added characters can be changed in `#coq.addedCharacter#`."
         },
         "coq.proofViewDiff.removedTextStrikethrough": {
           "type": "boolean",
           "default": true,
-          "description": "If `true`, in the proof view, the diff will show removed characters with a line through. Note: the color of added characters can be changed in `#coq.removedCharacter#`."
+          "markdownDescription": "If `true`, in the proof view, the diff will show removed characters with a line through. Note: the color of added characters can be changed in `#coq.removedCharacter#`."
         },
         "coq.format.enable": {
           "type": "boolean",
           "default": true,
-          "description": "If `false`, then all auto-formatting under `#coq.format#` is disabled"
+          "markdownDescription": "If `false`, then all auto-formatting under `#coq.format#` is disabled"
         },
         "coq.format.indentAfterBullet": {
           "type": "string",
@@ -146,17 +146,17 @@
             "align"
           ],
           "default": "none",
-          "description": "Control how to indent the line after a bullet. \"none\" - no indent; \"indent\" - tab-indent; \"align\" - align to the previous line's tactic"
+          "markdownDescription": "Control how to indent the line after a bullet. `none` - no indent; `indent` - tab-indent; `align` - align to the previous line's tactic"
         },
         "coq.format.indentAfterOpenProof": {
           "type": "boolean",
           "default": false,
-          "description": "Indent after opening a proof with 'Proof'"
+          "markdownDescription": "Indent after opening a proof with 'Proof'"
         },
         "coq.format.unindentOnCloseProof": {
           "type": "boolean",
           "default": true,
-          "description": "Auto-unindent `Qed.`, `Defined.`, and `Admitted.`. Note: requires `#editor.formatOnType#' to be set to `true` in settings.json"
+          "markdownDescription": "Auto-unindent `Qed.`, `Defined.`, and `Admitted.`. Note: requires `#editor.formatOnType#' to be set to `true` in settings.json"
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -123,10 +123,20 @@
           "default": "first-interaction",
           "description": "Create the proof view when a Coq script is opened, the user first interacts with coqtop, or else let the user do it manually."
         },
+        "coq.proofViewDiff.addedTextItalic": {
+          "type": "boolean",
+          "default": "true",
+          "description": "If `true`, in the proof view, the diff will show added characters in italic. Note: the color of added characters can be changed in `#coq.addedCharacter#`."
+        },
+        "coq.proofViewDiff.removedTextStrikethrough": {
+          "type": "boolean",
+          "default": "true",
+          "description": "If `true`, in the proof view, the diff will show removed characters with a line through. Note: the color of added characters can be changed in `#coq.removedCharacter#`."
+        },
         "coq.format.enable": {
           "type": "boolean",
           "default": true,
-          "description": "If `false`, then all auto-formatting under `coq.format` is disabled"
+          "description": "If `false`, then all auto-formatting under `#coq.format#` is disabled"
         },
         "coq.format.indentAfterBullet": {
           "type": "string",
@@ -146,7 +156,7 @@
         "coq.format.unindentOnCloseProof": {
           "type": "boolean",
           "default": true,
-          "description": "Auto-unindent `Qed.`, `Defined.`, and `Admitted.`. Note: requires `editor.formatOnType' to be set to `true` in settings.json"
+          "description": "Auto-unindent `Qed.`, `Defined.`, and `Admitted.`. Note: requires `#editor.formatOnType#' to be set to `true` in settings.json"
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -123,14 +123,14 @@
           "default": "first-interaction",
           "description": "Create the proof view when a Coq script is opened, the user first interacts with coqtop, or else let the user do it manually."
         },
-        "coq.proofViewDiff.addedTextItalic": {
+        "coq.proofViewDiff.addedTextIsItalic": {
           "type": "boolean",
-          "default": true,
+          "default": false,
           "markdownDescription": "If `true`, in the proof view, the diff will show added characters in italic. Note: the color of added characters can be changed in `#coq.addedCharacter#`."
         },
-        "coq.proofViewDiff.removedTextStrikethrough": {
+        "coq.proofViewDiff.removedTextIsStrikedthrough": {
           "type": "boolean",
-          "default": true,
+          "default": false,
           "markdownDescription": "If `true`, in the proof view, the diff will show removed characters with a line through. Note: the color of added characters can be changed in `#coq.removedCharacter#`."
         },
         "coq.format.enable": {

--- a/package.json
+++ b/package.json
@@ -125,12 +125,12 @@
         },
         "coq.proofViewDiff.addedTextItalic": {
           "type": "boolean",
-          "default": "true",
+          "default": true,
           "description": "If `true`, in the proof view, the diff will show added characters in italic. Note: the color of added characters can be changed in `#coq.addedCharacter#`."
         },
         "coq.proofViewDiff.removedTextStrikethrough": {
           "type": "boolean",
-          "default": "true",
+          "default": true,
           "description": "If `true`, in the proof view, the diff will show removed characters with a line through. Note: the color of added characters can be changed in `#coq.removedCharacter#`."
         },
         "coq.format.enable": {


### PR DESCRIPTION
Two new options allow the user to disable the italic/striked out text style that is used for the ProofView-diff feature.