### PR TITLE
Fix formatting of ProofView error messages

### DIFF
--- a/html_views/src/goals/display-proof-state.ts
+++ b/html_views/src/goals/display-proof-state.ts
@@ -263,7 +263,7 @@ export const Infoview = () => {
       element.innerHTML = "";
       const formatted = h("div.message", [
         h("strong", "Error: "),
-        h("code", message),
+        h("code", {id: "error"}, message),
       ]);
       element.appendChild(formatted);
     };

--- a/html_views/src/goals/display-proof-state.ts
+++ b/html_views/src/goals/display-proof-state.ts
@@ -263,7 +263,7 @@ export const Infoview = () => {
       element.innerHTML = "";
       const formatted = h("div.message", [
         h("strong", "Error: "),
-        h("code", {id: "error"}, message),
+        h("code#error", message),
       ]);
       element.appendChild(formatted);
     };


### PR DESCRIPTION
Error messages in proof views are no longer formatted correctly as observed in #323.
This is broke in 4f9aacf071d19cbfa6b597646a05ae7e100311d2 due to missing attributes on the div containing the error message.

Fixes #323 