### PR TITLE
[VSCoq2] Speed up highlighting 

### DIFF
--- a/language-server/dm/document.mli
+++ b/language-server/dm/document.mli
@@ -62,6 +62,9 @@ val sentences : document -> sentence list
 val get_sentence : document -> sentence_id -> sentence option
 val sentences_before : document -> int -> sentence list
 
+val surrounding_sentences : document -> sentence_id -> sentence option * sentence option
+(** [surrounding_sentences doc id] returns the sentence before and after [id] *)
+
 val find_sentence : document -> int -> sentence option
 (** [find_sentence doc loc] finds the sentence containing the loc *)
 

--- a/language-server/dm/documentManager.ml
+++ b/language-server/dm/documentManager.ml
@@ -52,7 +52,6 @@ type events = event Sel.event list
 type exec_overview = {
   parsed : Range.t list;
   checked : Range.t list;
-  checked_by_delegate : Range.t list;
   legacy_highlight : Range.t list;
 }
 
@@ -63,17 +62,14 @@ let executed_ranges doc execution_state loc =
   let ids_before_loc = List.map (fun s -> s.Document.id) @@ Document.sentences_before doc loc in
   let ids = List.map (fun s -> s.Document.id) @@ Document.sentences doc in
   let executed_ids = List.filter (ExecutionManager.is_executed execution_state) ids in
-  let remotely_executed_ids = List.filter (ExecutionManager.is_remotely_executed execution_state) ids in
-  let parsed_ids = List.filter (fun x -> not (List.mem x executed_ids || List.mem x remotely_executed_ids)) ids in
+  let parsed_ids = List.filter (fun x -> not (List.mem x executed_ids || ExecutionManager.is_remotely_executed execution_state x)) ids in
   let legacy_ids = List.filter (fun x -> ExecutionManager.is_executed execution_state x || ExecutionManager.is_remotely_executed execution_state x) ids_before_loc in
   log @@ Printf.sprintf "highlight: legacy: %s" (String.concat " " (List.map Stateid.to_string legacy_ids));
   log @@ Printf.sprintf "highlight: parsed: %s" (String.concat " " (List.map Stateid.to_string parsed_ids));
   log @@ Printf.sprintf "highlight: parsed + checked: %s" (String.concat " " (List.map Stateid.to_string executed_ids));
-  log @@ Printf.sprintf "highlight: parsed + checked_by_delegate: %s" (String.concat " " (List.map Stateid.to_string remotely_executed_ids));
   { 
     parsed = ranges_of parsed_ids;
     checked = ranges_of executed_ids;
-    checked_by_delegate = ranges_of remotely_executed_ids;
     legacy_highlight = ranges_of legacy_ids; 
   }
 

--- a/language-server/dm/documentManager.ml
+++ b/language-server/dm/documentManager.ml
@@ -186,7 +186,7 @@ let executed_ranges (st : state) =
   let checked = List.map (fun x -> { Range.start = x.start; Range.end_ = x.end_ }) st.checked in
   { 
     parsed = [];
-    checked = [];
+    checked = checked;
     legacy_highlight = checked; 
   }
 

--- a/language-server/dm/documentManager.mli
+++ b/language-server/dm/documentManager.mli
@@ -65,7 +65,6 @@ val reset : state -> state
 type exec_overview = {
   parsed : Range.t list;
   checked : Range.t list;
-  checked_by_delegate : Range.t list;
   legacy_highlight : Range.t list;
 }
 

--- a/language-server/dm/executionManager.ml
+++ b/language-server/dm/executionManager.ml
@@ -292,7 +292,7 @@ let execute ~doc_id st (vs, events, interrupted) task =
           let vs = { vs with Vernacstate.synterp } in
           let vs, v, ev = interp_ast ~doc_id ~state_id:id ~st:vs ast in
           let st = update st id v in
-          (st, vs, events @ ev, false, Some id)
+          (st, vs, events @ ev, false, Some [id])
       | PQuery (id,ast,synterp) ->
           let vs = { vs with Vernacstate.synterp } in
           let _, v, ev = interp_ast ~doc_id ~state_id:id ~st:vs ast in
@@ -335,7 +335,7 @@ let execute ~doc_id st (vs, events, interrupted) task =
                 ProofWorker.worker_available ~jobs
                   ~fork_action:worker_main in
               Queue.push (job_id, cancellation, job) jobs;
-              (st, last_vs,events @ [inject_proof_event e], false, Some (id_of_prepared_task task))
+              (st, last_vs,events @ [inject_proof_event e], false, Some (List.map id_of_prepared_task tasks))
             end
           | _ ->
             (* If executing the proof opener failed, we skip the proof *)

--- a/language-server/dm/executionManager.mli
+++ b/language-server/dm/executionManager.mli
@@ -55,7 +55,7 @@ val handle_event : event -> state -> (state option * events)
     one task at a time to ease checking for interruption *)
 type prepared_task
 val build_tasks_for : Document.document -> state -> sentence_id -> Vernacstate.t * prepared_task list
-val execute : doc_id:Feedback.doc_id -> state -> Vernacstate.t * events * bool -> prepared_task -> (state * Vernacstate.t * events * bool)
+val execute : doc_id:Feedback.doc_id -> state -> Vernacstate.t * events * bool -> prepared_task -> (state * Vernacstate.t * events * bool * sentence_id option)
 
 (** Coq toplevels for delegation without fork *)
 module ProofWorkerProcess : sig

--- a/language-server/dm/executionManager.mli
+++ b/language-server/dm/executionManager.mli
@@ -55,7 +55,7 @@ val handle_event : event -> state -> (state option * events)
     one task at a time to ease checking for interruption *)
 type prepared_task
 val build_tasks_for : Document.document -> state -> sentence_id -> Vernacstate.t * prepared_task list
-val execute : doc_id:Feedback.doc_id -> state -> Vernacstate.t * events * bool -> prepared_task -> (state * Vernacstate.t * events * bool * sentence_id option)
+val execute : doc_id:Feedback.doc_id -> state -> Vernacstate.t * events * bool -> prepared_task -> (state * Vernacstate.t * events * bool * sentence_id list option)
 
 (** Coq toplevels for delegation without fork *)
 module ProofWorkerProcess : sig

--- a/language-server/tests/dm_tests.ml
+++ b/language-server/tests/dm_tests.ml
@@ -72,15 +72,18 @@ let%test_unit "parse.extensions" =
   check_no_diag st
 
 let%test_unit "exec.init" =
-  let st, init_events = init "Definition x := true. Definition y := false." in
+  let prog = "Definition x := true. Definition y := false." in
+  let st, init_events = init prog in
   let st = DocumentManager.validate_document st in
   let st, events = DocumentManager.interpret_to_end st in
   let todo = Sel.(enqueue empty init_events) in
   let todo = Sel.(enqueue todo events) in
   let st = handle_events todo st in
   let ranges = (DocumentManager.executed_ranges st).checked in
-  let positions = Stdlib.List.map (fun s -> s.LspData.Range.start.character) ranges in
-  [%test_eq: int list] positions [ 0; 22 ]
+  let start_positions = Stdlib.List.map (fun s -> s.LspData.Range.start.character) ranges in
+  let end_positions = Stdlib.List.map (fun s -> s.LspData.Range.end_.character) ranges in
+  [%test_eq: int list] start_positions [ 0 ];
+  [%test_eq: int list] end_positions [ String.length prog ]
   (*check_no_diag st*)
 
 (*

--- a/language-server/vscoqtop/lspManager.ml
+++ b/language-server/vscoqtop/lspManager.ml
@@ -148,11 +148,10 @@ let publish_diagnostics uri doc =
   output_json @@ Notification.(yojson_of_t { method_; params })
 
 let send_highlights uri doc =
-  let { Dm.DocumentManager.parsed; checked; checked_by_delegate; legacy_highlight } =
+  let { Dm.DocumentManager.parsed; checked; legacy_highlight } =
     Dm.DocumentManager.executed_ranges doc in
   let parsed = List.map Range.yojson_of_t parsed in
   let checked = List.map Range.yojson_of_t checked in
-  (* let checked_by_delegate = List.map mk_range checked_by_delegate in *)
   let legacy_highlight = List.map Range.yojson_of_t legacy_highlight in
   let params = `Assoc [
     "uri", `String uri;


### PR DESCRIPTION
Fixes #454

This is faster due to not recreating the checked range each time highlights are sent.
By returning the ids from ExecutionManager.execute and keeping track of these it checks which have been executed.
Through I am not entirely happy with that implementation, returning an ID seems like an ugly design.
Maybe ExecutionManager and Document should each keep track of their respective parsed and checked ranges, which is then just called by DocumentManager?
What do you think @maximedenes 

Also I seem to have created a bug somewhere as the IDs from ExecutionManager.execute sometimes are not valid IDs in the document. Which is why remove_id_from_ranges and add_id_to_ranges are wrapped in a try statement.