### PR TITLE
Remove syntactically invalid sentences from structured document view

### DIFF
--- a/language-server/dm/document.ml
+++ b/language-server/dm/document.ml
@@ -145,12 +145,6 @@ type parsing_error = {
   msg: string Loc.located;
 }
 
-let string_of_sentence sentence =
-  Format.sprintf "[%s] %s (%i -> %i)" (Stateid.to_string sentence.id)
-  (string_of_parsed_ast sentence.ast)
-  sentence.start
-  sentence.stop
-
 let same_tokens (s1 : sentence) (s2 : pre_sentence) =
     CList.equal Tok.equal s1.ast.tokens s2.ast.tokens
 
@@ -160,8 +154,6 @@ module ParsedDoc : sig
   type t
 
   val empty : t
-
-  val to_string : t -> string
 
   val schedule : t -> Scheduler.schedule
 
@@ -219,9 +211,6 @@ end = struct
     parsing_errors_by_end = LM.empty;
     schedule = Scheduler.initial_schedule;
   }
-
-  let to_string parsed =
-    LM.fold (fun stop s acc -> acc ^ string_of_sentence s ^ "\n") parsed.sentences_by_end ""
 
   let schedule parsed = parsed.schedule
 
@@ -627,7 +616,12 @@ let word_at_position doc pos = RawDoc.word_at_position doc.raw_doc pos
 
 module Internal = struct
 
-  let to_string doc = ParsedDoc.to_string doc.parsed_doc
+  let string_of_sentence sentence =
+    Format.sprintf "[%s] %s (%i -> %i)" (Stateid.to_string sentence.id)
+    (string_of_parsed_ast sentence.ast)
+    sentence.start
+    sentence.stop
+
   let range_of_sentence_id doc id = range_of_exec_id doc id
 
 end

--- a/language-server/dm/document.mli
+++ b/language-server/dm/document.mli
@@ -30,7 +30,19 @@ val validate_document : document -> sentence_id_set * document
 (** [validate_document doc] parses the document without forcing any execution
     and returns the set of invalidated sentences *)
 
-val parse_errors : document -> (sentence_id * (Loc.t option * string)) list
+type parsed_ast = {
+  ast: ast;
+  classification: Vernacextend.vernac_classification;
+  tokens: Tok.t list
+}
+
+type parsing_error = {
+  start: int; 
+  stop: int; 
+  msg: string Loc.located;
+}
+
+val parse_errors : document -> parsing_error list
 (** [parse_errors doc] returns the list of sentences which failed to parse
     (see validate_document) together with their error message *)
 
@@ -39,10 +51,6 @@ type text_edit = Range.t * string
 val apply_text_edits : document -> text_edit list -> document
 (** [apply_text_edits doc edits] updates the text of [doc] with [edits]. The
     new text is not parsed or executed. *)
-
-type parsed_ast =
-  | ValidAst of ast * Vernacextend.vernac_classification * Tok.t list (* the list of tokens generating ast, a sort of fingerprint to compare ASTs  *)
-  | ParseError of string Loc.located
 
 type sentence = {
   start : int;

--- a/language-server/dm/document.mli
+++ b/language-server/dm/document.mli
@@ -22,6 +22,8 @@ open Lsp.LspData
     sentences *)
 type document
 
+val raw_document : document -> RawDocument.t
+
 val create_document : string -> document
 (** [create_document text] creates a fresh document with content defined by
     [text]. *)
@@ -31,7 +33,7 @@ val validate_document : document -> sentence_id_set * document
     and returns the set of invalidated sentences *)
 
 type parsed_ast = {
-  ast: ast;
+  ast: Synterp.vernac_control_entry;
   classification: Vernacextend.vernac_classification;
   tokens: Tok.t list
 }
@@ -46,11 +48,10 @@ val parse_errors : document -> parsing_error list
 (** [parse_errors doc] returns the list of sentences which failed to parse
     (see validate_document) together with their error message *)
 
-type text_edit = Range.t * string
-
-val apply_text_edits : document -> text_edit list -> document
-(** [apply_text_edits doc edits] updates the text of [doc] with [edits]. The
-    new text is not parsed or executed. *)
+val apply_text_edits : document -> text_edit list -> document * int
+(** [apply_text_edits doc edits] updates the text of [doc] with [edits]. The new
+    text is not parsed or executed. The returned int is the start loc of the topmost
+    edit. *)
 
 type sentence = {
   start : int;
@@ -69,39 +70,23 @@ val get_sentence : document -> sentence_id -> sentence option
 val sentences_before : document -> int -> sentence list
 
 val find_sentence : document -> int -> sentence option
-(** [find_sentence doc loc] finds the sentence containing the loc *)
+(** [find_sentence pos loc] finds the sentence containing the loc *)
 
 val find_sentence_before : document -> int -> sentence option
-(** [find_sentence_before doc loc] finds the last sentence before the loc *)
+(** [find_sentence_before pos loc] finds the last sentence before the loc *)
 
 val find_sentence_after : document -> int -> sentence option
-(** [find_sentence_after doc loc] finds the first sentence after the loc *)
+(** [find_sentence_after pos loc] finds the first sentence after the loc *)
 
 val get_last_sentence : document  -> sentence option
 (** [get_last_sentence doc] returns the last parsed sentence *)
 
-val parsed_loc : document -> int
-(** the last loc of the document which was parsed *)
-
-val end_loc : document -> int
-(** the last loc of the document *)
-
 val schedule : document -> Scheduler.schedule
 
-val text : document -> string
-(** the whole text *)
-
-(* Fishy APIs *)
-val range_of_exec_id : document -> Stateid.t -> Range.t
-val range_of_coq_loc : document -> Loc.t -> Range.t
-
-val position_of_loc : document -> int -> Position.t
-val position_to_loc : document -> Position.t -> int
-val word_at_position: document -> Position.t -> string option
+val range_of_id : document -> Stateid.t -> Range.t
 
 module Internal : sig
 
   val string_of_sentence : sentence -> string
-  val range_of_sentence_id : document -> sentence_id -> Range.t
 
 end

--- a/language-server/dm/document.mli
+++ b/language-server/dm/document.mli
@@ -101,7 +101,7 @@ val word_at_position: document -> Position.t -> string option
 
 module Internal : sig
 
-  val to_string : document -> string
+  val string_of_sentence : sentence -> string
   val range_of_sentence_id : document -> sentence_id -> Range.t
 
 end

--- a/language-server/dm/documentManager.ml
+++ b/language-server/dm/documentManager.ml
@@ -128,21 +128,7 @@ let reset { uri; opts; init_vs; document; execution_state } =
   let execution_state, feedback = ExecutionManager.init (Vernacstate.freeze_full_state ~marshallable:false) in
   { uri; opts; init_vs; document; execution_state; observe_id = None }, [inject_em_event feedback]
 
-let validate_document state =
-    let invalid_ids, document = Document.validate_document state.document in
-    let execution_state =
-      List.fold_left (fun st id ->
-        ExecutionManager.invalidate (Document.schedule state.document) id st
-        ) state.execution_state (Stateid.Set.elements invalid_ids) in
-    { state with document; execution_state }
-
 let interpret_to_loc state loc : (state * event Sel.event list) =
-    let invalid_ids, document = Document.validate_document state.document in
-    let execution_state =
-      List.fold_left (fun st id ->
-        ExecutionManager.invalidate (Document.schedule state.document) id st
-        ) state.execution_state (Stateid.Set.elements invalid_ids) in
-    let state = { state with document; execution_state } in
     (* We jump to the sentence before the position, otherwise jumping to the
     whitespace at the beginning of a sentence will observe the state after
     executing the sentence, which is unnatural. *)
@@ -157,12 +143,6 @@ let interpret_to_loc state loc : (state * event Sel.event list) =
         (state, [Sel.now (Execute {id; vst_for_next_todo; todo; started = Unix.gettimeofday () })])
 
 let interpret_to state id : (state * event Sel.event list) =
-  let invalid_ids, document = Document.validate_document state.document in
-  let execution_state =
-    List.fold_left (fun st id ->
-      ExecutionManager.invalidate (Document.schedule state.document) id st
-      ) state.execution_state (Stateid.Set.elements invalid_ids) in
-  let state = { state with document; execution_state } in
   match Document.get_sentence state.document id with
   | None -> (state, []) (* TODO error? *)
   | Some { id; stop; start } ->

--- a/language-server/dm/documentManager.ml
+++ b/language-server/dm/documentManager.ml
@@ -103,7 +103,8 @@ let diagnostics st =
     make_diagnostic st.document id oloc msg lvl
   in
   let mk_error_diag (id,(oloc,msg)) = mk_diag (id,(Feedback.Error,oloc,msg)) in
-  List.map mk_error_diag parse_errors @
+  let mk_parsing_error_diag Document.{ msg = (oloc,msg) } = mk_diag (Stateid.dummy (* FIXME *),(Feedback.Error,oloc,msg)) in
+  List.map mk_parsing_error_diag parse_errors @
     List.map mk_error_diag exec_errors @
     List.map mk_diag feedback
 

--- a/language-server/dm/documentManager.ml
+++ b/language-server/dm/documentManager.ml
@@ -335,4 +335,16 @@ module Internal = struct
   let execution_state st =
     st.execution_state
 
+  let string_of_state st =
+    let sentences = Document.sentences_sorted_by_loc st.document in
+    let string_of_state id =
+      if ExecutionManager.is_executed st.execution_state id then "(executed)"
+      else if ExecutionManager.is_remotely_executed st.execution_state id then "(executed in worker)"
+      else "(not executed)"
+    in
+    let string_of_sentence sentence =
+      Document.Internal.string_of_sentence sentence ^ " " ^ string_of_state sentence.id
+    in
+    String.concat "\n" @@ List.map string_of_sentence sentences
+
 end

--- a/language-server/dm/documentManager.ml
+++ b/language-server/dm/documentManager.ml
@@ -59,7 +59,7 @@ type exec_overview = {
 let executed_ranges doc execution_state loc =
   let ranges_of l =
     List.sort (fun { Range.start = s1 } { Range.start = s2 } -> compare s1 s2) @@
-    List.map (Document.range_of_exec_id doc) l in
+    List.map (Document.range_of_id doc) l in
   let ids_before_loc = List.map (fun s -> s.Document.id) @@ Document.sentences_before doc loc in
   let ids = List.map (fun s -> s.Document.id) @@ Document.sentences doc in
   let executed_ids = List.filter (ExecutionManager.is_executed execution_state) ids in
@@ -79,15 +79,17 @@ let executed_ranges doc execution_state loc =
 
 let executed_ranges st =
   match Option.bind st.observe_id (Document.get_sentence st.document) with
-  | None -> executed_ranges st.document st.execution_state (Document.end_loc st.document)
+  | None ->
+    let end_loc = RawDocument.end_loc @@ Document.raw_document st.document in
+    executed_ranges st.document st.execution_state end_loc
   | Some { stop } -> executed_ranges st.document st.execution_state stop
 
 let make_diagnostic doc id oloc message severity =
   let range =
     match oloc with
-    | None -> Document.range_of_exec_id doc id
+    | None -> Document.range_of_id doc id
     | Some loc ->
-      Document.range_of_coq_loc doc loc
+      RawDocument.range_of_loc (Document.raw_document doc) loc
   in
   Diagnostic.{ range; message; severity }
 
@@ -117,13 +119,22 @@ let init init_vs ~opts uri ~text =
   { uri; opts; init_vs; document; execution_state; observe_id = None }, [inject_em_event feedback]
 
 let reset { uri; opts; init_vs; document; execution_state } =
-  let document = Document.create_document (Document.text document) in
+  let text = RawDocument.text @@ Document.raw_document document in
+  let document = Document.create_document text in
   Vernacstate.unfreeze_full_state init_vs;
   let top = Coqargs.(dirpath_of_top (TopPhysical (Uri.path uri))) in
   Coqinit.start_library ~top opts;
   ExecutionManager.destroy execution_state;
   let execution_state, feedback = ExecutionManager.init (Vernacstate.freeze_full_state ~marshallable:false) in
   { uri; opts; init_vs; document; execution_state; observe_id = None }, [inject_em_event feedback]
+
+let validate_document state =
+    let invalid_ids, document = Document.validate_document state.document in
+    let execution_state =
+      List.fold_left (fun st id ->
+        ExecutionManager.invalidate (Document.schedule state.document) id st
+        ) state.execution_state (Stateid.Set.elements invalid_ids) in
+    { state with document; execution_state }
 
 let interpret_to_loc state loc : (state * event Sel.event list) =
     let invalid_ids, document = Document.validate_document state.document in
@@ -152,9 +163,6 @@ let interpret_to state id : (state * event Sel.event list) =
       ExecutionManager.invalidate (Document.schedule state.document) id st
       ) state.execution_state (Stateid.Set.elements invalid_ids) in
   let state = { state with document; execution_state } in
-  (* We jump to the sentence before the position, otherwise jumping to the
-  whitespace at the beginning of a sentence will observe the state after
-  executing the sentence, which is unnatural. *)
   match Document.get_sentence state.document id with
   | None -> (state, []) (* TODO error? *)
   | Some { id; stop; start } ->
@@ -166,7 +174,7 @@ let interpret_to state id : (state * event Sel.event list) =
       (state, [Sel.now (Execute {id; vst_for_next_todo; todo; started = Unix.gettimeofday () })])
 
 let interpret_to_position st pos =
-  let loc = Document.position_to_loc st.document pos in
+  let loc = RawDocument.loc_of_position (Document.raw_document st.document) pos in
   match Document.find_sentence_before st.document loc with
   | None -> (st, []) (* document is empty *)
   | Some { id } -> interpret_to st id
@@ -198,9 +206,9 @@ let interpret_to_next st =
       | Some {id } -> interpret_to st id
 
 let interpret_to_end st =
-  match Document.get_last_sentence st.document with 
+  match Document.get_last_sentence st.document with (* FIXME last sentence should be computed after document validation *)
   | None -> (st, [])
-  | Some {id} -> interpret_to st id
+  | Some {id} -> log ("interpret_to_end id = " ^ Stateid.to_string id); interpret_to st id
 
 let retract state loc =
   match Option.bind state.observe_id (Document.get_sentence state.document) with
@@ -212,9 +220,9 @@ let retract state loc =
     else state
 
 let apply_text_edits state edits =
-  let document = Document.apply_text_edits state.document edits in
+  let document, loc = Document.apply_text_edits state.document edits in
   let state = { state with document } in
-  retract state (Document.parsed_loc document) 
+  retract state loc
 
 let validate_document state =
   let invalid_ids, document = Document.validate_document state.document in
@@ -244,7 +252,7 @@ let handle_event ev st =
 
 let get_proof st pos =
   let id_of_pos pos =
-    let loc = Document.position_to_loc st.document pos in
+    let loc = RawDocument.loc_of_position (Document.raw_document st.document) pos in
     match Document.find_sentence_before st.document loc with
     | None -> None
     | Some { id } -> Some id
@@ -253,7 +261,7 @@ let get_proof st pos =
   Option.bind oid (ExecutionManager.get_proofview st.execution_state)
 
 let get_context st pos =
-  let loc = Document.position_to_loc st.document pos in
+  let loc = RawDocument.loc_of_position (Document.raw_document st.document) pos in
   match Document.find_sentence_before st.document loc with
   | None -> None
   | Some sentence ->
@@ -267,19 +275,19 @@ let get_lemmas st pos =
 
 let parse_entry st pos entry pattern =
   let pa = Pcoq.Parsable.make (Gramlib.Stream.of_string pattern) in
-  let loc = Document.position_to_loc st.document pos in
-  let st = match Document.find_sentence_before st.document loc with
+  let st = match Document.find_sentence_before st.document pos with
   | None -> st.init_vs.Vernacstate.synterp.parsing
   | Some { synterp_state } -> synterp_state.Vernacstate.Synterp.parsing
   in
   Vernacstate.Parser.parse st entry pa
 
 let about st pos ~goal ~pattern =
+  let loc = RawDocument.loc_of_position (Document.raw_document st.document) pos in
   match get_context st pos with 
   | None -> Error ("No context found") (*TODO execute *)
   | Some (sigma, env) ->
     try
-      let ref_or_by_not = parse_entry st pos (Pcoq.Prim.smart_global) pattern in
+      let ref_or_by_not = parse_entry st loc (Pcoq.Prim.smart_global) pattern in
       let udecl = None (* TODO? *) in
       Ok (Pp.string_of_ppcmds @@ Prettyp.print_about env sigma ref_or_by_not udecl)
     with e ->
@@ -287,21 +295,23 @@ let about st pos ~goal ~pattern =
       Error (Pp.string_of_ppcmds @@ CErrors.iprint (e, info))
 
 let search st ~id pos pattern =
+  let loc = RawDocument.loc_of_position (Document.raw_document st.document) pos in
   match get_context st pos with
   | None -> [] (* TODO execute? *)
   | Some (sigma, env) ->
-    let query = parse_entry st pos (G_vernac.search_query) pattern in
+    let query = parse_entry st loc (G_vernac.search_query) pattern in
     SearchQuery.interp_search ~id env sigma query
 
 let hover st pos = 
-  let opattern = Document.word_at_position st.document pos in
+  let opattern = RawDocument.word_at_position (Document.raw_document st.document) pos in
   Option.map (fun pattern -> about st pos ~goal:None ~pattern) opattern
 
 let check st pos ~goal ~pattern =
+  let loc = RawDocument.loc_of_position (Document.raw_document st.document) pos in
   match get_context st pos with 
   | None -> Error ("No context found") (*TODO execute *)
   | Some (sigma,env) ->
-    let rc = parse_entry st pos Pcoq.Constr.lconstr pattern in
+    let rc = parse_entry st loc Pcoq.Constr.lconstr pattern in
     try
       let redexpr = None in
       Ok (Pp.string_of_ppcmds @@ Vernacentries.check_may_eval env sigma redexpr rc)
@@ -310,7 +320,8 @@ let check st pos ~goal ~pattern =
       Error (Pp.string_of_ppcmds @@ CErrors.iprint (e, info))
 
 let locate st pos ~pattern = 
-  match parse_entry st pos (Pcoq.Prim.smart_global) pattern with
+  let loc = RawDocument.loc_of_position (Document.raw_document st.document) pos in
+  match parse_entry st loc (Pcoq.Prim.smart_global) pattern with
   | { v = AN qid } -> Ok (Pp.string_of_ppcmds @@ Prettyp.print_located_qualid qid)
   | { v = ByNotation (ntn, sc)} -> 
     match get_context st pos with
@@ -320,10 +331,11 @@ let locate st pos ~pattern =
         (Constrextern.without_symbols (Printer.pr_glob_constr_env env sigma)) ntn sc)
 
 let print st pos ~pattern = 
+  let loc = RawDocument.loc_of_position (Document.raw_document st.document) pos in
   match get_context st pos with 
   | None -> Error("No context found")
   | Some (sigma, env) -> 
-    let qid = parse_entry st pos (Pcoq.Prim.smart_global) pattern in
+    let qid = parse_entry st loc (Pcoq.Prim.smart_global) pattern in
     let udecl = None in (*TODO*)
     Ok ( Pp.string_of_ppcmds @@ Prettyp.print_name env sigma qid udecl )
 

--- a/language-server/dm/documentManager.mli
+++ b/language-server/dm/documentManager.mli
@@ -86,7 +86,7 @@ val handle_event : event -> state -> (state option * events)
 
 val search : state -> id:string -> Position.t -> string -> notification Sel.event list
 
-val about : state -> Position.t -> goal:(int option)  -> pattern:string -> (string,string) Result.t
+val about : state -> Position.t -> goal:(int option) -> pattern:string -> (string,string) Result.t
 
 val hover : state -> Position.t -> (string,string) Result.t option
 (** Returns an optional Result:

--- a/language-server/dm/documentManager.mli
+++ b/language-server/dm/documentManager.mli
@@ -104,5 +104,6 @@ module Internal : sig
 
   val document : state -> Document.document
   val execution_state : state -> ExecutionManager.state
+  val string_of_state : state -> string
 
 end

--- a/language-server/dm/dune
+++ b/language-server/dm/dune
@@ -1,7 +1,7 @@
 (library
  (name dm)
  (public_name vscoq-language-server.dm)
- (modules delegationManager parTactic documentManager document executionManager scheduler types searchQuery completionItems completionSuggester priorityManager Log)
+ (modules :standard \ vscoqtop_proof_worker vscoqtop_tactic_worker)
  (flags -rectypes)
  (libraries coq-core.sysinit coq-core.vernac coq-core.parsing sel lsp))
 

--- a/language-server/dm/rawDocument.ml
+++ b/language-server/dm/rawDocument.ml
@@ -1,0 +1,86 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 VSCoq                                  *)
+(*                                                                        *)
+(*                   Copyright INRIA and contributors                     *)
+(*       (see version control and README file for authors & dates)        *)
+(*                                                                        *)
+(**************************************************************************)
+(*                                                                        *)
+(*   This file is distributed under the terms of the MIT License.         *)
+(*   See LICENSE file.                                                    *)
+(*                                                                        *)
+(**************************************************************************)
+open Lsp
+open LspData
+
+type text_edit = Range.t * string
+
+let top_edit_position edits =
+  match edits with
+  | [] -> assert false
+  | (Range.{ start },_) :: edits ->
+    List.fold_left (fun min (Range.{ start },_) ->
+    if Position.compare start min < 0 then start else min) start edits
+
+let bottom_edit_position edits =
+  match edits with
+  | [] -> assert false
+  | (Range.{ end_ },_) :: edits ->
+    List.fold_left (fun max (Range.{ end_ },_) ->
+    if Position.compare end_ max > 0 then end_ else max) end_ edits
+
+
+type t = {
+  text : string;
+  lines : int array; (* locs of beginning of lines *)
+}
+
+let compute_lines text =
+  let lines = String.split_on_char '\n' text in
+  let _,lines_locs = CList.fold_left_map (fun acc s -> let n = String.length s in n + acc + 1, acc) 0 lines in
+  Array.of_list lines_locs
+
+let create text = { text; lines = compute_lines text }
+
+let text t = t.text
+
+let position_of_loc raw loc =
+  let i = ref 0 in
+  while (!i < Array.length raw.lines && raw.lines.(!i) <= loc) do incr(i) done;
+  Position.{ line = !i - 1; character = loc - raw.lines.(!i - 1) }
+
+let loc_of_position raw Position.{ line; character } =
+  raw.lines.(line) + character
+
+let end_loc raw =
+  String.length raw.text
+
+let range_of_loc raw loc =
+  let open Range in
+  { start = position_of_loc raw loc.Loc.bp;
+    end_ = position_of_loc raw loc.Loc.ep;
+  }
+
+let word_at_position raw pos : string option =
+  let r = Str.regexp {|\([a-zA-Z_][a-zA-Z_0-9]*\)|} in
+  let start = ref (loc_of_position raw pos) in
+  let word = ref None in
+  while (Str.string_match r raw.text start.contents) do
+    start := start.contents - 1;
+    word := Some (Str.matched_string raw.text);
+  done;
+  word.contents
+
+type edit = Range.t * string
+
+let apply_text_edit raw (Range.{start; end_}, editText) =
+  let start = loc_of_position raw start in
+  let stop = loc_of_position raw end_ in
+  let before = String.sub raw.text 0 start in
+  let after = String.sub raw.text stop (String.length raw.text - stop) in
+  let new_text = before ^ editText ^ after in (* FIXME avoid concatenation *)
+  let new_lines = compute_lines new_text in (* FIXME compute this incrementally *)
+  let old_length = stop - start in
+  let shift = String.length editText - old_length in
+  { text = new_text; lines = new_lines }, start, stop, shift

--- a/language-server/dm/rawDocument.mli
+++ b/language-server/dm/rawDocument.mli
@@ -11,16 +11,22 @@
 (*   See LICENSE file.                                                    *)
 (*                                                                        *)
 (**************************************************************************)
-open Lsp.LspData
-
-type sentence_id = Stateid.t
-type sentence_id_set = Stateid.Set.t
+open Lsp
+open LspData
 
 type text_edit = Range.t * string
 
-type link = {
-  write_to :  Unix.file_descr;
-  read_from:  Unix.file_descr;
-}
+type t
 
-type 'a log = Log : 'a -> 'a log
+val create : string -> t
+val text : t -> string
+
+val position_of_loc : t -> int -> Position.t
+val loc_of_position : t -> Position.t -> int
+val end_loc : t -> int
+
+val range_of_loc : t -> Loc.t -> Range.t
+val word_at_position: t -> Position.t -> string option
+
+(** Applies a text edit, and returns start, stop locations and shift *)
+val apply_text_edit : t -> text_edit -> t * int * int * int

--- a/language-server/dm/scheduler.ml
+++ b/language-server/dm/scheduler.ml
@@ -24,7 +24,7 @@ type error_recovery_strategy =
 
 type executable_sentence = {
   id : sentence_id;
-  ast : ast;
+  ast : Synterp.vernac_control_entry;
   synterp : Vernacstate.Synterp.t;
   error_recovery : error_recovery_strategy;
 }
@@ -140,7 +140,7 @@ Qed.
 
 (* FIXME handle commands with side effects followed by `Abort` *)
 
-let find_proof_using (ast : ast) =
+let find_proof_using (ast : Synterp.vernac_control_entry) =
   match ast.CAst.v.expr with
   | VernacSynPure(VernacProof(_,Some e)) -> Some e
   | _ -> log "no ast for proof using, looking at a default";

--- a/language-server/dm/scheduler.ml
+++ b/language-server/dm/scheduler.ml
@@ -215,9 +215,8 @@ let string_of_state st =
   let scopes = (List.map (fun b -> List.map (fun x -> x.id) b.proof_sentences) st.proof_blocks) @ [st.document_scope] in
   String.concat "|" (List.map (fun l -> String.concat " " (List.map Stateid.to_string l)) scopes)
 
-let schedule_sentence (id,oast) st schedule =
-  let base, st, task = match oast with
-    | Some (ast,classif,synterp_st) ->
+let schedule_sentence (id, (ast, classif, synterp_st)) st schedule =
+  let base, st, task = 
       let open Vernacexpr in
       let (base, st, task) = push_state id ast synterp_st classif st in
       begin match ast.CAst.v.expr with
@@ -227,7 +226,6 @@ let schedule_sentence (id,oast) st schedule =
         (base, { st with section_depth = max 0 (st.section_depth - 1) }, task)
       | _ -> (base, st, task)
       end
-    | None -> base_id st, st, Skip id
   in
 (*
   log @@ "Scheduled " ^ (Stateid.to_string id) ^ " based on " ^ (match base with Some id -> Stateid.to_string id | None -> "no state");

--- a/language-server/dm/scheduler.mli
+++ b/language-server/dm/scheduler.mli
@@ -29,7 +29,7 @@ type error_recovery_strategy =
 
 type executable_sentence = {
   id : sentence_id;
-  ast : ast;
+  ast : Synterp.vernac_control_entry;
   synterp : Vernacstate.Synterp.t;
   error_recovery : error_recovery_strategy;
 }
@@ -50,7 +50,7 @@ type schedule
 
 val initial_schedule : schedule
 
-val schedule_sentence : sentence_id * (ast * Vernacextend.vernac_classification * Vernacstate.Synterp.t) -> state -> schedule -> state * schedule
+val schedule_sentence : sentence_id * (Synterp.vernac_control_entry * Vernacextend.vernac_classification * Vernacstate.Synterp.t) -> state -> schedule -> state * schedule
 (** Identifies the structure of the document and dependencies between sentences
     in order to easily compute the tasks to interpret the a sentence.
     Input sentence is None on parsing error. *)

--- a/language-server/dm/scheduler.mli
+++ b/language-server/dm/scheduler.mli
@@ -50,7 +50,7 @@ type schedule
 
 val initial_schedule : schedule
 
-val schedule_sentence : sentence_id * (ast * Vernacextend.vernac_classification * Vernacstate.Synterp.t) option -> state -> schedule -> state * schedule
+val schedule_sentence : sentence_id * (ast * Vernacextend.vernac_classification * Vernacstate.Synterp.t) -> state -> schedule -> state * schedule
 (** Identifies the structure of the document and dependencies between sentences
     in order to easily compute the tasks to interpret the a sentence.
     Input sentence is None on parsing error. *)

--- a/language-server/tests/d_tests.ml
+++ b/language-server/tests/d_tests.ml
@@ -19,7 +19,7 @@ let %test_unit "document: invalidate top" =
   let invalid, doc = Document.validate_document doc in
   [%test_eq: sentence_id list] [] (Stateid.Set.elements invalid);
   let s1,(s2,(s3,(s4,(s5,())))) = d_sentences doc (P(P(P(P(P(O)))))) in
-  let doc = Document.apply_text_edits doc [Document.Internal.range_of_sentence_id doc s1.id,"Definition x := 4."] in
+  let doc, _loc = Document.apply_text_edits doc [Document.range_of_id doc s1.id,"Definition x := 4."] in
   let invalid, doc = Document.validate_document doc in
   let r1,(r2,(r3,(r4,(r5,())))) = d_sentences doc (P(P(P(P(P(O)))))) in
   [%test_eq: sentence_id list] [s1.id] (Stateid.Set.elements invalid);
@@ -40,7 +40,7 @@ let %test_unit "document: invalidate proof" =
   let invalid, doc = Document.validate_document doc in
   [%test_eq: sentence_id list] [] (Stateid.Set.elements invalid);
   let s1,(s2,(s3,(s4,(s5,())))) = d_sentences doc (P(P(P(P(P(O)))))) in
-  let doc = Document.apply_text_edits doc [Document.Internal.range_of_sentence_id doc s3.id,"idtac."] in
+  let doc, _loc = Document.apply_text_edits doc [Document.range_of_id doc s3.id,"idtac."] in
   let invalid, doc = Document.validate_document doc in
   let r1,(r2,(r3,(r4,(r5,())))) = d_sentences doc (P(P(P(P(P(O)))))) in
   [%test_eq: sentence_id list] [s3.id] (Stateid.Set.elements invalid);

--- a/language-server/vscoqtop/lspManager.ml
+++ b/language-server/vscoqtop/lspManager.ml
@@ -206,6 +206,7 @@ let textDocumentDidChange params =
   let st = Dm.DocumentManager.apply_text_edits st text_edits in
   let (st, events) = 
     if !check_mode = Settings.Mode.Continuous then 
+      let st = Dm.DocumentManager.validate_document st in
       Dm.DocumentManager.interpret_to_end st 
     else 
       (st, [])
@@ -241,6 +242,7 @@ let coqtopInterpretToPoint params =
   let Notification.Client.InterpretToPointParams.{ textDocument; position } = params in
   let uri = textDocument.uri in
   let st = Hashtbl.find states (Uri.path uri) in
+  let st = Dm.DocumentManager.validate_document st in
   let (st, events) = Dm.DocumentManager.interpret_to_position st position in
   Hashtbl.replace states (Uri.path uri) st;
   update_view uri st;
@@ -249,6 +251,7 @@ let coqtopInterpretToPoint params =
 let coqtopStepBackward params =
   let Notification.Client.StepBackwardParams.{ textDocument = { uri } } = params in
   let st = Hashtbl.find states (Uri.path uri) in
+  let st = Dm.DocumentManager.validate_document st in
   let (st, events) = Dm.DocumentManager.interpret_to_previous st in
   Hashtbl.replace states (Uri.path uri) st;
   update_view uri st;
@@ -257,6 +260,7 @@ let coqtopStepBackward params =
 let coqtopStepForward params =
   let Notification.Client.StepForwardParams.{ textDocument = { uri } } = params in
   let st = Hashtbl.find states (Uri.path uri) in
+  let st = Dm.DocumentManager.validate_document st in
   let (st, events) = Dm.DocumentManager.interpret_to_next st in
   Hashtbl.replace states (Uri.path uri) st;
   update_view uri st;
@@ -287,6 +291,7 @@ let coqtopResetCoq ~id params =
 let coqtopInterpretToEnd params =
   let Notification.Client.InterpretToEndParams.{ textDocument = { uri } } = params in
   let st = Hashtbl.find states (Uri.path uri) in
+  let st = Dm.DocumentManager.validate_document st in
   let (st, events) = Dm.DocumentManager.interpret_to_end st in
   Hashtbl.replace states (Uri.path uri) st;
   update_view uri st;

--- a/language-server/vscoqtop/lspManager.ml
+++ b/language-server/vscoqtop/lspManager.ml
@@ -334,10 +334,8 @@ let sendDocumentState ~id params =
   let Request.Client.DocumentStateParams.{ textDocument } = params in
   let uri = textDocument.uri in
   let st = Hashtbl.find states (Uri.path uri) in
-  let doc = Dm.DocumentManager.Internal.document st in
-  let document = Dm.Document.Internal.to_string doc in
+  let document = Dm.DocumentManager.Internal.string_of_state st in
   Ok Request.Client.DocumentStateResult.{ document }, []
-  
 
 let workspaceDidChangeConfiguration params = 
   let Protocol.Notification.Client.DidChangeConfigurationParams.{ settings } = params in


### PR DESCRIPTION
Parsing errors are now handled specifically, and will be integrated into a concrete syntax view of the document when we have it.

Fixes #478.