### PR TITLE
[VsCoq2] Change workers to be int

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -132,7 +132,7 @@
           "vscoq.proof.workers": {
             "scope": "window",
             "type": "number",
-            "default": "1",
+            "default": 1,
             "description": "Amount of workers assigned to proofs in delegation mode"
           }
         }


### PR DESCRIPTION
Previously it was saved as string which made Yosjon fail with this error message:
```
Uncaught exception Yojson.Safe.Util.Type_error("Expected int, got string", _).
Raised at Yojson.Safe.Util.typerr in file "util.ml", line 15, characters 20-60
Called from Dune__exe__LspManager.vscoqConfiguration in file "vscoqtop/lspManager.ml", line 340, characters 26-62
Called from Dune__exe__LspManager.dispatch_method in file "vscoqtop/lspManager.ml", line 364, characters 29-54
Called from Dune__exe__Vscoqtop.loop.loop in file "vscoqtop/vscoqtop.ml", line 30, characters 21-50
Called from Dune__exe__Vscoqtop.loop in file "vscoqtop/vscoqtop.ml", line 35, characters 6-15
```