### PR TITLE
Hotfix for #221

### DIFF
--- a/server/src/coqtop/CoqTop8.ts
+++ b/server/src/coqtop/CoqTop8.ts
@@ -84,10 +84,14 @@ export class CoqTop extends IdeSlave8 implements coqtop.CoqTop {
     this.console.log('starting coqtop');
 
     let coqtopVersion = await coqtop.detectVersion(this.coqtopBin, this.projectRoot, this.console);
+
     if(coqtopVersion)
       this.console.log(`Detected coqtop version ${coqtopVersion}`)
-    else
-      this.console.warn(`Could not detect coqtop version`)
+    else {
+      let fallbackVersion = "8.10"; //no changed behaviour in vscoq since this version
+      this.console.warn(`Could not detect coqtop version, defaulting to >= ${fallbackVersion}.`);
+      coqtopVersion = fallbackVersion;
+    }
 
     this.coqtopVersion = semver.coerce(coqtopVersion);
     this.console.log(`Coqtop version parsed into semver version ${this.coqtopVersion.format()}`);


### PR DESCRIPTION
Falling back to the >=8.10-behaviour if parsing fails. Closes #221 