### PR TITLE
[VsCoq2] Add declaration provider

### DIFF
--- a/language-server/dm/documentManager.ml
+++ b/language-server/dm/documentManager.ml
@@ -256,6 +256,12 @@ let get_proof st pos =
     | Some sentence ->
       ExecutionManager.get_context st.execution_state sentence.id
 
+let declaration st pos =
+  let (let*) = Option.bind in
+  let* word = Document.word_at_position st.document pos in
+  let* context = get_context st pos in
+  ExecutionManager.get_declaration context word
+
 let pr_event = function
 | ExecuteToLoc _ -> Pp.str "ExecuteToLoc"
 | ExecutionManagerEvent ev -> ExecutionManager.pr_event ev

--- a/language-server/dm/documentManager.mli
+++ b/language-server/dm/documentManager.mli
@@ -85,6 +85,8 @@ val about : state -> Position.t -> goal:(int option)  -> pattern:string -> (stri
 
 val hover : state -> Position.t -> (string,string) Result.t
 
+val declaration : state -> Position.t -> (string * Range.t option) option
+
 (*
 val check : state -> Position.t -> goal:(int option)  -> pattern:string -> (string,string) Result.t
 *)

--- a/language-server/dm/executionManager.ml
+++ b/language-server/dm/executionManager.ml
@@ -437,6 +437,20 @@ let get_context st id =
     let evar_map = Evd.from_env env in
     Some (env, evar_map)
 
+let get_declaration ((env : Environ.env), (sigma : Evd.evar_map)) requestedDeclaration =
+  let open Printer in
+  let open Loadpath in
+  let open Libnames in
+  let open Nametab in
+  let result = ref (None) in
+  let display ref kind env c =
+    let name = (Pp.string_of_ppcmds (pr_global ref)) in
+    if Option.is_empty result.contents && name = requestedDeclaration then
+      result := try Some (try_locate_absolute_library (dirpath_of_global ref)) with e -> None;
+  in
+  Search.generic_search env display;
+  Option.map (fun path -> path, None) result.contents
+
 module ProofWorkerProcess = struct
   type options = ProofWorker.options
   let parse_options = ProofWorker.parse_options

--- a/language-server/dm/executionManager.mli
+++ b/language-server/dm/executionManager.mli
@@ -9,6 +9,7 @@
 (************************************************************************)
 
 open Types
+open Lsp.LspData
 
 (** The event manager is in charge of the actual event of tasks (as
     defined by the scheduler), caching event states and invalidating
@@ -26,6 +27,8 @@ val is_executed : state -> sentence_id -> bool
 val is_remotely_executed : state -> sentence_id -> bool
 val get_proofview : state -> sentence_id -> Proof.data option
 val get_context : state -> sentence_id -> (Environ.env * Evd.evar_map) option
+val get_declaration : (Environ.env * Evd.evar_map) -> string -> (string * Range.t option) option
+
 
 (** Events for the main loop *)
 type event type events = event Sel.event list

--- a/language-server/lsp/lspData.ml
+++ b/language-server/lsp/lspData.ml
@@ -94,6 +94,7 @@ module ServerCapabilities = struct
   type t = {
     textDocumentSync : textDocumentSyncKind;
     hoverProvider : bool;
+    declarationProvider: bool;
   } [@@deriving yojson]
 
 end

--- a/language-server/lsp/lspData.mli
+++ b/language-server/lsp/lspData.mli
@@ -55,6 +55,7 @@ module ServerCapabilities : sig
   type t = {
     textDocumentSync : textDocumentSyncKind;
     hoverProvider : bool;
+    declarationProvider : bool;
   } [@@deriving yojson]
 
 end


### PR DESCRIPTION
Currently depends on the ".vo" and ".v" being in the same folder. 
A better way of searching for the source file should be created.
Closes #380 