### PR TITLE
[vscoq2] new logging (not based on Coq's feedback)

### DIFF
--- a/language-server/dm/delegationManager.ml
+++ b/language-server/dm/delegationManager.ml
@@ -27,9 +27,10 @@ type execution_status =
   | Success of Vernacstate.t option
   | Error of string Loc.located * Vernacstate.t option (* State to use for resiliency *)
 
-(* **alert** calling log from write value causes a loop, since log (from the woker)
-    writes the value to a channel *)
 let write_value { write_to; _ } x =
+(** alert: calling log from write value causes a loop, since log (from the worker)
+    writes the value to a channel. Hence we mask [log] *)
+let log _ = () in
   let data = Marshal.to_bytes x [] in
   let datalength = Bytes.length data in
   let writeno = Unix.write write_to data 0 datalength in

--- a/language-server/dm/delegationManager.ml
+++ b/language-server/dm/delegationManager.ml
@@ -12,10 +12,9 @@
 (*                                                                        *)
 (**************************************************************************)
 
-let debug_delegation_manager = CDebug.create ~name:"vscoq.delegationManager" ()
+open Types
 
-let log msg = debug_delegation_manager Pp.(fun () ->
-  str @@ Format.asprintf "[%d] %s" (Unix.getpid ()) msg)
+let Log log = Log.mk_log "delegationManager"
 
 type sentence_id = Stateid.t
 
@@ -28,13 +27,13 @@ type execution_status =
   | Success of Vernacstate.t option
   | Error of string Loc.located * Vernacstate.t option (* State to use for resiliency *)
 
+(* **alert** calling log from write value causes a loop, since log (from the woker)
+    writes the value to a channel *)
 let write_value { write_to; _ } x =
   let data = Marshal.to_bytes x [] in
   let datalength = Bytes.length data in
-  log @@ Printf.sprintf "marshaling %d bytes" datalength;
   let writeno = Unix.write write_to data 0 datalength in
   assert(writeno = datalength);
-  log @@ Printf.sprintf "marshaling done";
   flush_all ()
 
 let abort_on_unix_error f x =
@@ -70,11 +69,7 @@ let master_feedback_queue = Queue.create ()
 let install_feedback send =
   Feedback.add_feeder (fun fb ->
     match fb.Feedback.contents with
-    | Feedback.Message(Feedback.Debug,loc,m) ->
-        (* This is crucial to avoid a busy loop: since a feedback triggers and
-           event, if SEL debug is on we loop, since processing the debug print
-           is also a feedback *)
-        Printf.eprintf "%s\n" @@ Pp.string_of_ppcmds m
+    | Feedback.Message(Feedback.Debug,_,_) -> ()
     | Feedback.Message(lvl,loc,m) -> send (fb.Feedback.span_id,(lvl,loc,m))
     | Feedback.AddedAxiom
     | _ -> () (* STM feedbacks are handled differently *))
@@ -126,10 +121,12 @@ end
 module MakeWorker (Job : Job) = struct
 type job_t = Job.t
 type job_update_request = Job.update_request
-let debug_worker = CDebug.create ~name:("vscoq.Worker." ^ Job.name) ()
 
-let log_worker msg = debug_worker Pp.(fun () ->
-  str @@ Format.asprintf "    [%d] %s" (Unix.getpid ()) msg)
+type worker_message =
+  | Job_update of Job.update_request
+  | DebugMessage of Log.event
+
+let Log log_worker = Log.mk_log ("worker." ^ Job.name)
 
 let install_feedback_worker link =
   Feedback.del_feeder master_feeder;
@@ -139,7 +136,7 @@ let install_feedback_worker link =
    evants, then one ending event. *)
 type delegation =
  | WorkerStart : job_id * 'job * ('job -> send_back:(Job.update_request -> unit) -> unit) * string -> delegation
- | WorkerProgress of { link : link; update_request : Job.update_request }
+ | WorkerProgress of { link : link; update_request : worker_message } (* TODO: use a recurring event (+cancel) and remove link *)
  | WorkerEnd of (int * Unix.process_status)
  | WorkerIOError of exn
 let pr_event = function
@@ -147,6 +144,10 @@ let pr_event = function
   | WorkerIOError _ -> Pp.str "WorkerIOError"
   | WorkerProgress _ -> Pp.str "WorkerProgress"
   | WorkerStart _ -> Pp.str "WorkerStart"
+
+let install_debug_worker link =
+  Log.worker_initialization_done
+    ~fwd_event:(fun e -> write_value link (DebugMessage e))
 
 type events = delegation Sel.event list
 
@@ -207,14 +208,17 @@ let fork_worker : job_id -> (role * events, string * events) result = fun (_, jo
     if pid = 0 then begin
         (* Children process *)
         dup2 null stdin;
+        dup2 null stdout;
         close chan;
-        log_worker @@ "borning...";
+        Log.worker_initialization_begins ();
         let chan = socket PF_INET SOCK_STREAM 0 in
         connect chan address;
         let read_from = chan in
         let write_to = chan in
         let link = { write_to; read_from } in
         install_feedback_worker link;
+        install_debug_worker link;
+        log_worker @@ "borning...";
         Ok (Worker link, [])
     end else
       (* Parent process *)
@@ -262,6 +266,7 @@ let create_process_worker procname (_,job_id) job =
         let write_to = worker in
         let link = { write_to; read_from } in
         install_feedback_worker link;
+        install_debug_worker link;
         log @@ "sending job";
         write_value link job;
         flush_all ();
@@ -288,9 +293,12 @@ let handle_event = function
       if Queue.length pool < !current_pool_size then
         Queue.push () pool;
       (None,[])
-  | WorkerProgress { link; update_request } ->
+  | WorkerProgress { link; update_request = DebugMessage d } ->
+      Log.handle_event d;
+      (None, [worker_progress link])
+  | WorkerProgress { link; update_request = Job_update u } ->
       log "worker progress";
-      (Some update_request, [worker_progress link])
+      (Some u, [worker_progress link])
   | WorkerStart (job_id,job,action,procname) ->
     log "worker starts";
     if Sys.os_type = "Unix" then
@@ -299,7 +307,7 @@ let handle_event = function
         log "worker spawned (fork)";
         (None, events)
       | Ok(Worker link, _) ->
-        action job ~send_back:(abort_on_unix_error write_value link);
+        action job ~send_back:(fun j -> abort_on_unix_error write_value link (Job_update j));
         exit 0
       | Error(msg, cleanup_events) ->
         log @@ "worker did not spawn: " ^ msg;

--- a/language-server/dm/delegationManager.ml
+++ b/language-server/dm/delegationManager.ml
@@ -30,7 +30,7 @@ type execution_status =
 let write_value { write_to; _ } x =
 (** alert: calling log from write value causes a loop, since log (from the worker)
     writes the value to a channel. Hence we mask [log] *)
-let log _ = () in
+  let log _ = () in
   let data = Marshal.to_bytes x [] in
   let datalength = Bytes.length data in
   let writeno = Unix.write write_to data 0 datalength in

--- a/language-server/dm/document.ml
+++ b/language-server/dm/document.ml
@@ -16,10 +16,7 @@ open Gramlib
 open Types
 open Lsp.LspData
 
-let debug_document = CDebug.create ~name:"vscoq.document" ()
-
-let log msg = debug_document Pp.(fun () ->
-  str @@ Format.asprintf "         [%d] %s" (Unix.getpid ()) msg)
+let Log log = Log.mk_log "document"
 
 type text_edit = Range.t * string
 

--- a/language-server/dm/documentManager.ml
+++ b/language-server/dm/documentManager.ml
@@ -12,13 +12,12 @@
 (*                                                                        *)
 (**************************************************************************)
 
+open Types
 open Lsp.LspData
-let debug_dm = CDebug.create ~name:"vscoq.documentManager" ()
 
-let log msg = debug_dm Pp.(fun () ->
-  str @@ Format.asprintf "  [%d, %f] %s" (Unix.getpid ()) (Unix.gettimeofday ()) msg)
+let Log log = Log.mk_log "documentManager"
 
-  type proof_data = (Proof.data * Position.t) option
+type proof_data = (Proof.data * Position.t) option
 
 type state = {
   uri : string;

--- a/language-server/dm/dune
+++ b/language-server/dm/dune
@@ -1,7 +1,7 @@
 (library
  (name dm)
  (public_name vscoq-language-server.dm)
- (modules delegationManager parTactic documentManager document executionManager scheduler types searchQuery completionItems completionSuggester priorityManager)
+ (modules delegationManager parTactic documentManager document executionManager scheduler types searchQuery completionItems completionSuggester priorityManager Log)
  (flags -rectypes)
  (libraries coq-core.sysinit coq-core.vernac coq-core.parsing sel lsp))
 

--- a/language-server/dm/executionManager.ml
+++ b/language-server/dm/executionManager.ml
@@ -15,10 +15,7 @@
 open Scheduler
 open Types
 
-let debug_em = CDebug.create ~name:"vscoq.executionManager" ()
-
-let log msg = debug_em Pp.(fun () ->
-  str @@ Format.asprintf " [%d, %f] %s" (Unix.getpid ()) (Unix.gettimeofday ()) msg)
+let Log log = Log.mk_log "executionManager"
 
 type execution_status = DelegationManager.execution_status =
   | Success of Vernacstate.t option
@@ -260,6 +257,7 @@ let worker_execute ~doc_id last_step_id ~send_back (vs,events) = function
     (vs, events)
   | PExec (id,ast,synterp) ->
     let vs = { vs with Vernacstate.synterp } in
+    log ("worker interp " ^ Stateid.to_string id);
     let vs, v, ev = interp_ast ~doc_id ~state_id:id ~st:vs ast in
     let v = if Stateid.equal id last_step_id then ensure_proof_over v else v in
     send_back (ProofJob.UpdateExecStatus (id,purge_state v));

--- a/language-server/dm/log.ml
+++ b/language-server/dm/log.ml
@@ -1,0 +1,98 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 VSCoq                                  *)
+(*                                                                        *)
+(*                   Copyright INRIA and contributors                     *)
+(*       (see version control and README file for authors & dates)        *)
+(*                                                                        *)
+(**************************************************************************)
+(*                                                                        *)
+(*   This file is distributed under the terms of the MIT License.         *)
+(*   See LICENSE file.                                                    *)
+(*                                                                        *)
+(**************************************************************************)
+
+open Types
+
+let lsp_initialization_done = ref false
+let initialization_feedback_queue = Queue.create ()
+let feedback_queue = Queue.create ()
+
+let init_log =
+  try Some (
+    let oc = open_out @@ Filename.temp_file "vscoq_init_log." ".txt" in
+    output_string oc "command line:\n";
+    output_string oc (String.concat " " (Sys.argv |> Array.to_list));
+    output_string oc "\nstatic initialization:\n";
+    oc)
+  with _ -> assert (0=1); None
+
+let write_to_init_log str =
+  Option.iter (fun oc ->
+      output_string oc str;
+      output_char oc '\n';
+      flush oc)
+    init_log
+
+let rec is_enabled name = function
+  | [] -> false
+  | "-vscoq-d" :: "all" :: _ -> true
+  | "-vscoq-d" :: v :: rest ->
+    List.mem name (String.split_on_char ',' v) || is_enabled name rest
+  | _ :: rest -> is_enabled name rest
+
+let logs = ref []
+
+let mk_log name =
+  logs := name :: !logs;
+  let flag = is_enabled name (Array.to_list Sys.argv) in
+  let flag_init = is_enabled "init" (Array.to_list Sys.argv) in
+  write_to_init_log ("log " ^ name ^ " is " ^ if flag then "on" else "off");
+  Log (fun msg ->
+    if flag || (flag_init && not !lsp_initialization_done) then begin
+      let txt = Format.asprintf "[%-20s, %d, %f] %s" name (Unix.getpid ()) (Unix.gettimeofday ()) msg in
+      if not !lsp_initialization_done then begin
+        write_to_init_log txt;
+        Queue.push txt initialization_feedback_queue
+      end else
+        Feedback.msg_debug Pp.(str txt)
+    end else
+      ())
+
+let logs () = List.sort String.compare !logs
+
+type event = string
+type events = event Sel.event list
+
+let handle_event s = Printf.eprintf "%s\n" s
+
+let install_debug_feedback f =
+  Feedback.add_feeder (fun fb ->
+    match fb.Feedback.contents with
+    | Feedback.Message(Feedback.Debug,None,m) -> f Pp.(string_of_ppcmds m)
+    | _ -> ())
+
+let main_debug_feeder = install_debug_feedback (fun txt -> Queue.push txt feedback_queue)
+   
+let (debug, cancel_debug_event) : event Sel.event * Sel.cancellation_handle =
+  Sel.on_queue feedback_queue (fun x -> x) |>
+  fun (e, cancellation) ->
+    (e |> Sel.name "debug"
+       |> Sel.make_recurring
+       |> Sel.set_priority PriorityManager.feedback),
+    cancellation
+
+let lsp_initialization_done () =
+  lsp_initialization_done := true;
+  Option.iter close_out_noerr init_log;
+  Queue.transfer initialization_feedback_queue feedback_queue;
+  [debug]
+
+let worker_initialization_begins () =
+  Sel.cancel cancel_debug_event;
+  Feedback.del_feeder main_debug_feeder;
+  Queue.clear feedback_queue
+
+let worker_initialization_done ~fwd_event =
+  let _ = install_debug_feedback fwd_event in
+  ()

--- a/language-server/dm/log.mli
+++ b/language-server/dm/log.mli
@@ -12,14 +12,17 @@
 (*                                                                        *)
 (**************************************************************************)
 
+open Types
+
+val mk_log : string -> (string -> unit) log
+val logs : unit -> string list
+
 type event
 type events = event Sel.event list
 
-val lsp : event Sel.event
+val lsp_initialization_done : unit -> events
+val handle_event : event -> unit
 
-val handle_event : event -> events
-val pr_event : event -> Pp.t
-
-val init : Coqargs.injection_command list -> event Sel.event list
-
-val coqtopSearchResult : id:string -> string -> string -> unit
+val worker_initialization_begins : unit -> unit
+val worker_initialization_done : fwd_event:(event -> unit) -> unit
+  

--- a/language-server/dm/parTactic.ml
+++ b/language-server/dm/parTactic.ml
@@ -12,10 +12,9 @@
 (*                                                                        *)
 (**************************************************************************)
 
-let debug_par = CDebug.create ~name:"vscoq.parTactic" ()
+open Types
 
-let log msg = debug_par Pp.(fun () ->
-  str @@ Format.asprintf "        [%d] %s" (Unix.getpid ()) msg)
+let Log log = Log.mk_log "parTactic"
 
 type sentence_id = Stateid.t
 

--- a/language-server/dm/scheduler.ml
+++ b/language-server/dm/scheduler.ml
@@ -14,10 +14,7 @@
 
 open Types
 
-let debug_scheduler = CDebug.create ~name:"vscoq.scheduler" ()
-
-let log msg = debug_scheduler Pp.(fun () ->
-  str @@ Format.asprintf "        [%d] %s" (Unix.getpid ()) msg)
+let Log log = Log.mk_log "scheduler"
 
 module SM = CMap.Make (Stateid)
 

--- a/language-server/dm/types.ml
+++ b/language-server/dm/types.ml
@@ -18,3 +18,10 @@ type sentence_id_set = Stateid.Set.t
 type ast = Synterp.vernac_entry_control
 
 type text_edit = Range.t * string
+
+type link = {
+  write_to :  Unix.file_descr;
+  read_from:  Unix.file_descr;
+}
+
+type 'a log = Log : 'a -> 'a log

--- a/language-server/vscoqtop/lspManager.ml
+++ b/language-server/vscoqtop/lspManager.ml
@@ -32,7 +32,7 @@ let states : (string, Dm.DocumentManager.state) Hashtbl.t = Hashtbl.create 39
 
 let check_mode = ref Settings.Mode.Continuous
 
-let lsp_debug = CDebug.create ~name:"vscoq.lspManager" ()
+let Dm.Types.Log log = Dm.Log.mk_log "lspManager"
 
 let conf_request_id = 3456736879
 
@@ -41,11 +41,6 @@ let server_info = ServerInfo.{
   version = "2.0.0";
 } 
 
-let log msg = lsp_debug Pp.(fun () ->
-  str @@ Format.asprintf "       [%d, %f] %s" (Unix.getpid ()) (Unix.gettimeofday ()) msg)
-
-(*let string_field name obj = Yojson.Safe.to_string (List.assoc name obj)*)
-
 type lsp_event = 
   | Request of Yojson.Safe.t option
 
@@ -53,6 +48,7 @@ type event =
  | LspManagerEvent of lsp_event
  | DocumentManagerEvent of string * Dm.DocumentManager.event
  | Notification of notification
+ | LogEvent of Dm.Log.event
 
 type events = event Sel.event list
 
@@ -323,11 +319,17 @@ let inject_dm_event uri x : event Sel.event =
 let inject_notification x : event Sel.event =
   Sel.map (fun x -> Notification(x)) x
 
+let inject_debug_event x : event Sel.event =
+  Sel.map (fun x -> LogEvent x) x
+
 let inject_dm_events (uri,l) =
   List.map (inject_dm_event uri) l
 
 let inject_notifications l =
   List.map inject_notification l
+
+let inject_debug_events l =
+  List.map inject_debug_event l
 
 let coqtopUpdateProofView ~id params =
   let open Yojson.Safe.Util in
@@ -421,10 +423,14 @@ let workspaceDidChangeConfiguration params =
   let settings = params |> member "settings" |> Settings.t_of_yojson in
   do_configuration settings
 
+
 let dispatch_method ~id method_name params : events =
+  log ("dispatching: "^method_name);
   match method_name with
   | "initialize" -> do_initialize ~id params; []
-  | "initialized" -> []
+  | "initialized" ->
+    log "---------------- initialized --------------";
+    Dm.Log.lsp_initialization_done () |> inject_debug_events
   | "shutdown" -> do_shutdown ~id params; []
   | "exit" -> do_exit ~id params
   | "workspace/didChangeConfiguration" -> workspaceDidChangeConfiguration params; []
@@ -501,14 +507,18 @@ let handle_event = function
     end
   | Notification notification ->
     output_notification notification; [inject_notification Dm.SearchQuery.query_feedback]
+  | LogEvent e ->
+    Dm.Log.handle_event e; []
 
 let pr_event = function
   | LspManagerEvent e -> pr_lsp_event e
   | DocumentManagerEvent (uri, e) ->
     Pp.str @@ Format.asprintf "%a" Dm.DocumentManager.pp_event e
   | Notification _ -> Pp.str"notif"
+  | LogEvent _ -> Pp.str"debug"
 
 let init injections =
-  init_state := Some (Vernacstate.freeze_full_state ~marshallable:false, injections)
+  init_state := Some (Vernacstate.freeze_full_state ~marshallable:false, injections);
+  [lsp]
 
 


### PR DESCRIPTION
initialization (OCaml + vscoqtop) logging is saved to a file
  /tmp/vscoq_init_log.*.txt
since one cannot log anything before vscode is initialized.

if initialization works, then the vscoqtop initialization log is also reported to the output panel in vscode.