### PR TITLE
[VsCoq 1] Fix #443

### DIFF
--- a/client/coq.configuration.json
+++ b/client/coq.configuration.json
@@ -21,30 +21,6 @@
     [
       "(",
       ")"
-    ],
-    [
-      "Proof.",
-      "Qed."
-    ],
-    [
-      "Proof.",
-      "Admitted."
-    ],
-    [
-      "Proof.",
-      "Abort."
-    ],
-    [
-      "match",
-      "end"
-    ],
-    [
-      "repeat match",
-      "end"
-    ],
-    [
-      "repeat lazymatch",
-      "end"
     ]
   ],
   "colorizedBracketPairs": [


### PR DESCRIPTION
Remove matching pairs of words from languages bracket configuration. VS Code doesn't seem to like words there (matching is case insensitive, as far as I can tell the `Proof.` matches never matched either...).