### PR TITLE
Remove incompatible brackets

### DIFF
--- a/client/coq.configuration.json
+++ b/client/coq.configuration.json
@@ -17,30 +17,6 @@
     [
       "(",
       ")"
-    ],
-    [
-      "Proof.",
-      "Qed."
-    ],
-    [
-      "Proof.",
-      "Admitted."
-    ],
-    [
-      "Proof.",
-      "Abort."
-    ],
-    [
-      "match",
-      "end"
-    ],
-    [
-      "repeat match",
-      "end"
-    ],
-    [
-      "repeat lazymatch",
-      "end"
     ]
   ],
   "autoClosingPairs": [


### PR DESCRIPTION
The removed brackets are incompatible with VSCode parsing. VSCode does not work well with brackets that share starting symbols or ending symbols, which breaks bracket colorization extensions that depends on parsing.