### PR TITLE
Underscore at start

### DIFF
--- a/client/src/EditorAssist.ts
+++ b/client/src/EditorAssist.ts
@@ -8,7 +8,7 @@ export function unload() {
   subscriptions = [];
 }
 
-export const regExpQualifiedCoqIdent = /((\p{L}|_\u00A0)(\p{L}|[0-9_\u00A0'])*)(\.((\p{L}|_\u00A0)(\p{L}|[0-9_\u00A0'])*))*/u;
+export const regExpQualifiedCoqIdent = /((\p{L}|[_\u00A0])(\p{L}|[0-9_\u00A0'])*)(\.((\p{L}|[_\u00A0])(\p{L}|[0-9_\u00A0'])*))*/u;
 
 export function reload() : vscode.Disposable {
   unload();

--- a/client/syntaxes/coq.tmLanguage
+++ b/client/syntaxes/coq.tmLanguage
@@ -45,7 +45,7 @@
 
         <dict>
             <key>match</key>
-            <string>(Theorem|Lemma|Remark|Fact|Corollary|Property|Proposition|Goal)\s+(\p{L}(\p{L}|[0-9_'])*)</string>
+            <string>(Theorem|Lemma|Remark|Fact|Corollary|Property|Proposition|Goal)\s+((\p{L}|_\u00A0)(\p{L}|[0-9_\u00A0'])*)</string>
             <key>comment</key>
             <string>Theorem declarations</string>
             <key>captures</key>
@@ -65,7 +65,7 @@
 
         <dict>
             <key>match</key>
-            <string>(Parameters?|Axioms?|Conjectures?|Variables?|Hypothesis|Hypotheses)\s+(\p{L}(\p{L}|[0-9_'])*)</string>
+            <string>(Parameters?|Axioms?|Conjectures?|Variables?|Hypothesis|Hypotheses)\s+((\p{L}|_\u00A0)(\p{L}|[0-9_\u00A0'])*)</string>
             <key>comment</key>
             <string>Assumptions</string>
             <key>captures</key>
@@ -86,7 +86,7 @@
 
         <dict>
             <key>match</key>
-            <string>(Program Definition|Program Fixpoint|Program CoFixpoint|Program Function|Function|CoFixpoint|Fixpoint|Definition|Example|Let)\s+(\p{L}(\p{L}|[0-9_'])*)</string>
+            <string>(Program Definition|Program Fixpoint|Program CoFixpoint|Program Function|Function|CoFixpoint|Fixpoint|Definition|Example|Let)\s+((\p{L}|_\u00A0)(\p{L}|[0-9_\u00A0'])*)</string>
             <key>comment</key>
             <string>Definitions</string>
             <key>captures</key>
@@ -106,7 +106,7 @@
 
         <dict>
             <key>match</key>
-            <string>(CoInductive|Inductive)\s+(\p{L}(\p{L}|[0-9_'])*)</string>
+            <string>(CoInductive|Inductive)\s+((\p{L}|_\u00A0)(\p{L}|[0-9_\u00A0'])*)</string>
             <key>comment</key>
             <string>Inductive type declarations</string>
             <key>captures</key>
@@ -126,7 +126,7 @@
 
         <dict>
             <key>match</key>
-            <string>(Ltac)\s+(\p{L}(\p{L}|[0-9_'])*)</string>
+            <string>(Ltac)\s+((\p{L}|_\u00A0)(\p{L}|[0-9_\u00A0'])*)</string>
             <key>comment</key>
             <string>Ltac declarations</string>
             <key>captures</key>

--- a/client/syntaxes/coq.tmLanguage
+++ b/client/syntaxes/coq.tmLanguage
@@ -45,7 +45,7 @@
 
         <dict>
             <key>match</key>
-            <string>(Theorem|Lemma|Remark|Fact|Corollary|Property|Proposition|Goal)\s+((\p{L}|_\u00A0)(\p{L}|[0-9_\u00A0'])*)</string>
+            <string>(Theorem|Lemma|Remark|Fact|Corollary|Property|Proposition|Goal)\s+((\p{L}|[_\u00A0])(\p{L}|[0-9_\u00A0'])*)</string>
             <key>comment</key>
             <string>Theorem declarations</string>
             <key>captures</key>
@@ -65,7 +65,7 @@
 
         <dict>
             <key>match</key>
-            <string>(Parameters?|Axioms?|Conjectures?|Variables?|Hypothesis|Hypotheses)\s+((\p{L}|_\u00A0)(\p{L}|[0-9_\u00A0'])*)</string>
+            <string>(Parameters?|Axioms?|Conjectures?|Variables?|Hypothesis|Hypotheses)\s+((\p{L}|[_\u00A0])(\p{L}|[0-9_\u00A0'])*)</string>
             <key>comment</key>
             <string>Assumptions</string>
             <key>captures</key>
@@ -86,7 +86,7 @@
 
         <dict>
             <key>match</key>
-            <string>(Program Definition|Program Fixpoint|Program CoFixpoint|Program Function|Function|CoFixpoint|Fixpoint|Definition|Example|Let)\s+((\p{L}|_\u00A0)(\p{L}|[0-9_\u00A0'])*)</string>
+            <string>(Program Definition|Program Fixpoint|Program CoFixpoint|Program Function|Function|CoFixpoint|Fixpoint|Definition|Example|Let)\s+((\p{L}|[_\u00A0])(\p{L}|[0-9_\u00A0'])*)</string>
             <key>comment</key>
             <string>Definitions</string>
             <key>captures</key>
@@ -106,7 +106,7 @@
 
         <dict>
             <key>match</key>
-            <string>(CoInductive|Inductive)\s+((\p{L}|_\u00A0)(\p{L}|[0-9_\u00A0'])*)</string>
+            <string>(CoInductive|Inductive)\s+((\p{L}|[_\u00A0])(\p{L}|[0-9_\u00A0'])*)</string>
             <key>comment</key>
             <string>Inductive type declarations</string>
             <key>captures</key>
@@ -126,7 +126,7 @@
 
         <dict>
             <key>match</key>
-            <string>(Ltac)\s+((\p{L}|_\u00A0)(\p{L}|[0-9_\u00A0'])*)</string>
+            <string>(Ltac)\s+((\p{L}|[_\u00A0])(\p{L}|[0-9_\u00A0'])*)</string>
             <key>comment</key>
             <string>Ltac declarations</string>
             <key>captures</key>


### PR DESCRIPTION
Syntax highlighting for `Definition ...` etc now supports identifier starting with undercore.