### PR TITLE
[VsCoq1] Add thread count option, translated to -async-proofs-j

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,9 +75,12 @@
           "default": "coqidetop.opt",
           "description": "Name of the coqidetop binary (alternatively, hoqidetop)."
         },
+        "coqtop.threadCount": {
+          "type": ["null", "number"],
+          "markdownDescription": "Number of proof workers to enable."
+        },
         "coqtop.args": {
           "type": "array",
-          "default": [],
           "markdownDescription": "A list of arguments to send to coqtop. Use seperate elements instead of spaces to seperate each argument, especially when a flag expects another trailing argument, e.g. `[\"-I\",\"./bin\"]` instead of `[\"-I ./bin\"]`"
         },
         "coqtop.startOn": {

--- a/server/src/CoqProject.ts
+++ b/server/src/CoqProject.ts
@@ -80,6 +80,9 @@ export class CoqProject {
 
     this.notReady();
     this.settingsCoqTopArgs = newSettings.coqtop.args;
+    if (newSettings.coqtop.threadCount) {
+      this.settingsCoqTopArgs = this.settingsCoqTopArgs.concat(["-async-proofs-j", newSettings.coqtop.threadCount.toString()]);
+    }
     this.currentSettings = newSettings;
 
     if(newSettings.coq.coqProjectRoot ){

--- a/server/src/protocol.ts
+++ b/server/src/protocol.ts
@@ -37,6 +37,7 @@ export interface CoqTopSettings {
   coqtopExe: string;
   /** Name of coqidetop binary. @default `"coqidetop.opt"` */
   coqidetopExe: string;
+  threadCount?: number;
   /** A list of arguments to send to coqtop. @default `[]` */
   args: string[];
   /** When should an instance of coqtop be started for a Coq script */


### PR DESCRIPTION
Sketch fix to coq-community/vscoq-legacy#48. This seems to work but:
- it's the quickest thing I could put together
- I don't know what I'm doing :-)
- I mostly just opened this code in VSCode, grepped for `coqtop.args`, and changed the code in what seemed the obvious way.

I chose to leave out `-async-proofs-j` by default, but I'd hope that `-async-proofs-j 1` is a safe no-op?

TODO:
- [x] revise help text (help and bikeshedding welcome)
- [ ] ~~it'd be nice to autodetect the thread count by running `nproc`! (More advanced). EDIT: looking at coq-community/vscoq-legacy#48, we'd need to at least look at free memory for a default :-).~~