### PR TITLE
improved doc on coqtop.args

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
         "coqtop.args": {
           "type": "array",
           "default": [],
-          "description": "A list of arguments to send to coqtop."
+          "markdownDescription": "A list of arguments to send to coqtop. Use seperate elements instead of spaces to seperate each argument, especially when a flag expects another trailing argument, e.g. `[\"-I\",\"./bin\"]` instead of `[\"-I ./bin\"]`"
         },
         "coqtop.startOn": {
           "type": "string",


### PR DESCRIPTION
Different parts of the same option need to be in their own arguments, as we just pass the array as it is as argument array to coqidetop.

