### PR TITLE
Improve hover provider

### DIFF
--- a/client/src/HoverProvider.ts
+++ b/client/src/HoverProvider.ts
@@ -141,8 +141,8 @@ function formatAbout(response: string) {
     if (match !== null) {
       const notation = match[1].trim();
       let definition = response.slice(match[0].length).trim();
-      if (definition[0] == "(") {
-        const end = findClosingParenthese(definition, 0);
+      if (definition[0] === "(") {
+        const end = findClosingParenthese(definition, 1);
         if (end !== null) {
           definition = definition.slice(1, end);
         }

--- a/client/src/HoverProvider.ts
+++ b/client/src/HoverProvider.ts
@@ -122,13 +122,15 @@ function formatLocate(response: string) {
 
 // format the Expands to: xxx line returned by About queries
 function formatExpandsTo(line: string) {
-  const match_expands = line.match(/Expands to:\s+(\S+)\s+(.*)/);
+  const match_expands = line.match(/Expands to:\s+(\S+)(\s+.*)?/);
   if (match_expands !== null) {
     const md = new vscode.MarkdownString();
     md.appendMarkdown("**");
     md.appendText(match_expands[1]);
-    md.appendMarkdown("** ");
-    md.appendText(match_expands[2].trim());
+    md.appendMarkdown("**");
+    if (match_expands[2]) {
+      md.appendText(" " + match_expands[2].trim());
+    }
     return md;
   }
 

--- a/client/src/HoverProvider.ts
+++ b/client/src/HoverProvider.ts
@@ -131,6 +131,10 @@ function formatExpandsTo(line: string) {
     md.appendText(match_expands[2].trim());
     return md;
   }
+
+  if (line.trim() === "Hypothesis of the goal context.") {
+    return new vscode.MarkdownString("**Hypothesis**")
+  }
   return null;
 }
 

--- a/client/src/HoverProvider.ts
+++ b/client/src/HoverProvider.ts
@@ -128,18 +128,29 @@ function formatAbout(response: string) {
   // Or
   // |Notation leibnizO A := (discreteO A)
   // |Expands to: Notation iris.algebra.ofe.leibnizO
+  //
+  // Or
+  // |Notation z_to_addr := finz.of_z
+  // |Expands to: Notation cap_machine.addr_reg.z_to_addr
   if (response.match(/not a defined object\./gs) !== null) return;
 
   if (response.startsWith("Notation")) {
     const array = response.split(/\n(?!\s)/gms); // split on newline NOT followed by space
     let hover = []
-    const match = array[0].match(/Notation\s+(.*?)\s+:=\s+\(/);
+    const match = array[0].match(/Notation\s+(.*?)\s+:=\s*/);
     if (match !== null) {
-      const notation = match[1];
-      const end = findClosingParenthese(response, match[0].length);
-      if (end === null) return;
-      const definition = compactify(response.slice(match[0].length, end));
-      hover.push({ language: "coq", value: `"${notation}" := ${definition}` })
+      const notation = match[1].trim();
+      let definition = response.slice(match[0].length).trim();
+      if (definition[0] == "(") {
+        const end = findClosingParenthese(definition, 0);
+        if (end !== null) {
+          definition = definition.slice(1, end);
+        }
+      }
+      else {
+        definition = definition.split(/\s/, 1)[0];
+      }
+      hover.push({ language: "coq", value: `"${notation}" := ${compactify(definition)}` })
     }
 
     if (array[1].startsWith("Expands to: ")) {

--- a/client/src/HoverProvider.ts
+++ b/client/src/HoverProvider.ts
@@ -166,7 +166,9 @@ function formatAbout(response: string) {
   if (type === "") return;
   let hover = [{ language: "coq", value: type }];
 
-  let details = array[1].split(/\n(?!\s)/gms); // split on newline NOT followed by space
+  // re-join all remaining sections of the array,
+  // then split on newline NOT followed by space
+  let details = array.slice(1).join("\n\n").split(/\n(?!\s)/gms);
   for (const detail of details) {
     if (detail.startsWith("Arguments ")) {
       const source = detail.replace(/Arguments \S*\s*/, "Args: ").replace(/\s+/gms, " ");

--- a/client/src/HoverProvider.ts
+++ b/client/src/HoverProvider.ts
@@ -133,7 +133,7 @@ function formatExpandsTo(line: string) {
   }
 
   if (line.trim() === "Hypothesis of the goal context.") {
-    return new vscode.MarkdownString("**Hypothesis**")
+    return new vscode.MarkdownString("**Hypothesis**");
   }
   return null;
 }


### PR DESCRIPTION
I made a few small changes that improve the hover provider:

- **bugfix:** I noticed the hover provider wasn't rendering some notations. 
  This is because Coq omits parentheses for single word Notations. So:
  ```coq
  Notation foo := bar.
  About foo.
  ```
  Will print `Notation foo := bar` and not `Notation foo := (bar)`.

- **bugfix:** sometimes with implicit arguments the about query prints the type a second time 
  starting with `Expanded type for implicit arguments`. This broke `formatLocate` a bit as my split after type function would 
  split the output into three and not two.

- **Change:** I figure out how markdown formatting works so I could add some styling to the
  `Args:` and `Expands to:` sections of the hover.

- **Smallfix:** when in proof mode, instead of printing `Expands to: Variable foo`, `About foo` prints `Hypothesis of the goal context.`
