### PR TITLE
Small fix restores the webview.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules/
 out/
+_opam/
 
 backup.sh
 start-env.ps1

--- a/client/src/HtmlCoqView.ts
+++ b/client/src/HtmlCoqView.ts
@@ -125,10 +125,12 @@ export class HtmlCoqView implements view.CoqView {
       this.panel = vscode.window.createWebviewPanel(
         'html_coq',
         "ProofView: " + path.basename(this.docUri.fsPath),
-        { preserveFocus: true,
+        {
+          preserveFocus: true,
           viewColumn: pane,
         },
-        {enableScripts: true,
+        {
+          enableScripts: true,
           localResourceRoots: [vscode.Uri.file(path.join(extensionContext.extensionPath, 'out', VIEW_PATH))]
         }
       );
@@ -140,11 +142,11 @@ export class HtmlCoqView implements view.CoqView {
 
       let doc = await vscode.workspace.openTextDocument(this.coqViewUri);
 
-      let csspath = path.join(extensionContext.extensionPath,  'out', VIEW_PATH, 'proof-view.css');
-      let csspasthAsVscodeResource = vscode.Uri.file(csspath).with({ scheme: 'vscode-resource' });
+      let csspath = path.join(extensionContext.extensionPath, 'out', VIEW_PATH, 'proof-view.css');
+      let csspasthAsVscodeResource = this.panel.webview.asWebviewUri(vscode.Uri.file(csspath));
 
       let jspath = path.join(extensionContext.extensionPath, 'out', VIEW_PATH, 'goals.js');
-      let jspathAsVscodeResource = vscode.Uri.file(jspath).with({ scheme: 'vscode-resource' });
+      let jspathAsVscodeResource = this.panel.webview.asWebviewUri(vscode.Uri.file(jspath));
 
       this.panel.webview.html = mustache.render(doc.getText(), {
         jsPath: jspathAsVscodeResource,


### PR DESCRIPTION
This seems to fix issue #235 for me.

For more details, see:

https://code.visualstudio.com/updates/v1_56#_service-workers-now-used-to-load-resource-in-webview