### PR TITLE
Fix issues in protocol encoding

### DIFF
--- a/language-server/lsp/extProtocol.ml
+++ b/language-server/lsp/extProtocol.ml
@@ -66,7 +66,7 @@ module Request = struct
   module InterpretToPointParams = struct
 
     type t = {
-      textDocument : TextDocumentIdentifier.t;
+      textDocument : VersionedTextDocumentIdentifier.t;
       position : Position.t;
     } [@@deriving yojson]
 
@@ -75,7 +75,7 @@ module Request = struct
   module InterpretToEndParams = struct
 
     type t = {
-      textDocument : TextDocumentIdentifier.t;
+      textDocument : VersionedTextDocumentIdentifier.t;
     } [@@deriving yojson]
 
   end
@@ -83,7 +83,7 @@ module Request = struct
   module StepBackwardParams = struct
 
     type t = {
-      textDocument : TextDocumentIdentifier.t;
+      textDocument : VersionedTextDocumentIdentifier.t;
     } [@@deriving yojson]
 
   end
@@ -91,7 +91,7 @@ module Request = struct
   module StepForwardParams = struct
 
     type t = {
-      textDocument : TextDocumentIdentifier.t;
+      textDocument : VersionedTextDocumentIdentifier.t;
     } [@@deriving yojson]
 
   end
@@ -107,7 +107,7 @@ module Request = struct
   module AboutParams = struct
 
     type t = {
-      textDocument : TextDocumentIdentifier.t;
+      textDocument : VersionedTextDocumentIdentifier.t;
       position : Position.t;
       pattern : string;
     } [@@deriving yojson]
@@ -117,7 +117,7 @@ module Request = struct
   module CheckParams = struct
 
     type t = {
-      textDocument : TextDocumentIdentifier.t;
+      textDocument : VersionedTextDocumentIdentifier.t;
       position : Position.t;
       pattern : string;
     } [@@deriving yojson]
@@ -127,7 +127,7 @@ module Request = struct
   module LocateParams = struct
 
     type t = {
-      textDocument : TextDocumentIdentifier.t;
+      textDocument : VersionedTextDocumentIdentifier.t;
       position : Position.t;
       pattern : string;
     } [@@deriving yojson]
@@ -137,7 +137,7 @@ module Request = struct
   module PrintParams = struct
 
     type t = {
-      textDocument : TextDocumentIdentifier.t;
+      textDocument : VersionedTextDocumentIdentifier.t;
       position : Position.t;
       pattern : string;
     } [@@deriving yojson]
@@ -147,7 +147,7 @@ module Request = struct
   module SearchParams = struct
 
     type t = {
-      textDocument : TextDocumentIdentifier.t;
+      textDocument : VersionedTextDocumentIdentifier.t;
       position : Position.t;
       pattern : string;
       id : string;
@@ -158,7 +158,7 @@ module Request = struct
   module UpdateProofViewParams = struct
 
     type t = {
-      textDocument : TextDocumentIdentifier.t;
+      textDocument : VersionedTextDocumentIdentifier.t;
       position : Position.t;
     } [@@deriving yojson]
 
@@ -190,7 +190,6 @@ module Request = struct
   | Ext : int * _ params -> t
 
   let t_of_jsonrpc (JsonRpc.Request.{ id; method_; params } as req) =
-    let open Yojson.Safe.Util in
     match method_ with
     | "vscoq/interpretToPoint" -> Ext (id, InterpretToPoint InterpretToPointParams.(t_of_yojson params))
     | "vscoq/stepBackward" -> Ext (id, StepBackward StepBackwardParams.(t_of_yojson params))

--- a/language-server/lsp/lspData.ml
+++ b/language-server/lsp/lspData.ml
@@ -279,6 +279,7 @@ module TextDocumentContentChangeEvent = struct
 
   type t = {
     range : Range.t option; [@yojson.option]
+    rangeLength : int option; [@yojson.option]
     text : string;
   } [@@deriving yojson]
   

--- a/language-server/vscoqtop/lspManager.ml
+++ b/language-server/vscoqtop/lspManager.ml
@@ -385,17 +385,22 @@ let handle_lsp_event = function
   | Receive None ->
       []
   | Receive (Some rpc) ->
-    begin match rpc with
-    | Request req ->
-        log @@ "ui request: " ^ req.method_;
-        let resp, events = Request.Client.yojson_of_result req dispatch in
-        output_json resp;
-        events
-    | Notification notif ->
-      dispatch_notification @@ Notification.Client.t_of_jsonrpc notif
-    | Response resp ->
-        log @@ "got unknown response";
-        []
+    begin try
+      begin match rpc with
+      | Request req ->
+          log @@ "ui request: " ^ req.method_;
+          let resp, events = Request.Client.yojson_of_result req dispatch in
+          output_json resp;
+          events
+      | Notification notif ->
+        dispatch_notification @@ Notification.Client.t_of_jsonrpc notif
+      | Response resp ->
+          log @@ "got unknown response";
+          []
+      end
+    with Ppx_yojson_conv_lib__Yojson_conv.Of_yojson_error(exn,json) ->
+      log @@ "error parsing json: " ^ Yojson.Safe.pretty_to_string json;
+      []
     end
   | Send jsonrpc ->
     output_json (JsonRpc.yojson_of_t jsonrpc); []


### PR DESCRIPTION
These issues were introduced in #479. It seems our end-to-end tests do not cover vscoq-specific extensions of the protocol.