### PR TITLE
[sel] priority among tasks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
       run: opam install ./language-server/vscoq-language-server.opam --deps-only --with-doc --with-test
 
     - name: Install vscoq-language-server
-      run: opam install ./language-server/vscoq-language-server.opam
+      run: opam install ./language-server/vscoq-language-server.opam --with-test
 
     - run: |
         eval $(opam env)

--- a/flake.nix
+++ b/flake.nix
@@ -31,6 +31,7 @@
           ppx_inline_test
           ppx_assert
           ppx_sexp_conv
+          ppx_deriving
           sexplib
           ppx_yojson_conv
         ]);

--- a/language-server/Makefile
+++ b/language-server/Makefile
@@ -1,7 +1,10 @@
 .PHONY: coq
 world: coq
 	make -C coq dunestrap
-	dune build coq/coq-core.install coq/coq-stdlib.install vscoq-language-server.install
+	dune build coq/coq-core.install coq/coq-stdlib.install vscoq-language-server.install --error-reporting=twice
+
+test:
+	dune runtest
 
 coq/config/coq_config.ml:
 	cd coq

--- a/language-server/dm/documentManager.ml
+++ b/language-server/dm/documentManager.ml
@@ -34,6 +34,9 @@ type event =
       todo : ExecutionManager.prepared_task list;
     }
   | ExecutionManagerEvent of ExecutionManager.event
+let pp_event fmt = function
+  | ExecuteToLoc { loc; todo; _ } -> Stdlib.Format.fprintf fmt "ExecuteToLoc %d (%d tasks)" loc (List.length todo)
+  | ExecutionManagerEvent _ -> Stdlib.Format.fprintf fmt "ExecutionManagerEvent"
 
 let inject_em_event x = Sel.map (fun e -> ExecutionManagerEvent e) x
 let inject_em_events events = List.map inject_em_event events
@@ -114,7 +117,7 @@ let reset { uri; opts; init_vs; document } =
   let execution_state = ExecutionManager.init (Vernacstate.freeze_full_state ~marshallable:false) in
   { uri; opts; init_vs; document; execution_state; observe_loc = None }
 
-let interpret_to_loc state loc : (state * events) =
+let interpret_to_loc state loc : (state * event Sel.event list) =
     let invalid_ids, document = Document.validate_document state.document in
     let execution_state =
       List.fold_left (fun st id ->

--- a/language-server/dm/documentManager.mli
+++ b/language-server/dm/documentManager.mli
@@ -19,6 +19,8 @@ open Lsp.LspData
 type state
 
 type event
+val pp_event : Format.formatter -> event -> unit
+
 type events = event Sel.event list
 
 val init : Vernacstate.t -> opts:Coqargs.injection_command list -> uri:string -> text:string -> state * events

--- a/language-server/dm/executionManager.ml
+++ b/language-server/dm/executionManager.ml
@@ -162,7 +162,7 @@ let handle_feedback id fb state =
 let handle_event event state =
   match event with
   | LocalFeedback (id,fb) ->
-      Some (handle_feedback id fb state), [local_feedback]
+      Some (handle_feedback id fb state), []
   | ProofWorkerEvent event ->
       let update, events = ProofWorker.handle_event event in
       let state =

--- a/language-server/dm/searchQuery.ml
+++ b/language-server/dm/searchQuery.ml
@@ -11,6 +11,7 @@ let query_results_queue = Queue.create ()
 
 let query_feedback : notification Sel.event =
   Sel.on_queue query_results_queue (fun x -> QueryResultNotification x)
+  |> Sel.uncancellable
 
 let global_module qid =
   try Nametab.full_name_module qid

--- a/language-server/sel/dune
+++ b/language-server/sel/dune
@@ -1,3 +1,4 @@
 (library
  (name sel)
+ (preprocess (pps ppx_deriving.std))
  (public_name vscoq-language-server.sel))

--- a/language-server/sel/sel.ml
+++ b/language-server/sel/sel.ml
@@ -12,7 +12,7 @@ type 'a res = ('a,exn) result
 
 (* Events in progress *)
 type _ in_progress =
-  | Line : char list -> string in_progress
+  | Line : Bytes.t * Buffer.t -> string in_progress
   | Bytes : int * Bytes.t -> Bytes.t in_progress
 
 (* Reified function composition *)
@@ -35,31 +35,96 @@ let err : type a b c. (c res -> b) -> a in_progress -> (a -> b fcomp) -> b fcomp
     FCons(x,xs)
 
 (* Read events can be composed of many read operations *)
-type 'a event =
+type 'a system_event =
   | ReadInProgress of Unix.file_descr * 'a fcomp
   | WaitProcess of int * (Unix.process_status -> 'a)
-  | WaitQueue1 : 'b Queue.t * ('b -> 'a) -> 'a event
-  | WaitQueue2 : 'b Queue.t * 'c Queue.t * ('b -> 'c -> 'a) -> 'a event
-  | Ready of 'a
+let pp_system_event _ fmt = function
+  | ReadInProgress(_,_) -> Stdlib.Format.fprintf fmt "ReadInProgress"
+  | WaitProcess(pid,_) -> Stdlib.Format.fprintf fmt "WaitProcess %d" pid
 
-let map f = function
-  | Ready x -> Ready (f x)
-  | WaitQueue1(q1,k) -> WaitQueue1(q1,(fun x -> f (k x)))
-  | WaitQueue2(q1,q2,k) -> WaitQueue2(q1,q2,(fun x y -> f (k x y)))
+type 'a queue_event =
+  | WaitQueue1 : 'b Queue.t * ('b -> 'a) -> 'a queue_event
+  | WaitQueue2 : 'b Queue.t * 'c Queue.t * ('b -> 'c -> 'a) -> 'a queue_event
+
+let pp_queue_event _ fmt = function
+  | WaitQueue1 _ -> Stdlib.Format.fprintf fmt "WaitQueue1"
+  | WaitQueue2 _ -> Stdlib.Format.fprintf fmt "WaitQueue2"
+
+type 'a task_event = 'a [@@deriving show]
+
+type cancellation_handle = bool ref [@@deriving show]
+let cancel x = x := true
+
+type ('a,'b) with_attributes = {
+  name : string option ;
+  recurring : 'a;
+  priority : int;
+  it : 'b;
+  cancelled : cancellation_handle;
+}
+[@@deriving show]
+
+let cmp_priority { priority = t1; _} { priority = t2; _} = t1 - t2
+
+let name name it = { it with name = Some name }
+let make_recurring x = { x with recurring = true }
+let set_priority priority x = { x with priority }
+let is_recurring { recurring; _ } = recurring <> None
+let uncancellable (e,_) = e
+let cancellation_handle { cancelled; _ } = cancelled
+
+let make_event it =
+  let cancelled = ref false in
+  { name = None; recurring = false; priority = 0; cancelled; it }, cancelled
+
+type 'a event_ =
+  | SystemEvent of 'a system_event
+  | QueueEvent of 'a queue_event
+  | Task of 'a task_event
+type 'a event = (bool,'a event_) with_attributes
+
+let map_system_event f = function
   | WaitProcess(pid,k) -> WaitProcess(pid, (fun x -> f (k x)))
   | ReadInProgress(fd,fcomp) -> ReadInProgress(fd,map_fcomp f fcomp)
+  
+let map_queue_event f = function
+  | WaitQueue1(q1,k) -> WaitQueue1(q1,(fun x -> f (k x)))
+  | WaitQueue2(q1,q2,k) -> WaitQueue2(q1,q2,(fun x y -> f (k x y)))
+
+let map_task_event f x = f x
+
+let map_with_attributes f { name; recurring; priority; cancelled; it } =
+  { name; recurring; priority; cancelled; it = f it }
+
+let map f = function
+  | Task e -> Task (map_task_event f e)
+  | SystemEvent e -> SystemEvent (map_system_event f e)
+  | QueueEvent e -> QueueEvent(map_queue_event f e)
+
+let map f e = map_with_attributes (map f) e
+
+type ('a,'b) has_finished =
+  | Yes of 'a
+  | No  of 'b (* can make_event a step *)
 
 let mkReadInProgress fd = function
-  | FNil x -> Ready x
-  | f -> ReadInProgress(fd,f)
+  | FCons _ as f -> No (ReadInProgress(fd,f))
+  | FNil x -> Yes x
 
-let one_line = Line []
+let one_line () = Line (Bytes.make 1 '0', Buffer.create 40)
 let bytes n ?(buff=Bytes.create n) () = Bytes(n,buff)
 
-let on_line fd k = ReadInProgress(fd, one_line -- finish_with k)
-let on_bytes fd n k = ReadInProgress(fd, bytes n () -- finish_with k)
-let now x = Ready x
-let on_death_of ~pid k = WaitProcess(pid,k)
+let on_line fd k : 'a event * cancellation_handle =
+  make_event @@ SystemEvent (ReadInProgress(fd, one_line () -- finish_with k))
+
+let on_bytes fd n k : 'a event * cancellation_handle =
+  make_event @@ SystemEvent (ReadInProgress(fd, bytes n () -- finish_with k))
+
+let now task : 'a event =
+  make_event @@ Task task |> uncancellable
+
+let on_death_of ~pid k : 'a event * cancellation_handle =
+  make_event @@ SystemEvent (WaitProcess(pid,k))
 
 let ocaml_value (k : 'a res -> 'b) : 'b fcomp =
   let (--?) x y = err k x y in
@@ -70,7 +135,8 @@ let ocaml_value (k : 'a res -> 'b) : 'b fcomp =
   finish_with k (Ok value)))
 ;;
 
-let on_ocaml_value fd k = ReadInProgress(fd, ocaml_value k)
+let on_ocaml_value fd k : 'a event * cancellation_handle =
+  make_event @@ SystemEvent (ReadInProgress(fd, ocaml_value k))
 
 let parse_content_length_or err k s =
   try
@@ -82,44 +148,93 @@ let parse_content_length_or err k s =
 
 let httpcle (k : Bytes.t res -> 'b) : 'b fcomp  =
   let (--?) x y = err k x y in
-  one_line
+  one_line ()
   --? (parse_content_length_or (finish_with k) (fun length ->
-  one_line
+  one_line ()
   --? (fun _discard ->
   bytes length ()
   --? (fun buff ->
   finish_with k (Ok buff)))))
 
-let on_httpcle fd k = ReadInProgress(fd, httpcle k)
+let on_httpcle fd k : 'a event * cancellation_handle =
+  make_event @@ SystemEvent (ReadInProgress(fd, httpcle k))
 
-let on_queue q1 k = WaitQueue1(q1,k)
-let on_queues q1 q2 k = WaitQueue2(q1,q2,k)
+let on_queue q1 k : 'a event * cancellation_handle =
+  make_event @@ QueueEvent (WaitQueue1(q1,k))
 
-let advance ~ready_fds = function
-  | Ready _ as x -> x
-  | WaitQueue1(q1,_) as x when Queue.is_empty q1 -> x
-  | WaitQueue1(q1,k) -> Ready(k (Queue.pop q1))
-  | WaitQueue2(q1,q2,_) as x when Queue.is_empty q1 || Queue.is_empty q2 -> x
-  | WaitQueue2(q1,q2,k) -> Ready(k (Queue.pop q1) (Queue.pop q2))
+let on_queues q1 q2 k : 'a event * cancellation_handle =
+  make_event @@ QueueEvent (WaitQueue2(q1,q2,k))
+
+let cons_recurring e l =
+  match e.recurring with
+  | None -> l
+  | Some x -> { e with it = x } :: l
+
+let rec pull_ready f yes no min_priority = function
+  | [] -> List.rev yes, List.rev no, min_priority
+  | { it; cancelled; _ } as e :: rest ->
+      match f cancelled it with
+      | Yes y -> pull_ready f ({ e with it = y } :: yes) (cons_recurring e no) (min min_priority e.priority) rest
+      | No x  -> pull_ready f yes ({ e with it = x } :: no) min_priority rest 
+
+let pull_ready f l = pull_ready f [] [] max_int l
+
+let cast_to_recurring : (bool, 'a) with_attributes -> 'b -> ('b option, 'b) with_attributes =
+  fun e it ->
+  { it;
+    recurring = if e.recurring then Some it else None;
+    name = e.name;
+    priority = e.priority;
+    cancelled = e.cancelled;
+  }
+let cast_to_not_recurring : ('b, 'a) with_attributes -> ('c option, 'a) with_attributes =
+  fun e ->
+  { it = e.it;
+    recurring = None;
+    name = e.name;
+    priority = e.priority;
+    cancelled = e.cancelled;
+  }
+  
+let rec partition_events sys queue task = function
+  | [] -> List.rev sys, List.rev queue, List.rev task
+  | { it = SystemEvent x; _ } as e :: rest -> partition_events    (cast_to_recurring e x :: sys) queue task rest
+  | { it = QueueEvent x; _ } as e :: rest -> partition_events sys (cast_to_recurring e x :: queue) task rest
+  | { it = Task x; _ } as e :: rest -> partition_events sys queue (cast_to_recurring e x :: task) rest
+
+let partition_events l = partition_events [] [] [] l
+
+let advance_queue _ = function
+  | WaitQueue1(q1,_) as x when Queue.is_empty q1 ->  No x
+  | WaitQueue1(q1,k) -> Yes(k (Queue.pop q1))
+  | WaitQueue2(q1,q2,_) as x when Queue.is_empty q1 || Queue.is_empty q2 -> No x
+  | WaitQueue2(q1,q2,k) -> Yes(k (Queue.pop q1) (Queue.pop q2))
+
+let advance_system ~ready_fds _ = function
   | WaitProcess(pid,k) as x ->
       let rc, code = Unix.waitpid [Unix.WNOHANG] pid in
-      if rc == 0 then x
-      else Ready (k code)
+      if rc == 0 then No x
+      else Yes (k code)
   | ReadInProgress(_, FNil _) -> assert false
-  | ReadInProgress(fd,_) as x when not (List.mem fd ready_fds) -> x
-  | ReadInProgress(fd, FCons(Line acc,rest)) -> begin try
-      let buff = Bytes.make 1 '0' in
+  | ReadInProgress(fd,_) as x when not (List.mem fd ready_fds) -> No x
+  | ReadInProgress(fd, FCons(Line (buff,acc) as line,rest)) -> begin try
       let n = Unix.read fd buff 0 1 in
-      if n = 0 then
+      if n = 0 then begin
+        Buffer.clear acc;
         mkReadInProgress fd (rest (Error End_of_file))
-      else
+      end else
         let c = Bytes.get buff 0 in
-        if c != '\n' then
-          mkReadInProgress fd (FCons(Line (c :: acc),rest))
-        else
-          let one_line = String.concat "" (List.rev_map (String.make 1) acc) in
+        if c != '\n' then begin
+          Buffer.add_char acc c; 
+          mkReadInProgress fd (FCons(line,rest))
+        end else begin
+          let one_line = Buffer.contents acc in
+          Buffer.clear acc;
           mkReadInProgress fd (rest (Ok one_line))
-      with Unix.Unix_error _ as e -> mkReadInProgress fd (rest (Error e))
+        end
+      with Unix.Unix_error _ as e ->
+        Buffer.clear acc;
+        mkReadInProgress fd (rest (Error e))
       end
   | ReadInProgress(fd,FCons(Bytes(n,buff),rest)) -> begin try
       let m = Unix.read fd buff (Bytes.length buff - n) n in
@@ -133,16 +248,10 @@ let advance ~ready_fds = function
       with Unix.Unix_error _ as e -> mkReadInProgress fd (rest (Error e))
       end
 
-let rec partition_map f = function
-  | [] -> [], []
-  | x :: xs ->
-      match f x with
-      | None ->
-          let a, b = partition_map f xs in
-          a, x :: b
-      | Some x ->
-          let a, b = partition_map f xs in
-          x :: a, b
+(* TODO: find a better way to not duplicate recurring tasks *)
+let advance_task ready _min_prio key x =
+  if List.exists (fun x -> x.cancelled == key) ready then No x
+  else Yes x
 
 let rec map_filter f = function
   | [] -> []
@@ -156,38 +265,198 @@ let rec map_filter f = function
    system event is ready. We never sleep forever, since process death events
    do not wakeup select: we anyway wake up 10 times per second *)
 let check_for_system_events l =
-  let fds = map_filter (function ReadInProgress(fd,_) -> Some fd | _ -> None) l in
-  if fds = [] then [], l
-  else
-    let ready_fds, _, _ = Unix.select fds [] [] 0.0 in
-    let l = List.map (advance ~ready_fds) l in
-    let ready, waiting = partition_map (function Ready x -> Some x | _ -> None) l in
-    ready, waiting
+  let fds = map_filter (function { it = ReadInProgress(fd,_); _ } -> Some fd | _ -> None) l in
+  let ready_fds, _, _ = Unix.select fds [] [] 0.0 in
+  let ready, waiting, min_prio  = pull_ready (advance_system ~ready_fds) l in
+  ready, waiting, min_prio
+
+let check_for_queue_events l =
+  pull_ready advance_queue l
 
 let next_deadline delta = Unix.gettimeofday() +. delta
 
-let rec wait_for_system_events ~deadline l =
-  let fds = map_filter (function ReadInProgress(fd,_) -> Some fd | _ -> None) l in
-  let ready_fds, _, _ = Unix.select fds [] [] 0.1 in
-  let l = List.map (advance ~ready_fds) l in
-  let ready, waiting = partition_map (function Ready x -> Some x | _ -> None) l in
-  if ready <> [] then ready, waiting
-  else wait ~deadline waiting
+module Sorted : sig
 
-and wait ?(deadline=max_float) l =
-  if l = [] then [], []
-  else if Unix.gettimeofday () > deadline then [], l
+  type 'a list
+  type 'a list_ =
+    | Nil
+    | Cons of 'a * int * 'a list
+
+  val look : 'a list -> 'a list_
+  val cons : 'a -> int -> 'a list -> 'a list
+  val cons_opt : ('a * int) option -> 'a list -> 'a list
+  val nil : 'a list
+  val length : 'a list -> int
+  val filter : ('a -> bool) -> 'a list -> 'a list
+  val for_all : ('a -> bool) -> 'a list -> bool
+  val map_to_list : ('a -> 'b) -> 'a list -> 'b List.t
+  val append : 'a list -> 'a list -> 'a list
+  val concat3 : ('a -> int) -> 'a List.t -> 'a List.t -> 'a list -> 'a list
+  val sort : ('a -> int) -> 'a List.t -> 'a list
+  val min : 'a list -> int
+  val pp_list : (Format.formatter -> 'a -> unit) -> Format.formatter -> 'a list -> unit
+
+end = struct
+  module L = struct type 'a t = 'a list [@@deriving show] end
+
+  type 'a list = ('a * int) L.t
+  [@@deriving show]
+
+  type 'a list_ =
+    | Nil
+    | Cons of 'a * int * ('a * int) L.t
+
+  [@@deriving show]
+
+  let nil = []
+
+  let length = List.length
+
+  let on_fst f = (); fun (x,_) -> f x
+
+  let rec filter f l = List.filter (on_fst f) l
+
+  let rec for_all f l = List.for_all (on_fst f) l
+
+  let min = function [] -> max_int | (_,p) :: _ -> p
+
+  let look = function
+    | [] -> Nil
+    | (x,p) :: xs -> Cons(x,p,xs)
+
+  let rec cons x p = function
+    | [] -> [x,p]
+    | (_,q) :: _ as l when p < q -> (x,p) :: l
+    | (y,q) :: l -> (y,q) :: cons x p l
+  let cons_opt = function
+    | Some(x,p) -> cons x p
+    | None -> fun x -> x
+
+  let map_to_list f l = List.map (on_fst f) l
+
+  let cmp (_,p1) (_,p2) = p1 - p2
+
+  let append l1 l2 = List.sort cmp (l1 @ l2)
+    
+  let add_prio f l = List.map (fun x -> x, f x) l
+
+  let concat3 f l1 l2 l3 = List.sort cmp (add_prio f l1 @ add_prio f l2 @ l3)
+
+  let sort f l = add_prio f l |> List.sort cmp
+
+end
+
+let priority_sort l = List.stable_sort cmp_priority l
+
+type 'a todo = {
+  system : ('a system_event option,'a system_event) with_attributes list;
+  queue  : ('a queue_event option,'a queue_event)  with_attributes list;
+  tasks  : ('a task_event option,'a task_event)   with_attributes Sorted.list;
+  ready  : ('a option,'a) with_attributes Sorted.list;
+}
+[@@deriving show]
+let empty = { system = []; queue = [] ; tasks = Sorted.nil; ready = Sorted.nil }
+
+let size { system; queue; tasks; ready } =
+  List.(length system + length queue + Sorted.length tasks + Sorted.length ready )
+
+let nothing_left_to_do { system; queue; tasks; ready } =
+  system = [] && queue = [] && tasks = Sorted.nil && ready = Sorted.nil
+
+let only_recurring_events { system; queue; tasks; ready } =
+  List.for_all is_recurring system &&
+  List.for_all is_recurring queue &&
+  Sorted.for_all is_recurring tasks &&
+  ready = Sorted.nil
+
+let not_cancelled { cancelled; _ } = !cancelled = false
+
+let prune_cancelled { system; queue; tasks; ready } =
+  let system = List.filter not_cancelled system in
+  let queue  = List.filter not_cancelled queue in
+  let tasks  = Sorted.filter not_cancelled tasks in
+  let ready  = Sorted.filter not_cancelled ready in
+  { system; queue; tasks; ready }
+
+(* This is blocking wait (modulo a deadline). We check for system events
+   (io, process death) or a queue (in case some thread puts a token there). *)
+let rec wait_for_system_or_queue_events ~deadline (fds,sys) queue =
+  if Unix.gettimeofday () > deadline then [], [], sys, queue, max_int
   else
-    let l = List.map (advance ~ready_fds:[]) l in
-    let ready, waiting = partition_map (function Ready x -> Some x | _ -> None) l in
-    if ready = [] then wait_for_system_events ~deadline waiting
-    else
-      let more_ready, waiting = check_for_system_events waiting in
-      ready @ more_ready, waiting
+    let ready_fds, _, _ = Unix.select fds [] [] 0.1 in
+    let ready_sys, waiting_sys, min_prio_sys = pull_ready (advance_system ~ready_fds) sys in
+    let ready_queue, waiting_queue, min_prio_queue = pull_ready advance_queue queue in
+    if ready_sys <> [] || ready_queue <> [] then ready_sys, ready_queue, waiting_sys, waiting_queue, min min_prio_queue min_prio_sys
+    else wait_for_system_or_queue_events ~deadline (fds,waiting_sys) queue
 
-let wait ?stop_after_being_idle_for l =
-  match stop_after_being_idle_for with
-  | Some delta ->
-      let deadline = next_deadline delta in
-      wait ~deadline l
-  | None -> wait l
+let wait_return_sorted (l1,l2,l3,todo) =
+  priority_sort l1 |> List.map (fun x -> x.it),
+  priority_sort l2 |> List.map (fun x -> x.it),
+  l3 |> Sorted.map_to_list (fun x -> x.it),
+  todo
+
+let cons_recurring_sorted e p l =
+  match e.recurring with
+  | None -> l
+  | Some x -> Sorted.cons { e with it = x } p l
+  
+
+let pull_ready_sorted min_prio l =
+  match Sorted.look l with
+  | Sorted.Nil -> None, Sorted.nil
+  | Sorted.Cons(_,p,_) when min_prio <= p -> None, l
+  | Sorted.Cons(x,p,l) -> Some(x,p), cons_recurring_sorted x p l
+
+let wait ?(deadline=max_float) todo =
+  let { system; queue; tasks; ready } as todo = prune_cancelled todo in
+  if nothing_left_to_do todo then
+    [], [], Sorted.nil, todo
+  else
+    let ready_sys, waiting_sys, min_prio_sys = check_for_system_events system in
+    let ready_queue, waiting_queue, min_prio_queue = check_for_queue_events queue in
+    if ready = Sorted.nil && tasks = Sorted.nil && ready_queue = [] && ready_sys = [] then
+      let fds = map_filter (function { it = ReadInProgress(fd,_); _ } -> Some fd | _ -> None) waiting_sys in
+      let ready_sys, ready_queue, waiting_sys, waiting_queue, _ =
+        wait_for_system_or_queue_events ~deadline (fds,waiting_sys) waiting_queue in
+      ready_sys, ready_queue, Sorted.nil,
+      { system = waiting_sys; queue = waiting_queue; tasks = Sorted.nil; ready = Sorted.nil }
+    else
+      let min_prio = min min_prio_sys min_prio_queue in
+      let min_prio = min min_prio (Sorted.min ready) in
+      let ready_task, waiting_tasks = pull_ready_sorted min_prio tasks in
+      ready_sys, ready_queue, Sorted.cons_opt ready_task ready,
+      { system = waiting_sys; queue = waiting_queue; tasks = waiting_tasks; ready = Sorted.nil }
+
+
+let pop_return (ready_sys,ready_queue,ready_task, todo) =
+  let ready_sys = List.map cast_to_not_recurring ready_sys in
+  let ready_queue = List.map cast_to_not_recurring ready_queue in
+  let ready = Sorted.concat3 (fun x -> x.priority) ready_sys ready_queue ready_task in
+  match Sorted.look ready with
+  | Sorted.Cons(x,_,ready) -> Some x.it, { todo with ready }
+  | Sorted.Nil -> None, todo
+
+let pop l =
+  match pop_return @@ wait l with
+  | None, _ -> raise @@ Failure "nothing to pop"
+  | Some x, t -> x, t
+let pop_opt l = pop_return @@ wait l
+
+let pop_timeout ~stop_after_being_idle_for:delta l = 
+  let deadline = next_deadline delta in
+  pop_return @@ wait ~deadline l
+
+let wait_timeout ~stop_after_being_idle_for:delta l =
+  let deadline = next_deadline delta in
+  wait_return_sorted @@ wait ~deadline l
+
+let wait l = wait_return_sorted @@ wait l
+
+let enqueue { system; queue; tasks; ready } l =
+  let new_sys, new_queue, new_tasks = partition_events l in
+  { 
+    system = system @ new_sys;
+    queue = queue @ new_queue;
+    tasks = Sorted.append tasks (Sorted.sort (fun x -> x.priority) new_tasks);
+    ready;
+  }

--- a/language-server/sel/sel.mli
+++ b/language-server/sel/sel.mli
@@ -12,25 +12,41 @@
 
 type 'a event
 type 'a res = ('a,exn) result
+type cancellation_handle
+val cancel : cancellation_handle -> unit
 
 (** System events one can wait for *)
-val on_line : Unix.file_descr -> (string res -> 'a) -> 'a event
-val on_bytes : Unix.file_descr -> int -> (Bytes.t res -> 'a) -> 'a event
-val on_death_of : pid:int -> (Unix.process_status -> 'a) -> 'a event
+val on_line : Unix.file_descr -> (string res -> 'a) -> 'a event * cancellation_handle
+val on_bytes : Unix.file_descr -> int -> (Bytes.t res -> 'a) -> 'a event * cancellation_handle
+val on_death_of : pid:int -> (Unix.process_status -> 'a) -> 'a event * cancellation_handle
 
-val on_ocaml_value : Unix.file_descr -> ('b res -> 'a) -> 'a event
-val on_httpcle : Unix.file_descr -> (Bytes.t res -> 'a) -> 'a event
+val on_ocaml_value : Unix.file_descr -> ('b res -> 'a) -> 'a event * cancellation_handle
+val on_httpcle : Unix.file_descr -> (Bytes.t res -> 'a) -> 'a event * cancellation_handle
 
 (** Synchronization events between components (worker pool and a task queue) *)
-val on_queues : 'b Queue.t -> 'c Queue.t -> ('b -> 'c -> 'a) -> 'a event
+val on_queues : 'b Queue.t -> 'c Queue.t -> ('b -> 'c -> 'a) -> 'a event * cancellation_handle
 
 (** A way to feed the event queue *)
-val on_queue : 'b Queue.t -> ('b -> 'a) -> 'a event
+val on_queue : 'b Queue.t -> ('b -> 'a) -> 'a event * cancellation_handle
 
-(** Dummy event *)
+(** Mix regular computations with blocking event (reified) *)
 val now : 'a -> 'a event
 
 val map : ('a -> 'b) -> 'a event -> 'b event
+
+(** for debug printing *)
+val name : string -> 'a event -> 'a event
+(** a recurrent event is never removed from the todo set, that is, when
+   ready a copy of it is added back automatically *)
+val make_recurring : 'a event -> 'a event
+(** convenience adaptor to drop the cancellation handle *)
+val uncancellable : 'a event * cancellation_handle -> 'a event
+(** it is unusual to make a regular computation cancellable, hence the
+   event constructor does not recurn the cancellation handle. Here the way
+   to recover it *)
+val cancellation_handle : 'e event -> cancellation_handle
+(** lower integers correspond to hight priorities (as in Unix nice) *)
+val set_priority : int -> 'a event -> 'a event
 
 (** The main loop goes like this
 
@@ -40,23 +56,44 @@ val map : ('a -> 'b) -> 'a event -> 'b event
 
     let echo : top_event event =
       on_line Unix.stdin (function
-      | Ok s -> Echo s
-      | Error _ -> Echo "error")
+        | Ok s -> Echo s
+        | Error _ -> Echo "error")
+      |> uncancellable
+      |> make_recurrent
 
     let handle_event = function
-    | NotForMe e -> List.map (map (fun x -> NotForMe x)) (Component.handle_event e)
+    | NotForMe e ->
+        List.map (map (fun x -> NotForMe x)) (Component.handle_event e)
     | Echo text ->
         Printf.eprintf "echo: %s\n" text;
-        [echo]
+        []
 
     let rec loop evs =
-      let ready, waiting = wait evs in
-      let new_evs_l = List.map handle_event ready in
-      loop (waiting @ List.concat new_evs_l)
+      let ready, evs = pop evs in
+      let new_evs = handle_event ready in
+      loop (enqueue evs new_evs)
 
     let main () =
-      loop [echo; ...]
+      loop (enqueue empty [echo; ...])
 
  *)
 
-val wait : ?stop_after_being_idle_for:float -> 'a event list -> 'a list * 'a event list
+type 'a todo
+val pp_todo : (Format.formatter -> 'a -> unit) -> Format.formatter -> 'a todo -> unit
+
+val empty : 'a todo
+val size : 'a todo -> int
+val enqueue : 'a todo -> 'a event list -> 'a todo
+val nothing_left_to_do : 'a todo -> bool
+val only_recurring_events : 'a todo -> bool
+
+(** raises Failure if there is nothing left to do *)
+val pop : 'a todo -> 'a * 'a todo
+val pop_opt : 'a todo -> 'a option * 'a todo
+
+val pop_timeout : stop_after_being_idle_for:float -> 'a todo -> 'a option * 'a todo
+
+val wait : 'a todo -> 'a list * 'a list * 'a list * 'a todo
+val wait_timeout : stop_after_being_idle_for:float -> 'a todo -> 'a list * 'a list * 'a list * 'a todo
+
+

--- a/language-server/tests/sel_tests.ml
+++ b/language-server/tests/sel_tests.ml
@@ -1,17 +1,230 @@
 open Base
 open Sel
 
-let%test_unit "wait.empty" =
-  let (ready, remaining) = Sel.wait [] in
-  [%test_eq: bool] (List.is_empty ready) true;
-  [%test_eq: bool] (List.is_empty remaining) true
+(************************ UTILS **********************************************)
 
-let%test_unit "wait.emptyqueue" =
+(* we don't want to lock forever doing tests, esp if we know pop_opt would be
+   stuck *)
+let wait_timeout todo =
+  let ready, todo = pop_timeout ~stop_after_being_idle_for:0.1 todo in
+  [%test_eq: bool] (Option.is_none ready) true;
+  [%test_eq: bool] (nothing_left_to_do todo) false;
+  ready, todo
+
+(* match a string list against a rex list, useful for errors *)
+let rec osmatch r s =
+  match s with
+  | None -> false
+  | Some s -> Str.string_match (Str.regexp r) s 0
+  
+let b2s = function
+  | Ok b -> Bytes.to_string b
+  | Error x -> Stdlib.Printexc.to_string x
+
+let s2s = function
+  | Ok s -> s
+  | Error x -> Stdlib.Printexc.to_string x
+
+let write_pipe write s =
+  let len = String.length s in
+  let rc = Unix.write write (Bytes.of_string s) 0 len in
+  [%test_eq: int] rc len
+
+let pipe () =
+  let read, write = Unix.pipe () in
+  read, write_pipe write
+
+let read_leftover read n =
+  let b = Bytes.create n in
+  let rc = Unix.read read b 0 n in
+  [%test_eq: int] rc n;
+  Bytes.to_string b
+  
+(*****************************************************************************)
+
+(* pop_opt terminates *)
+let%test_unit "sel.wait.empty" =
+  let ready, todo = pop_opt empty in
+  [%test_eq: bool] (Option.is_none ready) true;
+  [%test_eq: bool] (nothing_left_to_do todo) true;
+;;
+
+(* tasks are returned according to their priority *)
+let %test_unit "sel.wait.prio" =
+  let todo = enqueue empty [
+    now 3 |> set_priority 3;
+    now 1 |> set_priority 1;
+    now 2 |> set_priority 2
+    ] in
+  let ready, todo = pop_opt todo in
+  [%test_eq: int option] ready (Some 1);
+  let ready, todo = pop_opt todo in
+  [%test_eq: int option] ready (Some 2);
+  let ready, todo = pop_opt todo in
+  [%test_eq: int option] ready (Some 3);
+;;
+
+(* recurring tasks are not lost/consumed *)
+let %test_unit "sel.wait.recurring" =
+  let e1 = now 1 |> set_priority 1 in
+  let e2 = now 2 |> set_priority 2 |> make_recurring in
+  let todo = enqueue empty [e1;e2] in
+  (* 1 and 2, are ready; 2 stays there *)
+  let ready, todo = pop_opt todo in
+  [%test_eq: int option] ready (Some 1);
+  [%test_eq: bool] (nothing_left_to_do todo) false;
+  [%test_eq: bool] (only_recurring_events todo) true;
+  let ready, todo = pop_opt todo in
+  [%test_eq: int option] ready (Some 2);
+  [%test_eq: bool] (nothing_left_to_do todo) false;
+  [%test_eq: bool] (only_recurring_events todo) true;
+  (* 2 still there *)
+  let ready, todo = pop_opt todo in
+  [%test_eq: int option] ready (Some 2);
+  [%test_eq: bool] (nothing_left_to_do todo) false;
+  [%test_eq: bool] (only_recurring_events todo) true;
+;;
+
+(* recurring tasks can lead to starvation *)
+let %test_unit "sel.wait.recurring.starvation" =
+  let e1 = now 1 |> set_priority 1 |> make_recurring in
+  let e2 = now 2 |> set_priority 2 in
+  let todo = enqueue empty [e1;e2] in
+  (* 1 and 2, are ready; 2 stays there *)
+  let ready, todo = pop_opt todo in
+  [%test_eq: bool] (nothing_left_to_do todo) false;
+  [%test_eq: bool] (only_recurring_events todo) false;
+  [%test_eq: int option] ready (Some 1);
+  let ready, todo = pop_opt todo in
+  [%test_eq: bool] (nothing_left_to_do todo) false;
+  [%test_eq: int option] ready (Some 1);
+  (* pp_todo (fun fmt i -> Format.fprintf fmt "%d" i) Format.std_formatter todo; *)
+  [%test_eq: bool] (only_recurring_events todo) false;
+;;
+
+(* bytes n waits until n bytes are read *)
+let %test_unit "sel.event.bytes" =
+  let read, write = pipe () in
+  let todo = enqueue empty [fst @@ on_bytes read 3 b2s] in
+  (* nothing to read *)
+  let ready, todo = wait_timeout todo in
+  (* something to read but not enough *)
+  write "1";
+  let ready, todo = wait_timeout todo in
+  (* more than enough *)
+  write "234";
+  let ready, todo = pop_opt todo in
+  [%test_eq: bool] (nothing_left_to_do todo) true;
+  [%test_eq: string option] ready (Some "123");
+  (* extra byte is not lost *)
+  [%test_eq: string] (read_leftover read 1) "4";
+;;
+
+(* internal buffer is reset *)
+let %test_unit "sel.event.bytes.recurring" =
+  let read, write = pipe () in
+  let todo = enqueue empty [on_bytes read 3 b2s |> uncancellable |> make_recurring] in
+  write "123";
+let ready, todo = pop_opt todo in
+  [%test_eq: string option] ready (Some "123");
+  write "456";
+  let ready, todo = pop_opt todo in
+  [%test_eq: string option] ready (Some "456");
+;;
+
+(* queue does not run unless something is pushed *)
+let%test_unit "sel.event.queue" =
   let q = Stdlib.Queue.create () in
-  let (ready, remaining) = Sel.wait ~stop_after_being_idle_for:1.0 [Sel.on_queue q (fun () -> ())] in
-  [%test_eq: bool] (List.is_empty ready) true;
-  [%test_eq: bool] (List.is_empty remaining) false;
+  let todo = enqueue empty [on_queue q (fun () -> ()) |> uncancellable] in
+  (* no progress since the queue is empty *)
+  let ready, todo = wait_timeout todo in
+  (* progress since the queue has a token *)
   Stdlib.Queue.push () q;
-  let (ready, remaining) = Sel.wait [Sel.on_queue q (fun () -> ())] in
-  [%test_eq: bool] (List.is_empty ready) false;
-  [%test_eq: bool] (List.is_empty remaining) true
+  let ready, todo = pop_opt todo in
+  [%test_eq: bool] (Option.is_none ready) false;
+  [%test_eq: bool] (nothing_left_to_do todo) true;
+;;
+
+(* queue2 does not advance unless both queues are pushed *)
+let%test_unit "sel.event.queue2" =
+  let q1 = Stdlib.Queue.create () in
+  let q2 = Stdlib.Queue.create () in
+  let todo = enqueue empty [on_queues q1 q2 (fun () () -> ()) |> uncancellable] in
+  Stdlib.Queue.push () q1;
+  (* no progress since one queue is empty *)
+  let ready, todo = wait_timeout todo in
+  Stdlib.Queue.push () q2;
+  (* progress since both queues have a token *)
+  let ready, todo = pop_opt todo in
+  [%test_eq: bool] (Option.is_none ready) false;
+  [%test_eq: bool] (nothing_left_to_do todo) true;
+;;
+
+(* line event waits for \n and does not eat more chars *)
+let %test_unit "sel.event.line" =
+  let read, write = pipe () in
+  let todo = enqueue empty [on_line read s2s |> uncancellable] in
+  let ready, todo = wait_timeout todo in
+  write "123";
+  let ready, todo = wait_timeout todo in
+  write "\naa";
+  let ready, todo = pop_opt todo in
+  [%test_eq: bool] (nothing_left_to_do todo) true;
+  [%test_eq: string option] ready (Some "123");
+  [%test_eq: string] (read_leftover read 2) "aa";
+;;
+
+(* line internal buffer is not pulluted by previous run *)
+let %test_unit "sel.event.line.recurring" =
+  let read, write = pipe () in
+  let todo = enqueue empty [on_line read s2s |> uncancellable |> make_recurring] in
+  write "123\n";
+  let ready, todo = pop_opt todo in
+  [%test_eq: bool] (nothing_left_to_do todo) false;
+  [%test_eq: string option] ready (Some "123");
+  write "456\n";
+  let ready, todo = pop_opt todo in
+  [%test_eq: bool] (nothing_left_to_do todo) false;
+  [%test_eq: string option] ready (Some "456");
+;;
+
+let %test_unit "sel.event.http_cle" =
+  let read, write = pipe () in
+  let todo = enqueue empty [on_httpcle read b2s |> uncancellable ] in
+  write "content-Length: 4\n\n1\n3.";
+  let ready, todo = pop_opt todo in
+  [%test_eq: bool] (nothing_left_to_do todo) true;
+  [%test_eq: string option] ready (Some "1\n3.");
+;;
+
+let %test_unit "sel.event.http_cle.recurring" =
+  let read, write = pipe () in
+  let todo = enqueue empty [on_httpcle read b2s |> uncancellable |> make_recurring] in
+  write "content-Length: 4\n\n1\n3.";
+  let ready, todo = pop_opt todo in
+  [%test_eq: bool] (nothing_left_to_do todo) false;
+  [%test_eq: string option] ready (Some "1\n3.");
+  write "content-Length: 4\n\n4\n6.";
+  let ready, todo = pop_opt todo in
+  [%test_eq: bool] (nothing_left_to_do todo) false;
+  [%test_eq: string option] ready (Some "4\n6.");
+;;
+
+let %test_unit "sel.event.http_cle.recurring.err" =
+  let read, write = pipe () in
+  let todo = enqueue empty [on_httpcle read b2s |> uncancellable |> make_recurring] in
+  write "content-Length: \n";
+  let ready, todo = pop_opt todo in
+  [%test_eq: bool] (nothing_left_to_do todo) false;
+  [%test_eq: string option] ready (Some "End_of_file");
+  write "a\n";
+  let ready, todo = pop_opt todo in
+  [%test_eq: bool] (nothing_left_to_do todo) false;
+  [%test_eq: bool] (osmatch ".*Scan_failure.*" ready) true;
+  write "content-Length: 4\n\n4\n6.";
+  let ready, todo = pop_opt todo in
+  [%test_eq: bool] (nothing_left_to_do todo) false;
+  [%test_eq: string option] ready (Some "4\n6.");
+;;
+
+  

--- a/language-server/tests/sel_tests.ml
+++ b/language-server/tests/sel_tests.ml
@@ -102,6 +102,21 @@ let %test_unit "sel.wait.recurring.starvation" =
   [%test_eq: bool] (only_recurring_events todo) false;
 ;;
 
+(* recurring tasks do not inflate the todo *)
+let %test_unit "sel.wait.recurring.inflation" =
+  let e1 = now 1 |> set_priority 1 |> make_recurring in
+  let e2 = now 2 |> set_priority 2 |> make_recurring in
+  let todo = enqueue empty [e1;e2] in
+  let _, todo = pop_opt todo in
+  let _, todo = pop_opt todo in
+  let _, todo = pop_opt todo in
+  let _, todo = pop_opt todo in
+  let _, todo = pop_opt todo in
+  let _, todo = pop_opt todo in
+  let _, todo = pop_opt todo in
+  [%test_eq: int] (size todo) 2;
+;;
+
 (* bytes n waits until n bytes are read *)
 let %test_unit "sel.event.bytes" =
   let read, write = pipe () in

--- a/language-server/vscoq-language-server.opam
+++ b/language-server/vscoq-language-server.opam
@@ -15,6 +15,8 @@ depends: [
   "ppx_inline_test"
   "ppx_assert"
   "ppx_sexp_conv"
+  "ppx_yojson_conv"
+  "ppx_deriving"
   "sexplib"
   "ppx_yojson_conv"
 ]

--- a/language-server/vscoqtop/lspManager.ml
+++ b/language-server/vscoqtop/lspManager.ml
@@ -74,7 +74,10 @@ let lsp : event Sel.event =
       end
     | Error exn ->
         log @@ ("failed to read message: " ^ Printexc.to_string exn);
-        exit 0)
+        LspManagerEvent (Request None))
+  |> fst
+  |> Sel.name "lsp"
+  |> Sel.make_recurring
 
 let logTrace ~message ~extra =
   let event = "$/logTrace" in
@@ -341,7 +344,7 @@ let handle_lsp_event = function
       let params = req |> member "params" in
       log @@ "ui request: " ^ method_name;
       let more_events = dispatch_method ~id method_name params in
-      more_events @ [lsp]
+      more_events
 
 let pr_lsp_event = function
   | Request req ->


### PR DESCRIPTION
This PR packs some orthogonal features (hem...) but I don't think it is worth making the history cleaner at this stage.

- sel now takes a `todo` which internally keeps system/queue/task events separate (for my mental sanity)
- tasks have now a priority, and are always returned accordingly (pretty naive, but that is it)
- events can be named, for debugging purposes
- events can be made recurrent (a copy always stays in the queue, we have two occurrences in the lang server, the lsp message event, and the some feedback from coq one)

The library is still a little low level, e.g. if you have two `ExecToLoc` events (tasks) it returns both, it is up to the caller to
give precedence to the first one, and put the other back (with the same priority, likely).
This is a deliberate choice, and lets one for example overrule both `ExecToLoc` if something happens, or purge/arrange one of the two if the other one includes/overlaps with it. I think these scheduling decision are not to be done by SEL.
