### PR TITLE
Revert "Auto-focus ProofView when updated"

### DIFF
--- a/client/src/HtmlCoqView.ts
+++ b/client/src/HtmlCoqView.ts
@@ -165,10 +165,8 @@ export class HtmlCoqView implements view.CoqView {
   }
 
   private async sendMessage(message: ProofViewProtocol) {
-    if (this.panel !== null) {
-      this.panel.reveal(this.panel.viewColumn, true);
+    if (this.panel !== null)
       this.panel.webview.postMessage(message);
-    }
   }
 
   private async updateClient(state: proto.CommandResult) {


### PR DESCRIPTION
This reverts commit bce1c76ca9dfb757679256b64111739e5b8ec952: it's a huge regression, as it prevents looking at another buffer on the right-hand pane when processing a proof on the left pane.