### PR TITLE
[VsCoq1] Progress on #134: Use dune coq top (when enabled by a setting)

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ The recommended way to install VsCoq is via the [Visual Studio Marketplace](http
 * `"coqtop.args": []` -- an array of strings specifying additional command line arguments for coqtop
 * `"coqtop.loadCoqProject": true` -- set to `false` to ignore <span>_CoqProject</span>
 * `"coqtop.coqProjectRoot": "."` -- where to expect the <span>_CoqProject</span> relative to the workspace root
+* `"coqtop.useDune": false` -- set to `true` to use `dune coq top` instead of parsing settings from `_CoqProject`.
 
 ## Install a local version
 

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
         "coqtop.binPath": {
           "type": "string",
           "default": "",
-          "description": "Path to coqtop and coqidetop binaries (alternatively, hoqtop and hoqidetop)."
+          "description": "Path to folder with coqtop and coqidetop binaries (alternatively, hoqtop and hoqidetop)."
         },
         "coqtop.coqtopExe": {
           "type": "string",

--- a/package.json
+++ b/package.json
@@ -94,6 +94,15 @@
           "default": "open-script",
           "markdownDescription": "When to start an instance of coqtop: when a Coq script is opened (`open-script`) or else when the user begins interaction (`interaction`; default)."
         },
+        "coqtop.projectSettingsType": {
+          "type": "string",
+          "enum": [
+            "_CoqProject",
+            "Dune"
+          ],
+          "default": "_CoqProject",
+          "description": "Load project settings from _CoqProject, or use dune coq top."
+        },
         "coqtop.useDune": {
           "type": "boolean",
           "markdownDescription": "(Experimental) Use `dune coq top` to run `coqidetop`."

--- a/package.json
+++ b/package.json
@@ -60,6 +60,11 @@
       "type": "object",
       "title": "Coq configuration",
       "properties": {
+        "coqtop.dunePath": {
+          "type": "string",
+          "default": "dune",
+          "markdownDescription": "Full path to dune binary (`dune` included)."
+        },
         "coqtop.binPath": {
           "type": "string",
           "default": "",
@@ -88,6 +93,10 @@
           ],
           "default": "open-script",
           "markdownDescription": "When to start an instance of coqtop: when a Coq script is opened (`open-script`) or else when the user begins interaction (`interaction`; default)."
+        },
+        "coqtop.useDune": {
+          "type": "boolean",
+          "markdownDescription": "(Experimental) Use `dune coq top` to run `coqidetop`."
         },
         "coq.loadCoqProject": {
           "type": "boolean",

--- a/server/src/CoqProject.ts
+++ b/server/src/CoqProject.ts
@@ -89,6 +89,8 @@ export class CoqProject {
     if(newSettings.coq.loadCoqProject ) {
       this.watchCoqProject();
       await this.loadCoqProject();
+    } else {
+      this.currentSettings.coqtop.args = this.settingsCoqTopArgs;
     }
 
     if(newSettings.prettifySymbolsMode && newSettings.prettifySymbolsMode.substitutions) {

--- a/server/src/CoqProject.ts
+++ b/server/src/CoqProject.ts
@@ -86,7 +86,8 @@ export class CoqProject {
       this.coqProjectRoot = newSettings.coq.coqProjectRoot;
       this.console.log("Updated project root to " + this.getCoqProjectRoot());
     }
-    if(newSettings.coq.loadCoqProject ) {
+    if(newSettings.coq.loadCoqProject && !newSettings.coqtop.useDune) {
+      // ^^ CoqProject settings aren't needed when using dune
       this.watchCoqProject();
       await this.loadCoqProject();
     } else {

--- a/server/src/coqtop/CoqTop8.ts
+++ b/server/src/coqtop/CoqTop8.ts
@@ -222,8 +222,10 @@ export class CoqTop extends IdeSlave8 implements coqtop.CoqTop {
         // '/D /C', this.coqPath + '/coqtop.exe',
         '-main-channel', mainAddr,
         '-control-channel', controlAddr,
-        '-async-proofs', 'on'
-        ].concat(this.settings.args).concat(topfile);
+        '-async-proofs', 'on',
+        ...this.settings.args,
+        ...topfile
+      ];
     } else {
       var coqtopModule = this.coqtopBin;
       // var coqtopModule = 'cmd';
@@ -232,8 +234,9 @@ export class CoqTop extends IdeSlave8 implements coqtop.CoqTop {
         '-main-channel', mainAddr,
         '-control-channel', controlAddr,
         '-ideslave',
-        '-async-proofs', 'on'
-        ].concat(this.settings.args);
+        '-async-proofs', 'on',
+        ...this.settings.args
+        ];
     }
     this.console.log('exec: ' + coqtopModule + ' ' + args.join(' '));
     return spawn(coqtopModule, args, {detached: false, cwd: this.projectRoot});

--- a/server/src/coqtop/CoqTop8.ts
+++ b/server/src/coqtop/CoqTop8.ts
@@ -223,6 +223,7 @@ export class CoqTop extends IdeSlave8 implements coqtop.CoqTop {
   private spawnCoqTop(mainAddr : string, controlAddr: string) {
     var topfile : string[] = [];
     var scriptPath = this.scriptPath;
+    const relScriptPath = path.relative(this.projectRoot, scriptPath);
     if (semver.satisfies(this.coqtopVersion, ">= 8.10") && !this.settings.useDune && scriptPath != undefined) {
       // Dune computes this internally, so we skip it.
       topfile = ['-topfile', scriptPath];
@@ -252,7 +253,7 @@ export class CoqTop extends IdeSlave8 implements coqtop.CoqTop {
 
     const [binary, args] = this.settings.useDune ?
       [this.settings.dunePath, ["coq", "top", "--toplevel=" + coqtopModule,
-        scriptPath, "--", ...coqArgs]] :
+        relScriptPath, "--", ...coqArgs]] :
       [coqtopModule, coqArgs]
 
     this.console.log('exec: ' + binary + ' ' + args.join(' '));

--- a/server/src/coqtop/CoqTop8.ts
+++ b/server/src/coqtop/CoqTop8.ts
@@ -1,5 +1,6 @@
 'use strict';
 
+import Uri from 'vscode-uri'
 import * as net from 'net';
 import * as path from 'path';
 import * as vscode from 'vscode-languageserver';
@@ -210,10 +211,20 @@ export class CoqTop extends IdeSlave8 implements coqtop.CoqTop {
     return path.join(this.settings.binPath.trim(), this.settings.coqidetopExe);
   }
 
+  private get scriptPath() {
+    // TODO: rename scriptFile to scriptUri everywhere.
+    let uri = Uri.parse(this.scriptFile)
+    if (uri.scheme == "file")
+      return uri.fsPath;
+    else
+      return undefined
+  }
+
   private spawnCoqTop(mainAddr : string, controlAddr: string) {
     var topfile : string[] = [];
-    if (semver.satisfies(this.coqtopVersion, ">= 8.10")) {
-      topfile = ['-topfile', this.scriptFile];
+    var scriptPath = this.scriptPath;
+    if (semver.satisfies(this.coqtopVersion, ">= 8.10") && scriptPath !== undefined) {
+      topfile = ['-topfile', scriptPath];
     }
     if (semver.satisfies(this.coqtopVersion, ">= 8.9")) {
       var coqtopModule = this.coqidetopBin;

--- a/server/src/coqtop/CoqTop8.ts
+++ b/server/src/coqtop/CoqTop8.ts
@@ -5,6 +5,7 @@ import * as net from 'net';
 import * as path from 'path';
 import * as vscode from 'vscode-languageserver';
 import * as semver from 'semver';
+import * as process from 'process';
 
 import {ChildProcess, spawn} from 'child_process';
 import {CoqTopSettings} from '../protocol';
@@ -224,6 +225,8 @@ export class CoqTop extends IdeSlave8 implements coqtop.CoqTop {
     var topfile : string[] = [];
     var scriptPath = this.scriptPath;
     const relScriptPath = path.relative(this.projectRoot, scriptPath);
+    this.console.log('process.cwd(): ' + process.cwd() + '; scriptPath: ' + scriptPath + '; this.projectRoot: ' +
+      this.projectRoot + '; relScriptPath: ' + relScriptPath);
     if (semver.satisfies(this.coqtopVersion, ">= 8.10") && !this.settings.useDune && scriptPath != undefined) {
       // Dune computes this internally, so we skip it.
       topfile = ['-topfile', scriptPath];

--- a/server/src/coqtop/CoqTop8.ts
+++ b/server/src/coqtop/CoqTop8.ts
@@ -227,29 +227,24 @@ export class CoqTop extends IdeSlave8 implements coqtop.CoqTop {
       // Dune computes this internally, so we skip it.
       topfile = ['-topfile', scriptPath];
     }
-    if (semver.satisfies(this.coqtopVersion, ">= 8.9")) {
-      var coqtopModule = this.coqidetopBin;
-      // var coqtopModule = 'cmd';
-      var coqArgs = [
-        // '/D /C', this.coqPath + '/coqtop.exe',
-        '-main-channel', mainAddr,
-        '-control-channel', controlAddr,
-        '-async-proofs', 'on',
-        ...this.settings.args,
-        ...topfile
-      ];
-    } else {
-      var coqtopModule = this.coqtopBin;
-      // var coqtopModule = 'cmd';
-      var coqArgs = [
-        // '/D /C', this.coqPath + '/coqtop.exe',
-        '-main-channel', mainAddr,
-        '-control-channel', controlAddr,
-        '-ideslave',
-        '-async-proofs', 'on',
-        ...this.settings.args
-        ];
-    }
+    const [coqtopModule, coqArgs] =
+      semver.satisfies(this.coqtopVersion, ">= 8.9") ?
+        [this.coqidetopBin, [
+          // '/D /C', this.coqPath + '/coqtop.exe',
+          '-main-channel', mainAddr,
+          '-control-channel', controlAddr,
+          '-async-proofs', 'on',
+          ...this.settings.args,
+          ...topfile
+        ]] :
+        [this.coqtopBin, [
+          // '/D /C', this.coqPath + '/coqtop.exe',
+          '-main-channel', mainAddr,
+          '-control-channel', controlAddr,
+          '-ideslave',
+          '-async-proofs', 'on',
+          ...this.settings.args
+        ]]
 
     if (this.settings.useDune && scriptPath === undefined) {
       throw new CoqtopSpawnError("", "File was not saved to local file system");

--- a/server/src/protocol.ts
+++ b/server/src/protocol.ts
@@ -41,6 +41,7 @@ export interface CoqTopSettings {
   args: string[];
   /** When should an instance of coqtop be started for a Coq script */
   startOn: "open-script" | "interaction",
+  projSettingsType: "_CoqProject" | "Dune"
   useDune: boolean;
   dunePath: string;
 }

--- a/server/src/protocol.ts
+++ b/server/src/protocol.ts
@@ -41,6 +41,8 @@ export interface CoqTopSettings {
   args: string[];
   /** When should an instance of coqtop be started for a Coq script */
   startOn: "open-script" | "interaction",
+  useDune: boolean;
+  dunePath: string;
 }
 
 export interface AutoFormattingSettings {

--- a/server/test/coqtop.8.7.ts
+++ b/server/test/coqtop.8.7.ts
@@ -45,6 +45,8 @@ describe("Coqtop 8.6", function() {
     coqidetopExe: "coqidetop.opt",
     args: [],
     startOn: "open-script",
+    dunePath: "",
+    useDune: false
   }
 
   let dummyConsole: RemoteConsole = {


### PR DESCRIPTION
Address #134 for VsCoq1. The first commit fixes #278.

This is a V0 prototype with some limitations, but it appears somewhat suitable for use.
- There's no auto-detection of `dune` projects, but an explicit setting. Since it can be set per workspace, since most dune projects _also_ have a `_CoqProject` file, and since `dune coq top` is probably somewhat experimental, I consider this sufficient for now.
- If the build fails, this does not redirect build outputs/errors to some proper log window (beyond "Coq Language Server" logs).
- User experience isn't great when dune decides to build code: a standard progress bar appears, but one must view "Coq Language Server" to understand what is happening.

What I tested was my integration branch — https://github.com/Blaisorblade/vscoq/tree/thread-count-option-misc.

Some unexpected messages appeared, but they seem due to the options added by dune coq top.
```
coqtop-stderr: Warning: Native compiler is disabled, -native-compiler ondemand option
ignored. [native-compiler-disabled,native-compiler]
Warning: The native-compiler option is deprecated. To compile native files
ahead of time, use the coqnative binary instead.
[deprecated-native-compiler-option,deprecated]

coqtop-stdout:Skipping rcfile loading.
```

The last one suggests that `.coqrc` is not being loaded, but it appears untrue — I used
```
Test Nested Proofs Allowed.
Test Ltac Backtrace.
```
to confirm my  `.coqrc` settings were active.