### PR TITLE
Fix mangled diff

### DIFF
--- a/server/src/parsing/error-parsing.ts
+++ b/server/src/parsing/error-parsing.ts
@@ -200,7 +200,7 @@ function costOfDifference(d: diff.Change[]): number {
 }
 
 export function parseError(txt: AnnotatedText) : AnnotatedText {
-  const str = text.textToDisplayString(txt);
+  const str = text.textToString(txt);
   df: for(let df of diffMessages) {
     const preMatch = df.pre.exec(str);
     const postMatch = preMatch ? df.post.exec(str) : undefined;
@@ -217,7 +217,7 @@ export function parseError(txt: AnnotatedText) : AnnotatedText {
       for (let mid of indicesOf(str, df.mid, preLen, str.length - postLen)) {
         const x = str.substring(preLen, mid[0]);
         const y = str.substring(mid[1], str.length - postLen);
-        const xy = diff.diffWords(x, y);
+        const xy = diff.diffWordsWithSpace(x, y);
         diffMatches.push({
           x: x,
           y: y,


### PR DESCRIPTION
The problem was that diffs where computes without whitespaces, but applied to the whitespaced file.
Sadly, non-matching whitespaces are now highlighted in the diff as well. (While before they caused the diff to be totally messed up, so this is an improvement).