### PR TITLE
Add logo as icon to coq files

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,11 @@
         "extensions": [
           ".v"
         ],
-        "configuration": "./client/coq.configuration.json"
+        "configuration": "./client/coq.configuration.json",
+        "icon": {
+          "light": "./images/logo.png",
+          "dark": "./images/logo.png"
+        }
       }
     ],
     "grammars": [


### PR DESCRIPTION
This adds the VSCoq logo to coq files in the editor (sidebar and tabs).

We might want to use the more official Coq logo (eg the favicon of https://coq.inria.fr/) but I'm not sure if I have the rights to add it to a public repo...