### PR TITLE
fix: Nix flake target error in VSCoq2

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -4,4 +4,4 @@
     sha256 = "0jm6nzb83wa6ai17ly9fzpqc40wg1viib8klq8lby54agpl213w5"; }
 ) {
   src =  ./.;
-}).defaultNix.packages.default
+}).defaultNix.packages.x86_64-linux.default

--- a/flake.nix
+++ b/flake.nix
@@ -4,6 +4,7 @@
   outputs = { self, nixpkgs }: {
 
     packages.default = self.packages.x86_64-linux.vscoq-language-server;
+    packages.x86_64-linux.default = self.packages.x86_64-linux.vscoq-language-server;
 
     packages.x86_64-linux.vscoq-language-server =
       # Notice the reference to nixpkgs here.

--- a/flake.nix
+++ b/flake.nix
@@ -3,7 +3,6 @@
 
   outputs = { self, nixpkgs }: {
 
-    packages.default = self.packages.x86_64-linux.vscoq-language-server;
     packages.x86_64-linux.default = self.packages.x86_64-linux.vscoq-language-server;
 
     packages.x86_64-linux.vscoq-language-server =

--- a/shell.nix
+++ b/shell.nix
@@ -4,4 +4,4 @@
     sha256 = "0jm6nzb83wa6ai17ly9fzpqc40wg1viib8klq8lby54agpl213w5"; }
 ) {
   src =  ./.;
-}).shellNix.packages.default
+}).shellNix.packages.x86_64-linux.default


### PR DESCRIPTION
To build the nix flake, @HjalteSorgenfrei, @Jakobis and I needed to add that it was the default target for linux specifically.
We honestly don't know enough about Nix to know if `packages.default` also should be provided, so if something here is wrong, then feel free to correct us.

That would probably also solve [the failing action](https://github.com/coq-community/vscoq/actions/runs/4125391653/jobs/7125890414).