### PR TITLE
Tentative fix for issue 250

### DIFF
--- a/client/coq.configuration.json
+++ b/client/coq.configuration.json
@@ -43,6 +43,11 @@
       "end"
     ]
   ],
+  "colorizedBracketPairs": [
+		["{", "}"],
+		["[", "]"],
+		["(", ")"]
+	],
   "autoClosingPairs": [
     {
       "open": "{",


### PR DESCRIPTION
Issue #250 appears to be caused by a new feature in VSCode, implementing native bracket pair colorization. This bug has been reported in many language support extensions :-) As far as I can see, it can be solved by adding a new key `colorizedBracketPairs` in the language configuration, which tells VSCode that only some brackets need to be colorized.