### PR TITLE
Fix proof view diff settings default values being ignored

### DIFF
--- a/client/src/HtmlCoqView.ts
+++ b/client/src/HtmlCoqView.ts
@@ -31,6 +31,7 @@ interface SettingsUpdate extends SettingsState {
 export interface ProofViewDiffSettings {
   addedTextIsItalic: boolean;
   removedTextIsStrikedthrough: boolean;
+  enabled: boolean;
 }
 
 interface SettingsState {

--- a/package.json
+++ b/package.json
@@ -133,9 +133,9 @@
           "default": "first-interaction",
           "description": "Create the proof view when a Coq script is opened, the user first interacts with coqtop, or else let the user do it manually."
         },
-        "coq.proofViewDiff": {
+        "coq.proofViewDiff.enabled": {
           "type": "boolean",
-          "default": "true",
+          "default": true,
           "markdownDescription": "Enable/disable VsCoq's Proof View Diff. Only has acceptable performance on small goals."
         },
         "coq.proofViewDiff.addedTextIsItalic": {

--- a/server/src/protocol.ts
+++ b/server/src/protocol.ts
@@ -50,6 +50,10 @@ export interface AutoFormattingSettings {
   unindentOnCloseProof: boolean,
 }
 
+export interface ProofViewDiffSettings {
+  enabled: boolean;
+}
+
 export interface CoqSettings {
   /** Load settings from _CoqProject (if found at the root of the Code project). @default `true` */
   loadCoqProject: boolean,
@@ -80,7 +84,7 @@ export interface CoqSettings {
   /** function used by hover provider to get info on identifier */
   hoverFunction: "about" | "check",
   /** Enable/Disable proof view diff render */
-  proofViewDiff: boolean,
+  proofViewDiff: ProofViewDiffSettings,
 }
 
 export interface FailValue {

--- a/server/src/stm/STM.ts
+++ b/server/src/stm/STM.ts
@@ -421,7 +421,7 @@ export class CoqStateMachine {
     }
   }
   private get proofViewDiff(): boolean {
-    return this.project.settings.coq.proofViewDiff
+    return this.project.settings.coq.proofViewDiff.enabled;
   }
 
   /**


### PR DESCRIPTION
Default values for the `coq.proofViewDiff.addedTextIsItalic` and `coq.proofViewDiff.removedTextIsStrikedthrough` are ignored after the addition of #321.
This was caused by overlapping setting keys.