### PR TITLE
XML protocoll can have string where vscoq expected a number

### DIFF
--- a/server/src/coqtop/coq-proto.ts
+++ b/server/src/coqtop/coq-proto.ts
@@ -197,7 +197,7 @@ export interface CoqInfo {
 }
 
 export interface Subgoal {
-  id: number;
+  id: string;
   hypotheses: AnnotatedText[];
   goal: AnnotatedText;
 }

--- a/server/src/coqtop/xml-protocol/deserialize.base.ts
+++ b/server/src/coqtop/xml-protocol/deserialize.base.ts
@@ -226,7 +226,7 @@ export namespace Nodes {
   export interface GoalNode {
     $name: 'goal',
     $: { },
-    $children: {[0]: number, [1]: AnnotatedText[], [2]: AnnotatedText|null} & {}[]
+    $children: {[0]: string, [1]: AnnotatedText[], [2]: AnnotatedText|null} & {}[]
   }
 
   export interface GoalsNode {
@@ -435,7 +435,7 @@ export abstract class Deserialize {
       }
       case 'goal':
         return check(value.$name, {
-          id: +value.$children[0],
+          id: value.$children[0],
           hypotheses: value.$children[1],
           goal: value.$children[2] || []
         })

--- a/server/src/protocol.ts
+++ b/server/src/protocol.ts
@@ -139,7 +139,7 @@ export interface Hypothesis {
   diff: HypothesisDifference;
 }
 export interface Goal {
-  id: number;
+  id: string;
   hypotheses: Hypothesis[];
   goal: AnnotatedText;
 }

--- a/server/src/stm/GoalsCache.ts
+++ b/server/src/stm/GoalsCache.ts
@@ -1,6 +1,6 @@
 import {ProofView,Goal,UnfocusedGoalStack} from '../protocol';
 
-export type GoalId  = number;
+export type GoalId  = string;
 
 interface UnfocusedGoalStackReference {
   before: GoalId[];


### PR DESCRIPTION
The goal ID is a string according to the xml protocol, yet we relied on it always being a number.
This is half of the problems that lead to #190, and the other half is already fixed in coq itself ( https://github.com/coq/coq/pull/13662 )