### PR TITLE
Fix opening proof view looses focus

### DIFF
--- a/client/src/HtmlCoqView.ts
+++ b/client/src/HtmlCoqView.ts
@@ -155,6 +155,7 @@ export class HtmlCoqView implements view.CoqView {
       });
 
       const doc = await vscode.workspace.openTextDocument(this.coqViewUri);
+      vscode.window.showTextDocument(vscode.window.activeTextEditor?.document);
 
       const csspath = path.join(
         extensionContext.extensionPath,


### PR DESCRIPTION
Fixes #156.
Sometimes opening a proof view causes the current document to loose focus.
This happens after calling `vscode.workspace.openTextDocument()` in https://github.com/coq-community/vscoq/blob/456b549a32a31784538ccb89adf7be43fb8efcbe/client/src/HtmlCoqView.ts#L157

This is a VSCode built-in function and is always called with the same arguments, so this seems like it could be a VSCode bug.

A workaround for this issue is to reset the document focus after opening the proof view.
