### PR TITLE
Improve nix dev build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
         cd client
         yarn run package
 
-  build-language-server:
+  nix-dev-build:
     strategy:
       matrix:
         os: [ubuntu-latest]
@@ -42,7 +42,8 @@ jobs:
       with:
         nix_path: nixpkgs=channel:nixos-unstable
     - run: nix build '.?submodules=1'
-    - run: nix-shell --run "cd language-server && make world"
+    - run: nix develop .#vscoq-language-server -c bash -c "cd language-server && make world"
+    - run: nix develop .#vscoq-client -c bash -c "cd client && yarn run install:all && yarn run build:all && yarn run compile"
 
   build-language-server-opam:
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
   nix-dev-build:
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
     - name: Checkout

--- a/default.nix
+++ b/default.nix
@@ -1,7 +1,0 @@
-(import (
-  fetchTarball {
-    url = "https://github.com/edolstra/flake-compat/archive/12c64ca55c1014cdc1b16ed5a804aa8576601ff2.tar.gz";
-    sha256 = "0jm6nzb83wa6ai17ly9fzpqc40wg1viib8klq8lby54agpl213w5"; }
-) {
-  src =  ./.;
-}).defaultNix.packages.x86_64-linux.default

--- a/docs/developers.md
+++ b/docs/developers.md
@@ -12,11 +12,18 @@ The language server is developed in ocaml and makes it possible to link from the
 
 ### Building
 
+If you have nix installed, you can do a full developer build of the language server by running:
+
+```
+nix build '.?submodules=1'
+nix develop .#vscoq-language-server -c bash -c "cd language-server && make world"
+```
+
 ### Debugging
 
 ## Client 
 
-The client is the VSCode extension in itself. Apart from the usual [VSCode](https://code.visualstudio.com/api) lingo, we develop two web apps that are used within seperate panels in the extension and are specific to Coq, namely the goal-view-ui and the search-view-ui. 
+The client is the VSCode extension in itself. Apart from the usual [VSCode](https://code.visualstudio.com/api) lingo, we develop two web apps that are used within separate panels in the extension and are specific to Coq, namely the goal-view-ui and the search-view-ui.
 
 ### Design pattern for the web apps
 
@@ -37,7 +44,7 @@ You can debug the web apps independently. From the client folder just run `yarn 
 
 Note that both the apps can also be built independently through the `yarn run build:goal-view-ui` or `yarn run build:search-ui` commands. 
 
-To launch the extension in debug mode, assuming you have build the language-server, you can either use a nix-shell to run vscode (`nix-shell --run "code client"`) or handle your own config. 
+To launch the extension in debug mode, assuming you have built the language-server, you can either use a nix dev shell to run vscode (`nix develop .#vscoq-client -c code .`) or handle your own config.
 
 Note that you need to set the path to vscoqtop in the VSCode user settings (just search for vscoq).
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,20 @@
 {
   "nodes": {
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1676283394,
+        "narHash": "sha256-XX2f9c3iySLCw54rJ/CZs+ZK6IQy7GXNY4nSOyu2QG4=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "3db36a8b464d0c4532ba1c7dda728f4576d6d073",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1675698036,
@@ -16,6 +31,7 @@
     },
     "root": {
       "inputs": {
+        "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -1,13 +1,18 @@
 {
   description = "VsCoq 2, a language server for Coq based on LSP";
 
-  outputs = { self, nixpkgs }: {
+  inputs.flake-utils.url = "github:numtide/flake-utils";
 
-    packages.x86_64-linux.default = self.packages.x86_64-linux.vscoq-language-server;
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+  
+   rec {
 
-    packages.x86_64-linux.vscoq-language-server =
+    packages.default = self.packages.${system}.vscoq-language-server;
+
+    packages.vscoq-language-server =
       # Notice the reference to nixpkgs here.
-      with import nixpkgs { system = "x86_64-linux"; };
+      with import nixpkgs { inherit system; };
       ocamlPackages.buildDunePackage {
         duneVersion = "3";
         pname = "vscoq-language-server";
@@ -37,8 +42,8 @@
         ]);
       };
 
-    packages.x86_64-linux.vscoq-client =
-      with import nixpkgs { system = "x86_64-linux"; };
+    packages.vscoq-client =
+      with import nixpkgs { inherit system; };
       stdenv.mkDerivation rec {
 
         name = "vscoq-client";
@@ -51,15 +56,15 @@
 
     };
 
-    devShells.x86_64-linux.default =
-      with import nixpkgs { system = "x86_64-linux"; };
+    devShells.default =
+      with import nixpkgs { inherit system; };
       mkShell {
         buildInputs =
-          self.packages.x86_64-linux.vscoq-language-server.buildInputs
+          self.packages.${system}.vscoq-language-server.buildInputs
           ++ (with ocamlPackages; [
             ocaml-lsp
           ]);
       };
 
-  };
+  });
 }

--- a/shell.nix
+++ b/shell.nix
@@ -1,7 +1,0 @@
-(import (
-  fetchTarball {
-    url = "https://github.com/edolstra/flake-compat/archive/12c64ca55c1014cdc1b16ed5a804aa8576601ff2.tar.gz";
-    sha256 = "0jm6nzb83wa6ai17ly9fzpqc40wg1viib8klq8lby54agpl213w5"; }
-) {
-  src =  ./.;
-}).shellNix.packages.x86_64-linux.default


### PR DESCRIPTION
We now support all default systems for nix build & dev shell

We had to remove compatibility with `nix-shell`, as it was already a bit broken for dev setups.

The documentation and CI targets were updated.