### PR TITLE
Allow creating ProofViews for files that got closed before

### DIFF
--- a/client/src/CoqLanguageServer.ts
+++ b/client/src/CoqLanguageServer.ts
@@ -128,8 +128,8 @@ export class CoqLanguageServer implements vscode.Disposable {
   }
 
   public registerDocument(uri: string, doc: DocumentCallbacks) {
-    if(this.documentCallbacks.has(uri))
-      throw "Duplicate Coq document being registered.";
+    //if(this.documentCallbacks.has(uri))
+    //  throw "Duplicate Coq document being registered.";
     this.documentCallbacks.set(uri, doc);
   }
 


### PR DESCRIPTION
This disables throwing an exception when a document gets registered for a file that already got registered before.

This fixes the behaviour that currently, after closing a file, the only file to get a proofView again is to restart VSCoq.

This maybe is a very bad hack; If yes, I want to open the PR and discuss what an actually fix would be.

Is this PR a Bad Idea because the language server in the background still has some resources and that would leak memory?
So, would a proper fix need to "remove" the CoqDocument from the language server when a file is closed?