### PR TITLE
[VSCoq2] fix: Hover now returns Null when not hovering a word.

### DIFF
--- a/language-server/dm/documentManager.ml
+++ b/language-server/dm/documentManager.ml
@@ -291,10 +291,7 @@ let search st ~id pos pattern =
 
 let hover st pos = 
   let opattern = Document.word_at_position st.document pos in
-  match opattern with 
-  | None -> Error ("No word under cursor") 
-  | Some pattern -> 
-    about st pos ~goal:None ~pattern
+  Option.map (fun pattern -> about st pos ~goal:None ~pattern) opattern
 
 module Internal = struct
 

--- a/language-server/dm/documentManager.mli
+++ b/language-server/dm/documentManager.mli
@@ -83,7 +83,10 @@ val search : state -> id:string -> Position.t -> string -> notification Sel.even
 
 val about : state -> Position.t -> goal:(int option)  -> pattern:string -> (string,string) Result.t
 
-val hover : state -> Position.t -> (string,string) Result.t
+val hover : state -> Position.t -> (string,string) Result.t option
+(** Returns an optional Result:
+    if None, the position did not have a word,
+    if Some, an Ok/Error result is returned. *)
 
 (*
 val check : state -> Position.t -> goal:(int option)  -> pattern:string -> (string,string) Result.t

--- a/language-server/vscoqtop/lspManager.ml
+++ b/language-server/vscoqtop/lspManager.ml
@@ -174,10 +174,12 @@ let textDocumentHover ~id params =
   let loc = params |> member "position" |> parse_loc in 
   let st = Hashtbl.find states uri in 
   match Dm.DocumentManager.hover st loc with
-  | Error _ -> ()
-  | Ok contents ->
+  (* Response: result: Hover | null *)
+  | None -> output_json @@ Response.(yojson_of_t { id; result = Ok (`Null) })
+  | Some (Ok contents) ->
     let result = Ok (Hover.(yojson_of_t {contents})) in
     output_json @@ Response.(yojson_of_t { id; result })
+  | _ -> ()
 
 
 let progress_hook uri () =


### PR DESCRIPTION
[The LSP documentation implies that the language server should return `contents: null` if no hover text should be showed.](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_hover)

I found that the client would pop-up a hover with the contents "Loading..." whenever the mouse rested on whitespace and the like.

With this fix, we now respond that we can't perform a hover at that point, making no hover popup appear.

@rtetley, should I assign you as reviewer/assignee?