### PR TITLE
[VsCoq1] Added a rudimentary message panel

### DIFF
--- a/client/src/CoqDocument.ts
+++ b/client/src/CoqDocument.ts
@@ -175,7 +175,10 @@ export class CoqDocument implements vscode.Disposable {
   private onCoqMessage(params: proto.NotifyMessageParams) {
     if (params.routeId == this.queryRouteId) {
       this.project.queryOut.show(true);
-      this.project.queryOut.appendLine(psm.prettyTextToString(params.message));
+      const processedMessage = psm.prettyTextToString(params.message);
+      this.project.queryOut.appendLine(processedMessage);
+      // send the same message to the message panel
+      this.view.update({ innertext: params.message, type: "message-query" });
     } else {
       switch (params.level) {
         case 'warning':
@@ -358,7 +361,7 @@ export class CoqDocument implements vscode.Disposable {
       }
     } else if(value.type === 'interrupted')
       this.statusBar.setStateComputing(proto.ComputingStatus.Interrupted)
-    else
+    else if (value.type !== 'message-query' && value.type !== 'message-clear')
       this.updateFocus(value.focus, this.project.settings.moveCursorToFocus);
 
     return true;
@@ -479,6 +482,7 @@ export class CoqDocument implements vscode.Disposable {
     try {
       if (term) {
         this.project.queryOut.clear();
+        this.view.update({ type:"message-clear" });
         this.project.queryOut.show(true);
         this.langServer.query(query, term, this.queryRouteId);
       }

--- a/client/src/CoqDocument.ts
+++ b/client/src/CoqDocument.ts
@@ -20,7 +20,7 @@ import {CoqDocumentLanguageServer} from './CoqLanguageServer';
 import {CoqView, adjacentPane} from './CoqView';
 import {StatusBar} from './StatusBar';
 import {CoqProject} from './CoqProject';
-import * as psm from './prettify-symbols-mode';
+// import * as psm from './prettify-symbols-mode';
 
 namespace DisplayOptionPicks {
   type T = vscode.QuickPickItem & {displayItem: number};
@@ -173,6 +173,8 @@ export class CoqDocument implements vscode.Disposable {
   // }
 
   private onCoqMessage(params: proto.NotifyMessageParams) {
+    this.view.update({ innertext: params.message, type: "message-query" });
+    /*
     if (params.routeId == this.queryRouteId) {
       this.project.queryOut.show(true);
       const processedMessage = psm.prettyTextToString(params.message);
@@ -203,6 +205,7 @@ export class CoqDocument implements vscode.Disposable {
           return;
       }
     }
+    */
   }
 
 
@@ -489,9 +492,9 @@ export class CoqDocument implements vscode.Disposable {
   public async query(query: proto.QueryFunction, term: string | undefined) {
     try {
       if (term) {
-        this.project.queryOut.clear();
+        // this.project.queryOut.clear();
         this.view.update({ type:"message-ready-clear" });
-        this.project.queryOut.show(true);
+        // this.project.queryOut.show(true);
         this.langServer.query(query, term, this.queryRouteId);
       }
     } catch (err) {

--- a/client/src/CoqDocument.ts
+++ b/client/src/CoqDocument.ts
@@ -184,18 +184,22 @@ export class CoqDocument implements vscode.Disposable {
         case 'warning':
           this.project.infoOut.show(true);
           this.project.infoOut.appendLine(psm.prettyTextToString(params.message));
+          this.view.update({ innertext: params.message, type: "message-query" });
           return;
         case 'info':
           this.project.infoOut.appendLine(psm.prettyTextToString(params.message));
+          this.view.update({ innertext: params.message, type: "message-query" });
           return;
         case 'notice':
           this.project.noticeOut.show(true);
           this.project.noticeOut.append(psm.prettyTextToString(params.message));
           this.project.noticeOut.append("\n");
+          this.view.update({ innertext: params.message, type: "message-query" });
           return;
         case 'debug':
           this.project.debugOut.show(true);
           this.project.debugOut.appendLine(psm.prettyTextToString(params.message));
+          this.view.update({ innertext: params.message, type: "message-query" });
           return;
       }
     }
@@ -361,7 +365,7 @@ export class CoqDocument implements vscode.Disposable {
       }
     } else if(value.type === 'interrupted')
       this.statusBar.setStateComputing(proto.ComputingStatus.Interrupted)
-    else if (value.type !== 'message-query' && value.type !== 'message-clear')
+    else if (value.type !== 'message-query' && value.type !== 'message-ready-clear')
       this.updateFocus(value.focus, this.project.settings.moveCursorToFocus);
 
     return true;
@@ -418,6 +422,7 @@ export class CoqDocument implements vscode.Disposable {
     try {
       this.makePreviewOpenedFilePermanent(editor);
       this.rememberCursors();
+      this.view.update({ type:"message-ready-clear" });
       const value = await this.langServer.stepForward();
       this.updateView(value, true);
       this.handleResult(value);
@@ -444,6 +449,7 @@ export class CoqDocument implements vscode.Disposable {
   public async finishComputations(editor: TextEditor) {
     this.statusBar.setStateWorking('Finishing computations');
     try {
+      this.view.update({ type:"message-ready-clear" });
       await this.langServer.finishComputations();
       this.statusBar.setStateReady();
     } catch (err) {
@@ -456,6 +462,7 @@ export class CoqDocument implements vscode.Disposable {
       if(!editor || editor.document.uri.toString() !== this.documentUri)
        return;
       this.makePreviewOpenedFilePermanent(editor);
+      this.view.update({ type:"message-ready-clear" });
       const value = await this.langServer.interpretToPoint(editor.selection.active, synchronous);
       this.updateView(value, true);
       this.handleResult(value);
@@ -471,6 +478,7 @@ export class CoqDocument implements vscode.Disposable {
     this.statusBar.setStateWorking('Interpreting to end');
     try {
       this.makePreviewOpenedFilePermanent(editor);
+      this.view.update({ type:"message-ready-clear" });
       const value = await this.langServer.interpretToEnd(synchronous);
       this.updateView(value, true);
       this.handleResult(value);
@@ -482,7 +490,7 @@ export class CoqDocument implements vscode.Disposable {
     try {
       if (term) {
         this.project.queryOut.clear();
-        this.view.update({ type:"message-clear" });
+        this.view.update({ type:"message-ready-clear" });
         this.project.queryOut.show(true);
         this.langServer.query(query, term, this.queryRouteId);
       }

--- a/client/src/CoqProject.ts
+++ b/client/src/CoqProject.ts
@@ -26,10 +26,12 @@ export class CoqProject implements vscode.Disposable {
   private subscriptions : vscode.Disposable[] = [];
 
   // lazily created output windows
+  /*
   private infoOutput: vscode.OutputChannel = vscode.window.createOutputChannel('Info');
   private queryOutput: vscode.OutputChannel = vscode.window.createOutputChannel('Queries');
   private noticeOutput: vscode.OutputChannel = vscode.window.createOutputChannel('Notices');
   private debugOutput: vscode.OutputChannel = vscode.window.createOutputChannel('Debug');
+  */
 
   private constructor(context: vscode.ExtensionContext) {
     this.langServer = CoqLanguageServer.create(context);
@@ -70,6 +72,7 @@ export class CoqProject implements vscode.Disposable {
     return CoqProject.instance;
   }
 
+  /*
   public get infoOut(): vscode.OutputChannel {
     return this.infoOutput;
   }
@@ -82,11 +85,14 @@ export class CoqProject implements vscode.Disposable {
   public get debugOut(): vscode.OutputChannel {
     return this.debugOutput;
   }
+  */
 
   dispose() {
+    /*
     this.infoOutput.dispose();
     this.queryOutput.dispose();
     this.noticeOutput.dispose();
+    */
     this.documents.forEach((doc) => doc.dispose());
     this.subscriptions.forEach((s) => s.dispose());
     this.langServer.dispose();

--- a/client/src/HtmlCoqView.ts
+++ b/client/src/HtmlCoqView.ts
@@ -41,7 +41,12 @@ interface SettingsState {
   proofViewDiff?: ProofViewDiffSettings;
 }
 
-type ProofViewProtocol = GoalUpdate | SettingsUpdate;
+interface QueryMessageUpdate {
+  command: "message-query";
+  msg: string
+}
+
+type ProofViewProtocol = GoalUpdate | SettingsUpdate | QueryMessageUpdate;
 
 const VIEW_PATH = "html_views";
 
@@ -146,6 +151,7 @@ export class HtmlCoqView implements view.CoqView {
         },
         {
           enableScripts: true,
+          enableFindWidget: true
         }
       );
 

--- a/client/src/protocol.ts
+++ b/client/src/protocol.ts
@@ -164,6 +164,10 @@ export interface CommandInterrupted {
   range: vscode.Range
 }
 
+export interface QueryMessageWrapper {
+  innertext: AnnotatedText
+}
+
 export type FocusPosition = {focus: vscode.Position}
 export type NotRunningTag = {type: 'not-running'}
 export type NoProofTag = {type: 'no-proof'}
@@ -171,13 +175,19 @@ export type FailureTag = {type: 'failure'}
 export type ProofViewTag = {type: 'proof-view'}
 export type InterruptedTag = {type: 'interrupted'}
 export type BusyTag = {type: 'busy'}
+export type QueryMessageTag = {type: 'message-query'}
+export type ClearMessageTag = {type: 'message-clear'}
 export type NotRunningResult = NotRunningTag & {reason: "not-started"|"spawn-failed", coqtop?: string}
 export type BusyResult = BusyTag
 export type NoProofResult = NoProofTag
 export type FailureResult = FailValue & FailureTag
 export type ProofViewResult = ProofView & ProofViewTag
 export type InterruptedResult = CommandInterrupted & InterruptedTag
+export type QueryMessageResult = QueryMessageWrapper & QueryMessageTag
+export type ClearMessageResult = ClearMessageTag
 export type CommandResult =
+  QueryMessageResult |
+  ClearMessageResult |
   NotRunningResult |
   (BusyResult & FocusPosition) |
   (FailureResult & FocusPosition) |

--- a/client/src/protocol.ts
+++ b/client/src/protocol.ts
@@ -176,7 +176,7 @@ export type ProofViewTag = {type: 'proof-view'}
 export type InterruptedTag = {type: 'interrupted'}
 export type BusyTag = {type: 'busy'}
 export type QueryMessageTag = {type: 'message-query'}
-export type ClearMessageTag = {type: 'message-clear'}
+export type ReadyClearMessageTag = {type: 'message-ready-clear'}
 export type NotRunningResult = NotRunningTag & {reason: "not-started"|"spawn-failed", coqtop?: string}
 export type BusyResult = BusyTag
 export type NoProofResult = NoProofTag
@@ -184,10 +184,10 @@ export type FailureResult = FailValue & FailureTag
 export type ProofViewResult = ProofView & ProofViewTag
 export type InterruptedResult = CommandInterrupted & InterruptedTag
 export type QueryMessageResult = QueryMessageWrapper & QueryMessageTag
-export type ClearMessageResult = ClearMessageTag
+export type ReadyClearMessageResult = ReadyClearMessageTag
 export type CommandResult =
   QueryMessageResult |
-  ClearMessageResult |
+  ReadyClearMessageResult |
   NotRunningResult |
   (BusyResult & FocusPosition) |
   (FailureResult & FocusPosition) |

--- a/html_views/src/goals/display-proof-state.ts
+++ b/html_views/src/goals/display-proof-state.ts
@@ -233,24 +233,35 @@ export const ProofState = () => {
 };
 
 export const OtherInfoView = () => {
-  const queryView = h("vscode-panel-view");
+  const messageView = h("vscode-panel-view");
   const element = h("vscode-panels.panels", [
-    h("vscode-panel-tab", "QUERY"),
-    queryView
+    h("vscode-panel-tab", "MESSAGE"),
+    messageView
   ]);
 
-  let queryViewInnerDiv = h("pre.richpp");
-  queryView.appendChild(queryViewInnerDiv);
+  let messageViewInnerDiv = h("pre");
+  messageView.appendChild(messageViewInnerDiv);
+  
+  /* 
+    clear-on-demand: 
+    if this flag is set, the message panel will be reset on receiving the next incoming message
+    and this flag will be unset immediately after that
+  */
+  let ready : boolean = true;
 
-  const resetInnerMessage = () => {
-    queryViewInnerDiv.innerHTML = "";
+  const readyForMessageReset = () => {
+    ready = true;
   };
 
   const updateInnerMessage = (s : AnnotatedText) => {
-    queryViewInnerDiv.appendChild(h("ul", createAnnotatedText(s)));
+    if (ready){
+      messageViewInnerDiv.innerHTML = "";
+      ready = false;
+    }
+    messageViewInnerDiv.appendChild(h("span", [...createAnnotatedText(s), "\n"]));
   };
 
-  return { element, updateInnerMessage, resetInnerMessage };
+  return { element, updateInnerMessage, readyForMessageReset };
 };
 
 export const Infoview = () => {
@@ -276,8 +287,8 @@ export const Infoview = () => {
       otherViewInstance.updateInnerMessage(state.innertext);
       // else
       //   otherViewInstance.updateInnerMessage("nothing. why?");
-    } else if (state.type === "message-clear") {
-      otherViewInstance.resetInnerMessage();
+    } else if (state.type === "message-ready-clear") {
+      otherViewInstance.readyForMessageReset();
     } else {
       if (proofStateInstance !== undefined) {
         proofStateInstance.unmount();

--- a/html_views/src/goals/display-proof-state.ts
+++ b/html_views/src/goals/display-proof-state.ts
@@ -232,10 +232,33 @@ export const ProofState = () => {
   return { element, updateState, unmount };
 };
 
+export const OtherInfoView = () => {
+  const queryView = h("vscode-panel-view");
+  const element = h("vscode-panels.panels", [
+    h("vscode-panel-tab", "QUERY"),
+    queryView
+  ]);
+
+  let queryViewInnerDiv = h("pre.richpp");
+  queryView.appendChild(queryViewInnerDiv);
+
+  const resetInnerMessage = () => {
+    queryViewInnerDiv.innerHTML = "";
+  };
+
+  const updateInnerMessage = (s : AnnotatedText) => {
+    queryViewInnerDiv.appendChild(h("ul", createAnnotatedText(s)));
+  };
+
+  return { element, updateInnerMessage, resetInnerMessage };
+};
+
 export const Infoview = () => {
   const element = h("div");
 
   let proofStateInstance: ReturnType<typeof ProofState> | undefined = undefined;
+  let otherViewInstance = OtherInfoView();
+  let divider = h("vscode-divider");
 
   const updateState = (state: CommandResult) => {
     if (state.type === "proof-view") {
@@ -243,9 +266,18 @@ export const Infoview = () => {
         element.innerHTML = "";
         proofStateInstance = ProofState();
         element.appendChild(proofStateInstance.element);
+        element.appendChild(divider);
+        element.appendChild(otherViewInstance.element);
       }
 
       proofStateInstance.updateState(state);
+    } else if (state.type === "message-query") {
+      // if (state.innertext)
+      otherViewInstance.updateInnerMessage(state.innertext);
+      // else
+      //   otherViewInstance.updateInnerMessage("nothing. why?");
+    } else if (state.type === "message-clear") {
+      otherViewInstance.resetInnerMessage();
     } else {
       if (proofStateInstance !== undefined) {
         proofStateInstance.unmount();
@@ -257,6 +289,8 @@ export const Infoview = () => {
       element.innerHTML = "";
       const formatted = h("div.message", message);
       element.appendChild(formatted);
+      element.appendChild(divider);
+      element.appendChild(otherViewInstance.element);
     };
 
     const setErrorMessage = (message: HTMLElement) => {
@@ -266,6 +300,8 @@ export const Infoview = () => {
         h("code", message),
       ]);
       element.appendChild(formatted);
+      element.appendChild(divider);
+      element.appendChild(otherViewInstance.element);
     };
 
     if (state.type === "not-running") {

--- a/html_views/src/goals/proof-view.css
+++ b/html_views/src/goals/proof-view.css
@@ -215,49 +215,79 @@ span[class~=charsRemoved][class~=substitution]::before {
   border-top-color: var(--vscode-coq-subgoalSeparator);
 }
 
-.richpp .constr-notation {
-  color: var(--vscode-coq-termNotation);
-}
-.richpp .constr-keyword {
-  color: var(--vscode-coq-termKeyword);
-}
+
+/* complying with the order of https://github.com/coq/coq/blob/master/ide/coqide/preferences.ml */
+/* FIXME: need to put this part into package.json */
 .richpp .constr-evar {
-  color: var(--vscode-coq-termEvar);
+  color: var(--vscode-coq-termEvarColor);
+  font-weight: var(--vscode-coq-termEvarFontWeight);
   font-style: italic;
 }
-.richpp .constr-path {
-  color: var(--vscode-coq-termPath);
-}
-.richpp .constr-reference {
-  color: var(--vscode-coq-termReference);
+.richpp .constr-keyword {
+  color: var(--vscode-coq-termKeywordColor);
+  /* font-weight: var(--vscode-coq-termKeywordFontWeight); */
+  font-weight:normal
 }
 .richpp .constr-type {
-  color: var(--vscode-coq-termType);
+  color: var(--vscode-coq-termTypeColor);
+  font-weight: var(--vscode-coq-termTypeFontWeight);
+}
+.richpp .constr-notation {
+  color: var(--vscode-coq-termNotationColor);
+  font-weight: var(--vscode-coq-termNotationFontWeight);
+}
+.richpp .constr-reference {
+  color: var(--vscode-coq-termReferenceColor);
+  font-weight: var(--vscode-coq-termReferenceFontWeight);
+}
+.richpp .constr-path {
+  color: var(--vscode-coq-termPathColor);
+  font-weight: var(--vscode-coq-termPathFontWeight);
 }
 .richpp .constr-variable {
-  color: var(--vscode-coq-termVariable);
+  color: var(--vscode-coq-termVariableColor);
+  font-weight: var(--vscode-coq-termVariableFontWeight);
 }
 .richpp .message-debug {
-  color: var(--vscode-coq-debugMessage);
+  color: var(--vscode-coq-debugMessageColor);
+  font-weight: var(--vscode-coq-debugMessageFontWeight);
 }
 .richpp .message-error {
-  color: var(--vscode-coq-errorMessage);
+  color: var(--vscode-coq-errorMessageColor);
+  font-weight: var(--vscode-coq-errorMessageFontWeight);
   text-decoration: underline;
 }
 .richpp .message-warning {
-  color: var(--vscode-coq-warningMessage);
+  color: var(--vscode-coq-warningMessageColor);
+  font-weight: var(--vscode-coq-warningMessageFontWeight);
+}
+.richpp .message-prompt {
+  color: var(--vscode-coq-promptMessageColor);
+  font-weight: var(--vscode-coq-promptMessageFontWeight);
+}
+.richpp .module-definition {
+  color: var(--vscode-coq-moduleDefinitionColor);
+  font-weight: var(--vscode-coq-moduleDefinitionFontWeight);
 }
 .richpp .module-keyword {
-  color: var(--vscode-coq-moduleKeyword);
+  color: var(--vscode-coq-moduleKeywordColor);
+  font-weight: var(--vscode-coq-moduleKeywordFontWeight);
 }
 .richpp .tactic-keyword {
-  color: var(--vscode-coq-tacticKeyword);
+  color: var(--vscode-coq-tacticKeywordColor);
+  font-weight: var(--vscode-coq-tacticKeywordFontWeight);
 }
 .richpp .tactic-primitive {
-  color: var(--vscode-coq-tacticPrimitive);
+  color: var(--vscode-coq-tacticPrimitiveColor);
+  font-weight: var(--vscode-coq-tacticPrimitiveFontWeight);
 }
 .richpp .tactic-string {
-  color: var(--vscode-coq-tacticString);
+  color: var(--vscode-coq-tacticStringColor);
+  font-weight: var(--vscode-coq-tacticStringFontWeight);
+}
+
+pre {
+  font-family: var(--vscode-editor-font-family);
 }
 
 .panels {
@@ -279,4 +309,40 @@ vscode-panel-tab {
 
 .given-up-goals-warning {
   padding-bottom: 10px;
+}
+
+:root {
+  --vscode-coq-termEvarColor:initial;
+  --vscode-coq-termEvarFontWeight:initial;
+  --vscode-coq-termKeywordColor:rgb(0, 173, 0);
+  --vscode-coq-termKeywordFontWeight:bold;
+  --vscode-coq-termTypeColor:orange;
+  --vscode-coq-termTypeFontWeight:bold;
+  --vscode-coq-termNotationColor:chocolate;
+  --vscode-coq-termNotationFontWeight:initial;
+  --vscode-coq-termReferenceColor:rgb(0, 173, 0);
+  --vscode-coq-termReferenceFontWeight:initial;
+  --vscode-coq-termPathColor:blueviolet;
+  --vscode-coq-termPathFontWeight:initial;
+  --vscode-coq-termVariableColor:initial;
+  --vscode-coq-termVariableFontWeight:initial;
+  --vscode-coq-debugMessageColor:initial;
+  --vscode-coq-debugMessageFontWeight:initial;
+  --vscode-coq-errorMessageColor:initial;
+  --vscode-coq-errorMessageFontWeight:initial;
+  --vscode-coq-warningMessageColor:initial;
+  --vscode-coq-warningMessageFontWeight:initial;
+  --vscode-coq-promptMessageColor:initial;
+  --vscode-coq-promptMessageFontWeight:initial;
+  --vscode-coq-moduleDefinitionColor:orangered;
+  --vscode-coq-moduleDefinitionFontWeight:bold;
+  --vscode-coq-moduleKeywordColor:initial;
+  --vscode-coq-moduleKeywordFontWeight:initial;
+  --vscode-coq-tacticKeywordColor:initial;
+  --vscode-coq-tacticKeywordFontWeight:initial;
+  --vscode-coq-tacticPrimitiveColor:initial;
+  --vscode-coq-tacticPrimitiveFontWeight:initial;
+  --vscode-coq-tacticStringColor:initial;
+  --vscode-coq-tacticStringFontWeight:initial;
+  --vscode-coq-hypothesisIdent:lime;
 }

--- a/html_views/src/goals/protocol.ts
+++ b/html_views/src/goals/protocol.ts
@@ -92,17 +92,27 @@ interface CommandInterrupted {
   range: any
 }
 
+export interface QueryMessageWrapper {
+  innertext: AnnotatedText
+}
+
 type FocusPosition = {focus: any}
 type NotRunningTag = {type: 'not-running'}
 type NoProofTag = {type: 'no-proof'}
 type FailureTag = {type: 'failure'}
 type ProofViewTag = {type: 'proof-view'}
 type InterruptedTag = {type: 'interrupted'}
+type QueryMessageTag = {type: 'message-query'}
+type ClearMessageTag = {type: 'message-clear'}
 type NoProofResult = NoProofTag
 type FailureResult = FailValue & FailureTag
 type ProofViewResult = ProofView & ProofViewTag
 type InterruptedResult = CommandInterrupted & InterruptedTag
+type QueryMessageResult = QueryMessageWrapper & QueryMessageTag
+type ClearMessageResult = ClearMessageTag
 export type CommandResult =
+  QueryMessageResult |
+  ClearMessageResult |
   NotRunningTag |
   (FailureResult & FocusPosition) |
   (ProofViewResult & FocusPosition) |

--- a/html_views/src/goals/protocol.ts
+++ b/html_views/src/goals/protocol.ts
@@ -103,16 +103,16 @@ type FailureTag = {type: 'failure'}
 type ProofViewTag = {type: 'proof-view'}
 type InterruptedTag = {type: 'interrupted'}
 type QueryMessageTag = {type: 'message-query'}
-type ClearMessageTag = {type: 'message-clear'}
+type ReadyClearMessageTag = {type: 'message-ready-clear'}
 type NoProofResult = NoProofTag
 type FailureResult = FailValue & FailureTag
 type ProofViewResult = ProofView & ProofViewTag
 type InterruptedResult = CommandInterrupted & InterruptedTag
 type QueryMessageResult = QueryMessageWrapper & QueryMessageTag
-type ClearMessageResult = ClearMessageTag
+type ReadyClearMessageResult = ReadyClearMessageTag
 export type CommandResult =
   QueryMessageResult |
-  ClearMessageResult |
+  ReadyClearMessageResult |
   NotRunningTag |
   (FailureResult & FocusPosition) |
   (ProofViewResult & FocusPosition) |


### PR DESCRIPTION
Tried implementing a rudimentary message panel in the fashion of that in CoqIDE. Also including some modifications on the displaying style (see `html_views/src/goals/proof-view.css`). 

**Screenshots**:
<img width="415" alt="image" src="https://user-images.githubusercontent.com/30336342/207109616-d6e53a57-9c0b-4a37-ae35-0675c5d41f11.png">

<img width="1105" alt="image" src="https://user-images.githubusercontent.com/30336342/207109474-2de2f0a1-d822-427e-b867-01f65b5e19b6.png">

**Features**:
- Output is highlighted (rendered using the same utilities of rendering goals/hypotheses)
- Per-document (each document holds its own message panel, just like the proof view)
- Searchable (with the search widget provided by the webview, see Line 154 in `client/src/HtmlCoqView.ts`)

**Some known issues**: 
- Not resizable (don't know how to implement it 😥)
- Only show the responses of queries triggered by commands like `Coq: Search` (possibly can be resolved by adding more panels and substituting them for the output channels) 

**Technical details:**
- Added another `vscode-panel-view` showing messages (from `vscode-webview-ui-toolkit`) below the proof view
- Messages are passed from the client on receiving them, using the extended `CommandResult` type (see the two changed `protocol.ts`)
