### PR TITLE
[VsCoq2] Move try statement as parsing entry might fail

### DIFF
--- a/language-server/dm/documentManager.ml
+++ b/language-server/dm/documentManager.ml
@@ -281,9 +281,9 @@ let about st pos ~goal ~pattern =
   match get_context st pos with 
   | None -> Error ("No context found") (*TODO execute *)
   | Some (sigma, env) ->
-    let ref_or_by_not = parse_entry st pos (Pcoq.Prim.smart_global) pattern in
-    let udecl = None (* TODO? *) in
     try
+      let ref_or_by_not = parse_entry st pos (Pcoq.Prim.smart_global) pattern in
+      let udecl = None (* TODO? *) in
       Ok (Pp.string_of_ppcmds @@ Prettyp.print_about env sigma ref_or_by_not udecl)
     with e ->
       let e, info = Exninfo.capture e in


### PR DESCRIPTION
Hovering some words, such as "forall" made the server crash. If we move the try statement it should crash less