### PR TITLE
[VsCoq1] Fix getSentenceIndexBeforeOrAt()

### DIFF
--- a/client/src/Snippets.ts
+++ b/client/src/Snippets.ts
@@ -285,7 +285,8 @@ export function setupSnippets(subscriptions: vscode.Disposable[]) {
   subscriptions.push(vscode.languages.registerCompletionItemProvider('coq', {
     provideCompletionItems: async (doc, pos, token) => {
       try {
-        const prefix = await CoqLanguageServer.getInstance().getPrefixText(doc.uri.toString(),pos,token);
+        const prefix = await (await CoqLanguageServer.getInstance().getPrefixText(doc.uri.toString(),pos,token)).trimStart();        
+
         if(prefix === "")
           return [];
         const trigger = getTriggerSnippet(prefix);

--- a/server/src/sentence-model/SentenceCollection.ts
+++ b/server/src/sentence-model/SentenceCollection.ts
@@ -244,7 +244,13 @@ export class SentenceCollection implements vscode.TextDocument {
     let prefix : string;
     if(sent < 0) {
       const offset = this.offsetAt(pos);
-      prefix = this.documentText.substring(0,offset);
+      const lastSentence = this.sentences[this.sentences.length-1];
+      if (lastSentence.isBefore(pos)) {
+        const lastEnd = this.offsetAt(lastSentence.getRange().end);
+        prefix = this.documentText.substring(lastEnd, offset);
+      } else {
+        prefix = this.documentText.substring(0,offset);
+      }
     } else if(this.sentences[sent].contains(pos)) {
       range = this.sentences[sent].getRange();
       text = this.sentences[sent].getText();

--- a/server/src/sentence-model/SentenceCollection.ts
+++ b/server/src/sentence-model/SentenceCollection.ts
@@ -141,7 +141,7 @@ export class SentenceCollection implements vscode.TextDocument {
     let sentIdx = 0;
     while(sentIdx < this.sentences.length && this.sentences[sentIdx].isBeforeOrAt(pos))
       ++sentIdx;
-    if(sentIdx >= this.sentences.length)
+    if(sentIdx == this.sentences.length && !this.sentences[sentIdx-1].contains(pos))
       return -1;
     else
       return sentIdx-1;
@@ -244,23 +244,23 @@ export class SentenceCollection implements vscode.TextDocument {
     let prefix : string;
     if(sent < 0) {
       const offset = this.offsetAt(pos);
-      prefix = parser.normalizeText(this.documentText.substring(0,offset));
+      prefix = this.documentText.substring(0,offset);
     } else if(this.sentences[sent].contains(pos)) {
       range = this.sentences[sent].getRange();
       text = this.sentences[sent].getText();
       const offset = textUtil.relativeOffsetAtAbsolutePosition(text,range.start,pos);
-      prefix = parser.normalizeText(text.substring(0,offset));
+      prefix = text.substring(0,offset);
     } else if(sent+1 < this.sentences.length) {
       const start = this.sentences[sent].getRange().end;
       const end = this.sentences[sent+1].getRange().start;
       text = this.documentText.substring(this.offsetAt(start),this.offsetAt(end));
       const offset = textUtil.relativeOffsetAtAbsolutePosition(text,start,pos);
-      prefix = parser.normalizeText(text.substring(0,offset));
+      prefix = text.substring(0,offset);
     } else {
       const start = this.sentences[sent].getRange().end;
       text = this.documentText.substring(this.offsetAt(start));
       const offset = textUtil.relativeOffsetAtAbsolutePosition(text,start,pos);
-      prefix = parser.normalizeText(text.substring(0,offset));
+      prefix = text.substring(0,offset);
     }
     if(normalize)
       return parser.normalizeText(prefix);


### PR DESCRIPTION
The function `getSentenceIndexBeforeOrAt()` returns `-1` when given a position that is inside the last sentence in the document rather than returning the index of the last sentence.
This results in completion suggestions failing at random.
