### PR TITLE
Merge improved autocomplete

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -151,6 +151,19 @@
             "description": "Amount of workers assigned to proofs in delegation mode"
           }
         }
+      },
+      {
+        "title": "Code Completion",
+        "type": "object",
+        "properties": {
+          "vscoq.completion.unificationLimit": {
+            "scope": "window",
+            "type": "number",
+            "default": 100,
+            "minimum": 0,
+            "description": "Sets the limit for, how many theorems unification is attempted for when attempting code completion for the application of theorems. This detemines which theorems can be marked as applicable. The higher the limit, the better results will be, but the slower code completion will be."
+          }
+        }
       }
     ],
     "commands": [
@@ -218,7 +231,7 @@
         "category": "Coq"
       }
     ],
-    "keybindings":[
+    "keybindings": [
       {
         "key": "alt+down",
         "mac": "ctrl+alt+down",

--- a/client/package.json
+++ b/client/package.json
@@ -162,6 +162,20 @@
             "default": 100,
             "minimum": 0,
             "description": "Sets the limit for, how many theorems unification is attempted for when attempting code completion for the application of theorems. This detemines which theorems can be marked as applicable. The higher the limit, the better results will be, but the slower code completion will be."
+          },
+          "vscoq.completion.algorithm": {
+            "scope": "window",
+            "type": "number",
+            "enum": [
+              0,
+              1
+            ],
+            "enumItemLabels": [
+              "SplitTypeIntersection",
+              "StructuredSplitUnification"
+            ],
+            "default": 1,
+            "description": "Configures the ranking algorithm for auto completions in Coq."
           }
         }
       }

--- a/language-server/dm/completionItems.ml
+++ b/language-server/dm/completionItems.ml
@@ -3,12 +3,27 @@ open Libnames
 open Nametab
 open Printer
 
+type completion_level = 
+  Fully
+  | Partially
+  | No_completion
+
+let symbol_prefix (completes: completion_level option) =
+  match completes with
+  | None -> ""
+  | Some level -> match level with
+    | Fully -> "★ "
+    | Partially -> "☆ "
+    | No_completion -> ""
+
 type completion_item = {
   ref : Names.GlobRef.t;
   path : full_path;
   typ : types;
   env : Environ.env;
   sigma : Evd.evar_map;
+  completes : completion_level option;
+  mutable debug_info : string;
 }
 
 let mk_completion_item sigma ref env (c : constr) : completion_item = 
@@ -18,11 +33,13 @@ let mk_completion_item sigma ref env (c : constr) : completion_item =
     typ = c;
     env = env;
     sigma = sigma;
+    completes = None;
+    debug_info = "";
   }
 
-let pp_completion_item (item : completion_item) : (string * string * string) =
+let pp_completion_item (item : completion_item) : (string * string * string * string) =
   let pr = pr_global item.ref in
   let name = Pp.string_of_ppcmds pr in
-  let path = string_of_path item.path in
+  let path = string_of_path item.path ^ "\n" ^ item.debug_info in
   let typ = Pp.string_of_ppcmds (pr_ltype_env item.env item.sigma item.typ) in
-  (name, typ, path)
+  (Printf.sprintf "%s%s" (symbol_prefix item.completes) name, name, typ, path)

--- a/language-server/dm/completionSuggester.ml
+++ b/language-server/dm/completionSuggester.ml
@@ -325,9 +325,9 @@ module Structured = struct
 
   (* A Lower score is better as we are sorting in ascending order *)
 
-  let rank (_options: Lsp.LspData.Settings.Completion.t) (goal, goal_evar) sigma _ lemmas : CompletionItems.completion_item list =
-    let size_impact = 5.0 in
-    let atomic_factor = 5.0 in
+  let rank (options: Lsp.LspData.Settings.Completion.t) (goal, goal_evar) sigma _ lemmas : CompletionItems.completion_item list =
+    let size_impact = options.sizeFactor in
+    let atomic_factor = options.atomicFactor in
     let finalScore score size = Float.sub size (Float.mul score size_impact) in
     let hyps = get_hyps sigma goal_evar in
     match (unifier_kind sigma hyps goal, unifier_kind sigma HypothesisMap.empty goal) with

--- a/language-server/dm/completionSuggester.ml
+++ b/language-server/dm/completionSuggester.ml
@@ -45,6 +45,7 @@ let get_hyps sigma goal =
     hyps
 
 let get_goal_type_option st loc =
+  DocumentManager.unfreeze_interp_state st loc;
   let proof = DocumentManager.get_proof st loc in
   Option.bind proof (fun Proof.{ goals; sigma; _ } -> 
     List.nth_opt goals 0 

--- a/language-server/dm/completionSuggester.ml
+++ b/language-server/dm/completionSuggester.ml
@@ -1,35 +1,481 @@
 module CompactedDecl = Context.Compacted.Declaration
 open Printer
+open EConstr
+open Names
 
-let mk_hyp sigma d (env,l) =
+module TypeCompare = struct
+  type t = types
+  let compare = compare
+end
+
+let takeSkip n l = 
+  let rec sub_list n accu l =
+    match l with 
+    | [] -> accu, [] 
+    | hd :: tl ->
+      if n = 0 then accu, tl
+      else sub_list (n - 1) (hd :: accu) tl
+  in
+  let take, skip = sub_list n [] l in
+  List.rev (take), skip
+
+
+module Atomics = Set.Make(TypeCompare)
+
+module HypothesisMap = Map.Make (struct type t = Id.t let compare = compare end)
+
+let mk_hyp d (env,l) =
   let d' = CompactedDecl.to_named_context d in
   let env' = List.fold_right EConstr.push_named d' env in
   let ids, typ = match d with
   | CompactedDecl.LocalAssum (ids, typ) -> ids, typ
-  | CompactedDecl.LocalDef (ids,_c,typ) -> ids, typ
+  | CompactedDecl.LocalDef (ids,_,typ) -> ids, typ
   in
-  let ids' = List.map (fun id -> Names.Id.to_string id.Context.binder_name) ids in
-  let typ' = pr_letype_env env sigma typ in
-  let hyps = ids' |> List.map (fun id -> (id, Pp.string_of_ppcmds typ', "")) in
-  (env', hyps @ l)
+  let ids' = List.map (fun id -> id.Context.binder_name) ids in
+  let m = List.fold_right (fun id acc -> HypothesisMap.add id typ acc) ids' l in
+  (env', m)
 
-let get_hyps st loc =
-  let mk_hyps sigma goal =
+let get_hyps sigma goal =
     let EvarInfo evi = Evd.find sigma goal in
     let env = Evd.evar_filtered_env (Global.env ()) evi in
     let min_env = Environ.reset_context env in
     let (_env, hyps) =
-      Context.Compacted.fold (mk_hyp sigma)
-        (Termops.compact_named_context sigma (EConstr.named_context env)) ~init:(min_env,[]) in
-    hyps in
+      Context.Compacted.fold (mk_hyp)
+        (Termops.compact_named_context sigma (EConstr.named_context env)) ~init:(min_env, HypothesisMap.empty) in
+    hyps
 
-  DocumentManager.get_proof st (Some loc)
-    |> Option.map (fun Proof.{ goals; sigma; _ } -> Option.cata (mk_hyps sigma) [] (List.nth_opt goals 0)) 
- 
-let get_completion_items st loc =
-  let hypotheses = get_hyps st loc in
-  let lemmasOption = DocumentManager.get_lemmas st loc in
-  let lemmas = lemmasOption |> Option.map (List.map CompletionItems.pp_completion_item) in
-  [hypotheses; lemmas] 
-  |> List.map (Option.default [])
-  |> List.flatten
+let get_goal_type_option st loc =
+  let proof = DocumentManager.get_proof st loc in
+  Option.bind proof (fun Proof.{ goals; sigma; _ } -> 
+    List.nth_opt goals 0 
+    |> Option.map (fun goal ->
+      let evi = Evd.find_undefined sigma goal in
+      let env = Evd.evar_filtered_env (Global.env ()) evi in
+      Evd.evar_concl evi, sigma, env, goal
+      )
+    )
+
+let type_kind_opt sigma t = try Some (kind_of_type sigma t) with _ -> None 
+
+let type_size sigma t : int = 
+  let rec aux u = 
+    match kind sigma u with
+    | Sort _ -> 1
+    | Cast (c,_,t) -> aux c + aux t
+    | Prod (_,t,c) -> aux t + aux c
+    | LetIn (_,b,t,c) -> aux b + aux t + aux c
+    | App (c,l) -> Array.map aux l |> Array.fold_left (+) (aux c)
+    | Rel _ -> 1
+    | (Meta _ | Var _ | Evar _ | Const _
+    | Proj _ | Case _ | Fix _ | CoFix _ | Ind _) -> 1
+    | (Lambda _ | Construct _ | Array _ | Int _ | Float _) -> 1
+  in
+  aux t
+
+module SimpleAtomics = struct
+  let atomic_types sigma t: Atomics.t = 
+    let rec aux t : types list = 
+      match (type_kind_opt sigma t) with
+      | Some SortType _ -> [] (* Might be possible to get atomics from also *)
+      | Some CastType (tt, t) -> aux tt @ aux t
+      | Some ProdType (_, t1, t2) -> aux t1 @ aux t2
+      | Some LetInType _ -> [] 
+      | Some AtomicType (t, ta) ->
+        t :: (Array.map aux ta |> Array.to_list |> List.flatten);
+      | None -> [] (* Lol :) *)
+      in
+    aux t |>
+    Atomics.of_list
+
+  let compare_atomics (goal : Atomics.t) (a1, _ : Atomics.t * _) (a2, _ : Atomics.t * _) : int = 
+    match (Atomics.inter a1 goal, Atomics.inter a2 goal) with
+    | r1, r2 when Atomics.cardinal r1 = Atomics.cardinal r2 -> 
+      (* If the size is equal, priotize the one with fewest types *)
+      compare (Atomics.cardinal a1) (Atomics.cardinal a2)
+    | r1, r2 -> 
+      (* Return the set with largest overlap, so we sort in increasing order swap the arguments *)
+      compare (Atomics.cardinal r2) (Atomics.cardinal r1)
+
+  let rank (goal : Evd.econstr) sigma _ lemmas : CompletionItems.completion_item list =
+    let lemmaAtomics = List.map (fun (l : CompletionItems.completion_item) -> 
+      (atomic_types sigma (of_constr l.typ), l)
+    ) lemmas in
+    let goalAtomics = atomic_types sigma goal in
+    List.stable_sort (compare_atomics goalAtomics) lemmaAtomics |> 
+    List.map snd 
+end 
+
+module Split = struct
+  let split_types sigma c =
+    let (list, other_c) = decompose_prod sigma c in 
+    list 
+    |> List.map snd
+    |> List.cons other_c
+    |> List.map (fun typ -> SimpleAtomics.atomic_types sigma typ)
+    |> List.fold_left (fun (acc, result) item -> (Atomics.union acc item, Atomics.union acc item :: result)) (Atomics.empty, [])
+    |> snd
+
+  let best_subtype sigma goal c = 
+    c |> split_types sigma |> List.map (fun a -> (a, a)) |> List.stable_sort (SimpleAtomics.compare_atomics goal) |> List.hd |> fst
+
+  let rank (goal : Evd.econstr) sigma _ (lemmas : CompletionItems.completion_item list) : CompletionItems.completion_item list =
+    (*Split type intersection: Split the lemmas by implications, compare the suffix to the goal, pick best match*)
+    let goal = SimpleAtomics.atomic_types sigma goal in
+    let lemmaTypes = List.map (fun (l : CompletionItems.completion_item) -> 
+      let best = best_subtype sigma goal (of_constr l.typ) in
+      (best, l)
+    ) lemmas in
+    List.stable_sort (SimpleAtomics.compare_atomics goal) lemmaTypes |> 
+    List.map snd
+end
+
+type rev_bruijn_index = int
+
+module Structured = struct
+  type unifier = 
+    | SortUniType of ESorts.t * rev_bruijn_index
+    | AtomicUniType of types * unifier array
+
+  let _print_unifier env sigma u =
+    let po u = match kind sigma u with
+    | Sort s -> Printf.eprintf "Sort: ";
+      (match ESorts.kind sigma s with 
+      | SProp -> Printf.eprintf "SProp\n";
+      | Prop -> Printf.eprintf "Prop\n";
+      | Set  -> Printf.eprintf "Set\n";
+      | Type _ -> Printf.eprintf "Type\n";
+      | QSort (_, _) -> Printf.eprintf "QSort\n";
+      )
+    | Cast (c,_,t) -> Printf.eprintf "cast: %s, %s\n" 
+      (Pp.string_of_ppcmds (pr_econstr_env env sigma c))
+      (Pp.string_of_ppcmds (pr_econstr_env env sigma t))
+    | Prod (na,_,_) -> Printf.eprintf "Prod: %s\n"
+      (Name.print na.binder_name |> Pp.string_of_ppcmds)
+    | LetIn (_,b,t,c) -> 
+      Printf.eprintf "LetIn: %s, %s, %s\n" 
+        (Pp.string_of_ppcmds (pr_econstr_env env sigma b))
+        (Pp.string_of_ppcmds (pr_econstr_env env sigma t))
+        (Pp.string_of_ppcmds (pr_econstr_env env sigma c))
+    | App (c,_) -> 
+      Printf.eprintf "App: %s\n" 
+        (Pp.string_of_ppcmds (pr_econstr_env env sigma c))
+    | Rel i -> Printf.eprintf "Rel: %d\n" i
+    | Meta _ -> Printf.eprintf "Meta: %s\n" (Pp.string_of_ppcmds (pr_econstr_env env sigma u))
+    | Var _ -> Printf.eprintf "Var: %s\n" (Pp.string_of_ppcmds (pr_econstr_env env sigma u))
+    | Evar _ -> Printf.eprintf "Evar: %s\n" (Pp.string_of_ppcmds (pr_econstr_env env sigma u))
+    | Const _ -> Printf.eprintf "Const: %s\n" (Pp.string_of_ppcmds (pr_econstr_env env sigma u))
+    | Proj _ -> Printf.eprintf "Proj: %s\n" (Pp.string_of_ppcmds (pr_econstr_env env sigma u))
+    | Case _ -> Printf.eprintf "Case: %s\n" (Pp.string_of_ppcmds (pr_econstr_env env sigma u))
+    | Fix _ -> Printf.eprintf "Fix: %s\n" (Pp.string_of_ppcmds (pr_econstr_env env sigma u))
+    | CoFix _ -> Printf.eprintf "CoFix: %s\n" (Pp.string_of_ppcmds (pr_econstr_env env sigma u))
+    | Ind _ -> Printf.eprintf "Ind: %s\n" (Pp.string_of_ppcmds (pr_econstr_env env sigma u))
+    | Lambda _ -> Printf.eprintf "Lambda: %s\n" (Pp.string_of_ppcmds (pr_econstr_env env sigma u))
+    | Construct _ -> Printf.eprintf "Construct: %s\n" (Pp.string_of_ppcmds (pr_econstr_env env sigma u))
+    | Int _ -> Printf.eprintf "Int: %s\n" (Pp.string_of_ppcmds (pr_econstr_env env sigma u))
+    | Float _ -> Printf.eprintf "Float: %s\n" (Pp.string_of_ppcmds (pr_econstr_env env sigma u))
+    | Array _ -> Printf.eprintf "Array: %s\n" (Pp.string_of_ppcmds (pr_econstr_env env sigma u))
+    in
+    let rec aux i u = 
+      Printf.eprintf "%s" (String.init i (fun _ -> ' '));
+      match u with
+      | SortUniType (s, i) -> Printf.eprintf "Sort %d: %s\n" i
+        (match ESorts.kind sigma s with 
+        | SProp -> "SProp"
+        | Prop -> "Prop"
+        | Set  -> "Set"
+        | Type _ -> "Type"
+        | QSort _ -> "QSort"
+        )
+      | AtomicUniType (t, ta) -> Printf.eprintf "Atomic: ";
+        po t;
+      Array.iter (aux (i+1)) ta
+    in
+    aux 0 u
+
+
+
+  (* map from rev_bruijn_index to unifier *)
+  module UM = Map.Make(struct type t = rev_bruijn_index let compare = compare end)
+
+  (* This is extremely slow, we should not convert it to a list. *)
+  let filter_options a = 
+    a |> Array.to_list |> Option.List.flatten |> Array.of_list
+
+  let _debug_print env sigma t : unit = 
+    let rec aux i u = 
+      Printf.eprintf "%s" (String.init i (fun _ -> ' '));
+      match kind sigma u with
+      | Sort s -> Printf.eprintf "Sort: ";
+        (match ESorts.kind sigma s with 
+        | SProp -> Printf.eprintf "SProp\n";
+        | Prop -> Printf.eprintf "Prop\n";
+        | Set  -> Printf.eprintf "Set\n";
+        | Type _ -> Printf.eprintf "Type\n";
+        | QSort (_, _) -> Printf.eprintf "QSort\n";
+        )
+      | Cast (c,_,t) -> Printf.eprintf "cast: %s, %s\n" 
+        (Pp.string_of_ppcmds (pr_econstr_env env sigma c))
+        (Pp.string_of_ppcmds (pr_econstr_env env sigma t))
+      | Prod (na,t,c) -> Printf.eprintf "Prod: %s\n"
+        (Name.print na.binder_name |> Pp.string_of_ppcmds);
+        aux (i+1) t;
+        aux (i+1) c
+      | LetIn (_,b,t,c) -> 
+        Printf.eprintf "LetIn: %s, %s, %s\n" 
+          (Pp.string_of_ppcmds (pr_econstr_env env sigma b))
+          (Pp.string_of_ppcmds (pr_econstr_env env sigma t))
+          (Pp.string_of_ppcmds (pr_econstr_env env sigma c));
+        aux (i+1) t;
+        aux (i+1) c;
+        aux (i+1) b
+      | App (c,l) -> 
+        Printf.eprintf "App: %s\n" 
+          (Pp.string_of_ppcmds (pr_econstr_env env sigma c));
+        Array.iter (aux (i+1)) l
+      | Rel i -> Printf.eprintf "Rel: %d\n" i
+      | Meta _ -> Printf.eprintf "Meta: %s\n" (Pp.string_of_ppcmds (pr_econstr_env env sigma u))
+      | Var _ -> Printf.eprintf "Var: %s\n" (Pp.string_of_ppcmds (pr_econstr_env env sigma u))
+      | Evar _ -> Printf.eprintf "Evar: %s\n" (Pp.string_of_ppcmds (pr_econstr_env env sigma u))
+      | Const _ -> Printf.eprintf "Const: %s\n" (Pp.string_of_ppcmds (pr_econstr_env env sigma u))
+      | Proj _ -> Printf.eprintf "Proj: %s\n" (Pp.string_of_ppcmds (pr_econstr_env env sigma u))
+      | Case _ -> Printf.eprintf "Case: %s\n" (Pp.string_of_ppcmds (pr_econstr_env env sigma u))
+      | Fix _ -> Printf.eprintf "Fix: %s\n" (Pp.string_of_ppcmds (pr_econstr_env env sigma u))
+      | CoFix _ -> Printf.eprintf "CoFix: %s\n" (Pp.string_of_ppcmds (pr_econstr_env env sigma u))
+      | Ind _ -> Printf.eprintf "Ind: %s\n" (Pp.string_of_ppcmds (pr_econstr_env env sigma u))
+      | Lambda _ -> Printf.eprintf "Lambda: %s\n" (Pp.string_of_ppcmds (pr_econstr_env env sigma u))
+      | Construct _ -> Printf.eprintf "Construct: %s\n" (Pp.string_of_ppcmds (pr_econstr_env env sigma u))
+      | Int _ -> Printf.eprintf "Int: %s\n" (Pp.string_of_ppcmds (pr_econstr_env env sigma u))
+      | Float _ -> Printf.eprintf "Float: %s\n" (Pp.string_of_ppcmds (pr_econstr_env env sigma u))
+      | Array _ -> Printf.eprintf "Array: %s\n" (Pp.string_of_ppcmds (pr_econstr_env env sigma u))
+    in
+    aux 0 t
+
+  let unifier_kind sigma (hyps : types HypothesisMap.t) (t : types) : unifier option =
+    let rec aux bruijn t = match kind sigma t with
+      | Sort s -> SortUniType (s, List.length bruijn) |> Option.make
+      | Cast (c,_,_) -> aux bruijn c
+      | Prod (_,t,c) -> aux (aux bruijn t :: bruijn) c (* Possibly the index should be assigned here instead and be a thing for both types. *)
+      | LetIn (_,_,t,c) -> aux (aux bruijn t :: bruijn) c
+      | App (c,l) -> 
+        let l' = Array.map (aux bruijn) l in
+        AtomicUniType (c, filter_options l') |> Option.make
+      | Rel i -> List.nth bruijn (i-1)
+      | Var v when HypothesisMap.mem v hyps -> aux bruijn (HypothesisMap.find v hyps)
+      | (Meta _ | Var _ | Evar _ | Const _
+      | Proj _ | Case _ | Fix _ | CoFix _ | Ind _)
+        -> AtomicUniType (t,[||]) |> Option.make
+      | (Lambda _ | Construct _ | Int _ | Float _ | Array _) -> None
+    in
+    aux [] t
+
+  let rec matches evd (u1: unifier) (u2: unifier) =
+    match (u1, u2) with
+    | SortUniType (s1, _), SortUniType (s2, _) -> 
+      ESorts.equal evd s1 s2
+    | SortUniType _, _ -> false
+    | _, SortUniType _ -> false (* TODO: Maybe add to UM? Maybe not? The UM is not the goal. *)
+    | AtomicUniType (t1, ua1), AtomicUniType (t2, ua2) -> 
+      let c = EConstr.compare_constr evd (EConstr.eq_constr evd) t1 t2 in
+      if c then 
+        let rec aux ua1 ua2 = 
+          match (ua1, ua2) with
+          | [], [] -> true
+          | [], _ | _, [] -> false
+          | u1 :: ua1, u2 :: ua2 -> 
+            let c = matches evd u1 u2 in
+            if c then aux ua1 ua2 else false
+        in
+        aux (Array.to_list ua1) (Array.to_list ua2)
+      else false
+  
+  let score_unifier use_um atomic_factor evd (goal : unifier) (u : unifier) : float =
+    let rec aux (um : unifier UM.t) g u  : (float * unifier UM.t) = 
+    match (g, u) with
+      | SortUniType (s1, _), SortUniType (s2, _) -> if ESorts.equal evd s1 s2 then (1., um) else (0., um)
+      (* We might want to check if the t in AtomicUniType actually belongs in the sort*)
+      | SortUniType _, _ -> (0., um) (* If the goal has a sort then it has to match *)
+      | AtomicUniType (_, _), SortUniType (s, i) ->
+        if UM.mem i um then 
+          let u = UM.find i um in
+          matches evd u (SortUniType (s, i)) |> Bool.to_float |> fun x -> (x, um)
+        else (1., if use_um then UM.add i u um else um)
+      | AtomicUniType (t1, ua1), AtomicUniType (t2, ua2) -> 
+        let c = EConstr.compare_constr evd (EConstr.eq_constr evd) t1 t2 |> Bool.to_float |> (Float.mul atomic_factor) in
+        let c = 
+          if isVar evd t1 && isVar evd t2 then
+            Float.mul c 2.0
+          else c in
+        if Array.length ua1 <> Array.length ua2 then (c, um)
+        else 
+          let (score, um) = Array.fold_left (fun (acc, um) (u1, u2) -> 
+            let (s, um) = aux um u1 u2 in
+            (Float.add acc s, um)
+          ) (c, um) (Array.combine ua1 ua2) in
+          (score, um)
+    in
+    aux UM.empty goal u |> fst
+
+  let unpack_unifier u : unifier list = 
+    let res = ref [] in
+    let rec aux u = match u with
+      | SortUniType (_, _) -> ();
+      | AtomicUniType (_, ua) -> 
+        res := u :: !res;
+        Array.iter aux ua
+    in
+    aux u;
+    !res
+
+  let size_unifier u = 
+    let rec aux u = match u with
+      | SortUniType (_, _) -> 1l
+      | AtomicUniType (_, ua) -> Array.fold_left (fun acc u -> Int32.add acc (aux u)) 1l ua
+    in
+    aux u
+
+  (* A Lower score is better as we are sorting in ascending order *)
+
+  let rank use_um (size_impact, atomic_factor) (goal, goal_evar) sigma _ lemmas : CompletionItems.completion_item list =
+    let finalScore score size = Float.sub size (Float.mul score size_impact) in
+    let hyps = get_hyps sigma goal_evar in
+    match (unifier_kind sigma hyps goal, unifier_kind sigma HypothesisMap.empty goal) with
+    | None, _ | _, None -> lemmas
+    | Some goalUnf, Some goalUnfNoHypothesisSub -> 
+      (*         
+      print_unifier env sigma goalUnf;
+      debug_print env sigma goal;
+      *)
+      let lemmaUnfs = List.map (fun (l : CompletionItems.completion_item) -> 
+        match (unifier_kind sigma HypothesisMap.empty (of_constr l.typ)) with
+        | None -> ((Float.min_float), l)
+        | Some unf -> 
+          let scores = List.map (score_unifier use_um atomic_factor sigma goalUnf) (unpack_unifier unf) in
+          let scores = scores @ (List.map (score_unifier use_um atomic_factor sigma goalUnfNoHypothesisSub) (unpack_unifier unf)) in
+          let size = size_unifier unf |> Int32.to_float in
+          let maxScore = List.fold_left Float.max 0. scores in
+          let final = finalScore maxScore size in
+          l.debug_info <- (Printf.sprintf "Score: %f, Size: %f, Final Score: %f" maxScore size final);
+          (final, l)
+      ) lemmas in
+      let sorted = List.stable_sort (fun (x, _) (y, _) -> Float.compare x y) lemmaUnfs in
+      (*
+      let hd = List.hd sorted |> snd in
+      print_unifier env sigma ((unifier_kind sigma HypothesisMap.empty (of_constr hd.typ)) |> Option.get);
+      debug_print env sigma (of_constr hd.typ);
+      *)
+      List.map snd sorted
+end
+
+module SelectiveUnification = struct
+  let realRank (goal : Evd.econstr) sigma env (lemmas : CompletionItems.completion_item list) : CompletionItems.completion_item list =
+    let goal_size = type_size sigma goal in
+    let aux (lemma : CompletionItems.completion_item) =
+      if type_size sigma (of_constr lemma.typ) + goal_size > 500 then (lemma, 1)
+      else
+        try
+          let flags = Evarconv.default_flags_of TransparentState.full in
+          let res = Evarconv.evar_conv_x flags env sigma Conversion.CONV goal (of_constr lemma.typ) in
+          match res with 
+          | Success _ ->
+            ({lemma with completes = Some Fully}, 0)
+          | UnifFailure _ ->
+            (lemma, 1)
+        with e ->
+          Printf.eprintf "Error in Unification: %s for %s\n%!" (Printexc.to_string e) (Pp.string_of_ppcmds (pr_global lemma.ref));
+          (lemma, 1)
+     in
+      lemmas
+    |> List.map aux
+    |> List.stable_sort (fun a b -> compare (snd a) (snd b))
+    |> List.map fst
+  
+  let selectiveRank (goal : Evd.econstr) sigma env (lemmas : CompletionItems.completion_item list) : CompletionItems.completion_item list =
+    try 
+      let take, skip = takeSkip 100 lemmas in
+      List.append (realRank goal sigma env take) skip
+    with e ->
+      Printf.eprintf "Error in Unification: %s\n%!" (Printexc.to_string e);
+      lemmas
+
+  let rank = selectiveRank
+end
+
+module SelectiveSplitUnification = struct
+  let realRank (goal : Evd.econstr) sigma env (lemmas : CompletionItems.completion_item list) : CompletionItems.completion_item list =
+    let goal_size = type_size sigma goal in
+    let make_sortable (lemma : CompletionItems.completion_item) =
+      let flags = Evarconv.default_flags_of TransparentState.full in
+      let rec aux (iterations: int) (typ : types) : (CompletionItems.completion_item * int)=
+        if type_size sigma typ + goal_size > 500 then (lemma, 1)
+        else
+        let res = Evarconv.evar_conv_x flags env sigma Conversion.CONV goal typ in
+        match res with
+        | Success _ ->
+          ({lemma with completes = if iterations = 0 then Some Fully else Some Partially}, iterations)
+        | UnifFailure (_, _) ->
+          match kind sigma typ with
+          | Prod (_,_,c) -> aux (iterations + 1) c
+          | Cast (c,_,_) -> aux iterations c
+          | _            -> (lemma, 1000) (* This just needs to be an arbitrarily high number*)
+        in
+      try 
+        aux 0 (of_constr lemma.typ)
+      with e ->
+        Printf.eprintf "Error in Split Unification: %s for %s\n%!" (Printexc.to_string e) (Pp.string_of_ppcmds (pr_global lemma.ref));
+        (lemma, 1000)
+     in
+    lemmas
+    |> List.map make_sortable
+    |> List.stable_sort (fun a b -> compare (snd a) (snd b))
+    |> List.map fst
+
+  let selectiveRank (goal : Evd.econstr) sigma env (lemmas : CompletionItems.completion_item list) : CompletionItems.completion_item list =
+    try 
+      let take, skip = takeSkip 100 lemmas in
+      List.append (realRank goal sigma env take) skip
+    with e ->
+      Printf.eprintf "Error in Split Unification: %s\n%!" (Printexc.to_string e);
+      lemmas
+
+  let rank = selectiveRank
+end
+
+let shuffle d =
+  let nd = List.map (fun c -> (Random.bits (), c)) d in
+  let sond = List.sort compare nd in
+  List.map snd sond
+
+let rank_choices algorithm algorithm_factor (goal, goal_evar) sigma env lemmas = 
+  let open Lsp.LspData.RankingAlgoritm in
+  match algorithm with
+  | SimpleTypeIntersection -> SimpleAtomics.rank goal sigma env lemmas
+  | SplitTypeIntersection -> Split.rank goal sigma env lemmas
+  | StructuredTypeEvaluation -> Structured.rank true algorithm_factor (goal, goal_evar) sigma env lemmas
+  | StructuredUnification -> SelectiveUnification.rank goal sigma env (Structured.rank true algorithm_factor (goal, goal_evar) sigma env lemmas)
+  | StructuredSplitUnification -> SelectiveSplitUnification.rank goal sigma env (Structured.rank true algorithm_factor (goal, goal_evar) sigma env lemmas)
+  | SimpleUnification -> SelectiveUnification.rank goal sigma env (SimpleAtomics.rank goal sigma env lemmas)
+  | SimpleSplitUnification -> SelectiveSplitUnification.rank goal sigma env (SimpleAtomics.rank goal sigma env lemmas)
+  | SplitTypeUnification -> SelectiveUnification.rank goal sigma env (Split.rank goal sigma env lemmas)
+  | SplitTypeSplitUnification -> SelectiveSplitUnification.rank goal sigma env (Split.rank goal sigma env lemmas)
+  | Shuffle -> shuffle lemmas
+  | ShuffleUnification -> SelectiveUnification.rank goal sigma env (shuffle lemmas)
+  | ShuffleSplitUnification -> SelectiveSplitUnification.rank goal sigma env (shuffle lemmas)
+  | Basic -> lemmas
+
+
+let get_completion_items st loc algorithm algorithm_factor =
+  try 
+    match get_goal_type_option st (Some loc), DocumentManager.get_lemmas st loc with
+    | None, _ -> Error ("Error in creating completion items because GOAL could not be found")
+    | _ , None -> Error ("Error in creating completion items because LEMMAS could not be found")
+    | Some (goal, sigma, env, goal_evar), Some lemmas ->
+      let lemmas = try
+        rank_choices algorithm algorithm_factor (goal, goal_evar) sigma env lemmas
+      with e ->
+        Printf.eprintf "Ranking of lemmas failed: %s" (Printexc.to_string e);
+        lemmas
+      in
+      List.map (CompletionItems.pp_completion_item) lemmas |> Result.ok
+  with e -> 
+    Printf.eprintf "Error in creating completion items: %s" (Printexc.to_string e);
+    Error ("Error in creating completion items: " ^ (Printexc.to_string e))

--- a/language-server/dm/completionSuggester.mli
+++ b/language-server/dm/completionSuggester.mli
@@ -1,1 +1,0 @@
-val get_completion_items : DocumentManager.state -> Lsp.LspData.Position.t -> Lsp.LspData.RankingAlgoritm.t -> (float * float) -> ((string * string * string * string) list, string) Result.t

--- a/language-server/dm/completionSuggester.mli
+++ b/language-server/dm/completionSuggester.mli
@@ -1,1 +1,1 @@
-val get_completion_items : DocumentManager.state -> Lsp.LspData.Position.t -> (string * string * string) list
+val get_completion_items : DocumentManager.state -> Lsp.LspData.Position.t -> Lsp.LspData.RankingAlgoritm.t -> (float * float) -> ((string * string * string * string) list, string) Result.t

--- a/language-server/dm/documentManager.ml
+++ b/language-server/dm/documentManager.ml
@@ -248,16 +248,6 @@ let handle_event ev st =
     let execution_state_update, events = ExecutionManager.handle_event ev st.execution_state in
     (Option.map (fun execution_state -> {st with execution_state}) execution_state_update, inject_em_events events)
 
-let unfreeze_interp_state st pos =
-  let id_of_pos pos =
-    let loc = RawDocument.loc_of_position (Document.raw_document st.document) pos in
-    match Document.find_sentence_before st.document loc with
-    | None -> None
-    | Some { id } -> Some id
-  in
-  let oid = Option.cata id_of_pos st.observe_id pos in
-  Option.iter (ExecutionManager.unfreeze_interp_state st.execution_state) oid
-
 let get_proof st pos =
   let id_of_pos pos =
     let loc = RawDocument.loc_of_position (Document.raw_document st.document) pos in

--- a/language-server/dm/documentManager.ml
+++ b/language-server/dm/documentManager.ml
@@ -248,6 +248,16 @@ let handle_event ev st =
     let execution_state_update, events = ExecutionManager.handle_event ev st.execution_state in
     (Option.map (fun execution_state -> {st with execution_state}) execution_state_update, inject_em_events events)
 
+let unfreeze_interp_state st pos =
+  let id_of_pos pos =
+    let loc = RawDocument.loc_of_position (Document.raw_document st.document) pos in
+    match Document.find_sentence_before st.document loc with
+    | None -> None
+    | Some { id } -> Some id
+  in
+  let oid = Option.cata id_of_pos st.observe_id pos in
+  Option.iter (ExecutionManager.unfreeze_interp_state st.execution_state) oid
+
 let get_proof st pos =
   let id_of_pos pos =
     let loc = RawDocument.loc_of_position (Document.raw_document st.document) pos in

--- a/language-server/dm/documentManager.ml
+++ b/language-server/dm/documentManager.ml
@@ -275,11 +275,14 @@ let get_context st pos =
   | Some sentence ->
     ExecutionManager.get_context st.execution_state sentence.id
 
-let get_lemmas st pos =
-  match get_context st pos with
-  | None -> None
-  | Some (sigma, env) -> 
-    Some (ExecutionManager.get_lemmas sigma env)
+let get_completions st pos =
+  let loc = RawDocument.loc_of_position (Document.raw_document st.document) pos in
+  match Document.find_sentence_before st.document loc with
+  | None -> Error ("Can't get completions, no sentence found before the cursor")
+  | Some sentence ->
+    match ExecutionManager.get_completions st.execution_state sentence.id with
+    | None -> Error ("Can't get completions, no sentence found before the cursor")
+    | Some lemmas -> Ok (lemmas)
 
 let parse_entry st pos entry pattern =
   let pa = Pcoq.Parsable.make (Gramlib.Stream.of_string pattern) in

--- a/language-server/dm/documentManager.mli
+++ b/language-server/dm/documentManager.mli
@@ -85,7 +85,7 @@ val unfreeze_interp_state : state -> Position.t option -> unit
 
 val get_proof : state -> Position.t option -> Proof.data option
 
-val get_lemmas : state -> Position.t -> completion_item list option
+val get_completions : state -> Position.t -> (completion_item list, string) Result.t
 
 val handle_event : event -> state -> (state option * events)
 (** handles events and returns a new state if it was updated *)

--- a/language-server/dm/documentManager.mli
+++ b/language-server/dm/documentManager.mli
@@ -81,6 +81,8 @@ val diagnostics : state -> Diagnostic.t list
 (** diagnostics [doc] returns the diagnostics corresponding to the sentences
     that have been executed in [doc]. *)
 
+val unfreeze_interp_state : state -> Position.t option -> unit
+
 val get_proof : state -> Position.t option -> Proof.data option
 
 val get_lemmas : state -> Position.t -> completion_item list option

--- a/language-server/dm/documentManager.mli
+++ b/language-server/dm/documentManager.mli
@@ -81,8 +81,6 @@ val diagnostics : state -> Diagnostic.t list
 (** diagnostics [doc] returns the diagnostics corresponding to the sentences
     that have been executed in [doc]. *)
 
-val unfreeze_interp_state : state -> Position.t option -> unit
-
 val get_proof : state -> Position.t option -> Proof.data option
 
 val get_completions : state -> Position.t -> (completion_item list, string) Result.t

--- a/language-server/dm/executionManager.ml
+++ b/language-server/dm/executionManager.ml
@@ -584,17 +584,6 @@ let get_context st id =
       lemmas |> LemmaStack.with_top ~f:Proof.get_current_context |> Option.make
     end
 
-(*
-    match find_fulfilled_opt id st.of_sentence with
-    | Some (Success (Some { interp = ist; synterp = sst })) when Option.has_some ist.lemmas ->
-      Vernacstate.Interp.unfreeze_interp_state ist;
-      Vernacstate.Synterp.unfreeze sst;
-      let proof = get_proofview st pos in
-      None
-    | _ -> log "Cannot unfreeze state";
-    None   
-*)
-
 let get_completions st id =
   let aux () = 
     match find_fulfilled_opt id st.of_sentence with

--- a/language-server/dm/executionManager.ml
+++ b/language-server/dm/executionManager.ml
@@ -531,6 +531,12 @@ let rec invalidate schedule id st =
   let deps = Scheduler.dependents schedule id in
   Stateid.Set.fold (invalidate schedule) deps { st with of_sentence }
 
+let unfreeze_interp_state st id =
+  match find_fulfilled_opt id st.of_sentence with
+  | Some (Success (Some { interp = st })) when Option.has_some st.lemmas ->
+    Vernacstate.Interp.unfreeze_interp_state st
+  | _ -> log "Cannot unfreeze state"
+
 let get_proof st id =
   match find_fulfilled_opt id st.of_sentence with
   | None -> log "Cannot find state for proof"; None

--- a/language-server/dm/executionManager.ml
+++ b/language-server/dm/executionManager.ml
@@ -585,20 +585,12 @@ let get_context st id =
     end
 
 let get_completions st id =
-  let aux () = 
-    match find_fulfilled_opt id st.of_sentence with
-    | Some (Success (Some { interp = interp_state; synterp = synterp_state })) when Option.has_some interp_state.lemmas ->
-      Vernacstate.Interp.unfreeze_interp_state interp_state;
-      Vernacstate.Synterp.unfreeze synterp_state;
-      let proof = get_proofview st id in
-      (match get_context st id with
-      | None -> None
-      | Some (sigma, env) -> 
-        let lemmas = get_lemmas sigma env in
-        Some (CompletionSuggester.get_completion_items proof lemmas !options.completion_options))
-    | _ -> None
-    in
-  Vernacstate.System.protect aux ()
+  let proof = get_proofview st id in
+  (match get_context st id with
+  | None -> None
+  | Some (sigma, env) -> 
+    let lemmas = get_lemmas sigma env in
+    Some (CompletionSuggester.get_completion_items proof lemmas !options.completion_options))
 
 module ProofWorkerProcess = struct
   type options = ProofWorker.options

--- a/language-server/dm/executionManager.ml
+++ b/language-server/dm/executionManager.ml
@@ -42,13 +42,17 @@ type delegation_mode =
 type options = {
   delegation_mode : delegation_mode;
   completion_options : Lsp.LspData.Settings.Completion.t;
+  enableDiagnostics : bool
 }
-let default_options = { 
-  delegation_mode = CheckProofsInMaster; 
+let default_options = {
+  delegation_mode = CheckProofsInMaster;
   completion_options = {
-    algorithm = StructuredSplitUnification; 
-    unificationLimit = 100
-  }
+    algorithm = StructuredSplitUnification;
+    unificationLimit = 100;
+    atomicFactor = 5.;
+    sizeFactor = 5.
+  };
+  enableDiagnostics = true;
 }
 
 let doc_id = ref (-1)
@@ -73,6 +77,7 @@ let options = ref default_options
 
 let set_options o = options := o
 let set_default_options () = options := default_options
+let is_diagnostics_enabled () = !options.enableDiagnostics
 
 type prepared_task =
   | PSkip of sentence_id

--- a/language-server/dm/executionManager.ml
+++ b/language-server/dm/executionManager.ml
@@ -538,12 +538,6 @@ let rec invalidate schedule id st =
   let deps = Scheduler.dependents schedule id in
   Stateid.Set.fold (invalidate schedule) deps { st with of_sentence }
 
-let unfreeze_interp_state st id =
-  match find_fulfilled_opt id st.of_sentence with
-  | Some (Success (Some { interp = st })) when Option.has_some st.lemmas ->
-    Vernacstate.Interp.unfreeze_interp_state st
-  | _ -> log "Cannot unfreeze state"
-
 let get_proof st id =
   match find_fulfilled_opt id st.of_sentence with
   | None -> log "Cannot find state for proof"; None
@@ -585,14 +579,32 @@ let get_context st id =
       lemmas |> LemmaStack.with_top ~f:Proof.get_current_context |> Option.make
     end
 
-let get_completions st pos =
-  unfreeze_interp_state st pos;
-  let proof = get_proofview st pos in
-  match get_context st pos with
-  | None -> None
-  | Some (sigma, env) -> 
-    let lemmas = get_lemmas sigma env in
-    Some (CompletionSuggester.get_completion_items proof lemmas !options.completion_options)
+(*
+    match find_fulfilled_opt id st.of_sentence with
+    | Some (Success (Some { interp = ist; synterp = sst })) when Option.has_some ist.lemmas ->
+      Vernacstate.Interp.unfreeze_interp_state ist;
+      Vernacstate.Synterp.unfreeze sst;
+      let proof = get_proofview st pos in
+      None
+    | _ -> log "Cannot unfreeze state";
+    None   
+*)
+
+let get_completions st id =
+  let aux () = 
+    match find_fulfilled_opt id st.of_sentence with
+    | Some (Success (Some { interp = interp_state; synterp = synterp_state })) when Option.has_some interp_state.lemmas ->
+      Vernacstate.Interp.unfreeze_interp_state interp_state;
+      Vernacstate.Synterp.unfreeze synterp_state;
+      let proof = get_proofview st id in
+      (match get_context st id with
+      | None -> None
+      | Some (sigma, env) -> 
+        let lemmas = get_lemmas sigma env in
+        Some (CompletionSuggester.get_completion_items proof lemmas !options.completion_options))
+    | _ -> None
+    in
+  Vernacstate.System.protect aux ()
 
 module ProofWorkerProcess = struct
   type options = ProofWorker.options

--- a/language-server/dm/executionManager.ml
+++ b/language-server/dm/executionManager.ml
@@ -43,7 +43,13 @@ type options = {
   delegation_mode : delegation_mode;
   completion_options : Lsp.LspData.Settings.Completion.t;
 }
-let default_options = { delegation_mode = CheckProofsInMaster; completion_options = {algorithm = StructuredSplitUnification}}
+let default_options = { 
+  delegation_mode = CheckProofsInMaster; 
+  completion_options = {
+    algorithm = StructuredSplitUnification; 
+    unificationLimit = 100
+  }
+}
 
 let doc_id = ref (-1)
 let fresh_doc_id () = incr doc_id; !doc_id

--- a/language-server/dm/executionManager.ml
+++ b/language-server/dm/executionManager.ml
@@ -41,8 +41,9 @@ type delegation_mode =
 
 type options = {
   delegation_mode : delegation_mode;
+  completion_options : Lsp.LspData.Settings.Completion.t;
 }
-let default_options = { delegation_mode = CheckProofsInMaster }
+let default_options = { delegation_mode = CheckProofsInMaster; completion_options = {algorithm = StructuredSplitUnification}}
 
 let doc_id = ref (-1)
 let fresh_doc_id () = incr doc_id; !doc_id
@@ -577,6 +578,15 @@ let get_context st id =
       let open Vernacstate in
       lemmas |> LemmaStack.with_top ~f:Proof.get_current_context |> Option.make
     end
+
+let get_completions st pos =
+  unfreeze_interp_state st pos;
+  let proof = get_proofview st pos in
+  match get_context st pos with
+  | None -> None
+  | Some (sigma, env) -> 
+    let lemmas = get_lemmas sigma env in
+    Some (CompletionSuggester.get_completion_items proof lemmas !options.completion_options)
 
 module ProofWorkerProcess = struct
   type options = ProofWorker.options

--- a/language-server/dm/executionManager.mli
+++ b/language-server/dm/executionManager.mli
@@ -26,6 +26,7 @@ type delegation_mode =
 
 type options = {
   delegation_mode : delegation_mode;
+  completion_options : Lsp.LspData.Settings.Completion.t;
 }
 
 (** Execution state, includes the cache *)
@@ -51,6 +52,7 @@ val get_proof : state -> sentence_id -> Proof.t option
 val get_proofview : state -> sentence_id -> Proof.data option
 val get_context : state -> sentence_id -> (Evd.evar_map * Environ.env) option
 val get_lemmas : Evd.evar_map -> Environ.env -> completion_item list
+val get_completions : state -> sentence_id -> completion_item list option
 
 (** Events for the main loop *)
 val handle_event : event -> state -> (state option * events)

--- a/language-server/dm/executionManager.mli
+++ b/language-server/dm/executionManager.mli
@@ -46,6 +46,7 @@ val shift_locs : state -> int -> int -> state
 val executed_ids : state -> sentence_id list
 val is_executed : state -> sentence_id -> bool
 val is_remotely_executed : state -> sentence_id -> bool
+val unfreeze_interp_state : state -> sentence_id -> unit
 val get_proof : state -> sentence_id -> Proof.t option
 val get_proofview : state -> sentence_id -> Proof.data option
 val get_context : state -> sentence_id -> (Evd.evar_map * Environ.env) option

--- a/language-server/dm/executionManager.mli
+++ b/language-server/dm/executionManager.mli
@@ -47,7 +47,6 @@ val shift_locs : state -> int -> int -> state
 val executed_ids : state -> sentence_id list
 val is_executed : state -> sentence_id -> bool
 val is_remotely_executed : state -> sentence_id -> bool
-val unfreeze_interp_state : state -> sentence_id -> unit
 val get_proof : state -> sentence_id -> Proof.t option
 val get_proofview : state -> sentence_id -> Proof.data option
 val get_context : state -> sentence_id -> (Evd.evar_map * Environ.env) option

--- a/language-server/dm/executionManager.mli
+++ b/language-server/dm/executionManager.mli
@@ -27,7 +27,10 @@ type delegation_mode =
 type options = {
   delegation_mode : delegation_mode;
   completion_options : Lsp.LspData.Settings.Completion.t;
+  enableDiagnostics : bool;
 }
+
+val is_diagnostics_enabled: unit -> bool
 
 (** Execution state, includes the cache *)
 type state

--- a/language-server/lsp/lspData.ml
+++ b/language-server/lsp/lspData.ml
@@ -58,10 +58,22 @@ module CompletionItem = struct
 
   type t = {
     label : string;
+    insertText : string option [@yojson.option];
     detail : string option [@yojson.option];
     documentation : string option [@yojson.option];
+    sortText : string option [@yojson.option];
+    filterText : string option [@yojson.option];
   } [@@deriving yojson]
 
+end
+
+module CompletionList = struct 
+
+  type t = {
+    isIncomplete : bool;
+    items : CompletionItem.t list;
+  } [@@deriving yojson]
+  
 end
 
 module Severity = struct
@@ -263,6 +275,57 @@ module VersionedTextDocumentIdentifier = struct
     uri: Uri.t;
     version: int;
   } [@@deriving yojson]
+
+end
+
+module RankingAlgoritm = struct
+
+  type t = 
+  | Basic
+  | Shuffle
+  | SimpleTypeIntersection
+  | SplitTypeIntersection
+  | StructuredTypeEvaluation
+  | StructuredUnification
+  | StructuredSplitUnification
+  | SimpleUnification
+  | SimpleSplitUnification
+  | SplitTypeUnification
+  | SplitTypeSplitUnification
+  | ShuffleUnification
+  | ShuffleSplitUnification
+  
+
+  let yojson_of_t = function
+  | Basic -> `Int 0
+  | Shuffle -> `Int 1
+  | SimpleTypeIntersection -> `Int 2
+  | SplitTypeIntersection -> `Int 3
+  | StructuredTypeEvaluation -> `Int 4
+  | StructuredUnification -> `Int 5
+  | StructuredSplitUnification -> `Int 6
+  | SimpleUnification -> `Int 7
+  | SimpleSplitUnification -> `Int 8
+  | SplitTypeUnification -> `Int 9
+  | SplitTypeSplitUnification -> `Int 10
+  | ShuffleUnification -> `Int 11
+  | ShuffleSplitUnification -> `Int 12
+
+  let t_of_yojson = function
+  | `Int 0 -> Basic
+  | `Int 1 -> Shuffle
+  | `Int 2 -> SimpleTypeIntersection
+  | `Int 3 -> SplitTypeIntersection
+  | `Int 4 -> StructuredTypeEvaluation
+  | `Int 5 -> StructuredUnification
+  | `Int 6 -> StructuredSplitUnification
+  | `Int 7 -> SimpleUnification
+  | `Int 8 -> SimpleSplitUnification
+  | `Int 9 -> SplitTypeUnification
+  | `Int 10 -> SplitTypeSplitUnification
+  | `Int 11 -> ShuffleUnification
+  | `Int 12 -> ShuffleSplitUnification
+  | _ -> Yojson.json_error @@ "invalid value "
 
 end
 

--- a/language-server/lsp/lspData.ml
+++ b/language-server/lsp/lspData.ml
@@ -266,6 +266,8 @@ module Settings = struct
     type t = {
       algorithm: RankingAlgoritm.t;
       unificationLimit: int;
+      atomicFactor: float [@default 5.]; (** Controls how highly specific types are prioritised over generics *)
+      sizeFactor: float [@default 5.]; (** Controls how highly small types are prioritised over larger ones *)
     } [@@deriving yojson] [@@yojson.allow_extra_fields]
 
   end
@@ -273,6 +275,7 @@ module Settings = struct
   type t = {
     proof: Proof.t;
     completion: Completion.t;
+    enableDiagnostics: bool [@default true]; (** Sets whether diagnostics like errors and highlighting are sent to the client at all. *)
   } [@@deriving yojson] [@@yojson.allow_extra_fields]
 
 end

--- a/language-server/lsp/lspData.ml
+++ b/language-server/lsp/lspData.ml
@@ -265,13 +265,14 @@ module Settings = struct
 
     type t = {
       algorithm: RankingAlgoritm.t;
+      unificationLimit: int;
     } [@@deriving yojson] [@@yojson.allow_extra_fields]
 
   end
 
   type t = {
     proof: Proof.t;
-    algorithm: Completion.t;
+    completion: Completion.t;
   } [@@deriving yojson] [@@yojson.allow_extra_fields]
 
 end

--- a/language-server/lsp/lspData.ml
+++ b/language-server/lsp/lspData.ml
@@ -281,50 +281,17 @@ end
 module RankingAlgoritm = struct
 
   type t = 
-  | Basic
-  | Shuffle
-  | SimpleTypeIntersection
   | SplitTypeIntersection
-  | StructuredTypeEvaluation
-  | StructuredUnification
   | StructuredSplitUnification
-  | SimpleUnification
-  | SimpleSplitUnification
-  | SplitTypeUnification
-  | SplitTypeSplitUnification
-  | ShuffleUnification
-  | ShuffleSplitUnification
   
 
-  let yojson_of_t = function
-  | Basic -> `Int 0
-  | Shuffle -> `Int 1
-  | SimpleTypeIntersection -> `Int 2
-  | SplitTypeIntersection -> `Int 3
-  | StructuredTypeEvaluation -> `Int 4
-  | StructuredUnification -> `Int 5
-  | StructuredSplitUnification -> `Int 6
-  | SimpleUnification -> `Int 7
-  | SimpleSplitUnification -> `Int 8
-  | SplitTypeUnification -> `Int 9
-  | SplitTypeSplitUnification -> `Int 10
-  | ShuffleUnification -> `Int 11
-  | ShuffleSplitUnification -> `Int 12
+  let yojson_of_t = function  
+  | SplitTypeIntersection -> `Int 0
+  | StructuredSplitUnification -> `Int 1
 
   let t_of_yojson = function
-  | `Int 0 -> Basic
-  | `Int 1 -> Shuffle
-  | `Int 2 -> SimpleTypeIntersection
-  | `Int 3 -> SplitTypeIntersection
-  | `Int 4 -> StructuredTypeEvaluation
-  | `Int 5 -> StructuredUnification
-  | `Int 6 -> StructuredSplitUnification
-  | `Int 7 -> SimpleUnification
-  | `Int 8 -> SimpleSplitUnification
-  | `Int 9 -> SplitTypeUnification
-  | `Int 10 -> SplitTypeSplitUnification
-  | `Int 11 -> ShuffleUnification
-  | `Int 12 -> ShuffleSplitUnification
+  | `Int 0 -> SplitTypeIntersection
+  | `Int 1 -> StructuredSplitUnification
   | _ -> Yojson.json_error @@ "invalid value "
 
 end

--- a/language-server/lsp/lspData.ml
+++ b/language-server/lsp/lspData.ml
@@ -244,8 +244,34 @@ module Settings = struct
 
   end
 
+  module Completion = struct
+    
+    module RankingAlgoritm = struct
+
+      type t = 
+      | SplitTypeIntersection
+      | StructuredSplitUnification
+    
+      let yojson_of_t = function  
+      | SplitTypeIntersection -> `Int 0
+      | StructuredSplitUnification -> `Int 1
+    
+      let t_of_yojson = function
+      | `Int 0 -> SplitTypeIntersection
+      | `Int 1 -> StructuredSplitUnification
+      | _ -> Yojson.json_error @@ "invalid value "
+    
+    end
+
+    type t = {
+      algorithm: RankingAlgoritm.t;
+    } [@@deriving yojson] [@@yojson.allow_extra_fields]
+
+  end
+
   type t = {
     proof: Proof.t;
+    algorithm: Completion.t;
   } [@@deriving yojson] [@@yojson.allow_extra_fields]
 
 end
@@ -275,24 +301,6 @@ module VersionedTextDocumentIdentifier = struct
     uri: Uri.t;
     version: int;
   } [@@deriving yojson]
-
-end
-
-module RankingAlgoritm = struct
-
-  type t = 
-  | SplitTypeIntersection
-  | StructuredSplitUnification
-  
-
-  let yojson_of_t = function  
-  | SplitTypeIntersection -> `Int 0
-  | StructuredSplitUnification -> `Int 1
-
-  let t_of_yojson = function
-  | `Int 0 -> SplitTypeIntersection
-  | `Int 1 -> StructuredSplitUnification
-  | _ -> Yojson.json_error @@ "invalid value "
 
 end
 

--- a/language-server/tests/em_tests.ml
+++ b/language-server/tests/em_tests.ml
@@ -23,7 +23,7 @@ let uri = Uri.make ~scheme:"file" ~path:"foo" ()
 let init text = openDoc uri ~text
 
 let set_delegation_mode mode =
-  ExecutionManager.(set_options { delegation_mode = mode; completion_options = { unificationLimit = 100; algorithm = StructuredSplitUnification} })
+  ExecutionManager.(set_options { delegation_mode = mode; completion_options = { unificationLimit = 100; algorithm = StructuredSplitUnification; atomicFactor = 5.; sizeFactor = 5. }; enableDiagnostics = true })
 
 let%test_unit "exec: finished proof" =
   let st, init_events = init "Lemma x : True. trivial. Qed. Check x." in

--- a/language-server/tests/em_tests.ml
+++ b/language-server/tests/em_tests.ml
@@ -22,6 +22,9 @@ let uri = Uri.make ~scheme:"file" ~path:"foo" ()
 
 let init text = openDoc uri ~text
 
+let set_delegation_mode mode =
+  ExecutionManager.(set_options { delegation_mode = mode; completion_options = { unificationLimit = 100; algorithm = StructuredSplitUnification} })
+
 let%test_unit "exec: finished proof" =
   let st, init_events = init "Lemma x : True. trivial. Qed. Check x." in
   let st, (s1, (s2, (s3, (s4, ())))) = dm_parse st (P(P(P(P O)))) in
@@ -36,7 +39,7 @@ let%test_unit "exec: finished proof" =
 let%test_unit "exec: finished proof skip" =
   let st, init_events = init "Lemma x : True. trivial. Qed. Check x." in
   let st, (s1, (s2, (s3, (s4, ())))) = dm_parse st (P(P(P(P O)))) in
-  ExecutionManager.(set_options { delegation_mode = SkipProofs });
+  set_delegation_mode SkipProofs;
   let st, exec_events = DocumentManager.interpret_to_end st in
   let todo = Sel.(enqueue empty init_events) in
   let todo = Sel.(enqueue todo exec_events) in
@@ -63,7 +66,7 @@ let%test_unit "exec: unfinished proof" =
 let%test_unit "exec: unfinished proof skip" =
   let st, init_events = init "Lemma x : True. Qed. Check x." in
   let st, (s1, (s2, (s3, ()))) = dm_parse st (P(P(P O))) in
-  ExecutionManager.(set_options { delegation_mode = SkipProofs });
+  set_delegation_mode SkipProofs;
   let st, exec_events = DocumentManager.interpret_to_end st in
   let todo = Sel.(enqueue empty init_events) in
   let todo = Sel.(enqueue todo exec_events) in
@@ -77,7 +80,7 @@ let%test_unit "exec: unfinished proof skip" =
 let%test_unit "exec: unfinished proof delegate" =
   let st, init_events = init "Lemma x : True. Qed. Check x." in
   let st, (s1, (s2, (s3, ()))) = dm_parse st (P(P(P O))) in
-  ExecutionManager.(set_options { delegation_mode = DelegateProofsToWorkers { number_of_workers = 1 }});
+  set_delegation_mode (DelegateProofsToWorkers { number_of_workers = 1 });
   let st, exec_events = DocumentManager.interpret_to_end st in
   let todo = Sel.(enqueue empty init_events) in
   let todo = Sel.(enqueue todo exec_events) in

--- a/language-server/vscoqtop/lspManager.ml
+++ b/language-server/vscoqtop/lspManager.ml
@@ -105,13 +105,13 @@ let inject_debug_events l =
 let do_configuration settings = 
   let open Settings in
   let open Dm.ExecutionManager in
-  let options =
+  let delegation_mode =
     match settings.proof.delegation with
-    | None     -> { delegation_mode = CheckProofsInMaster }
-    | Skip     -> { delegation_mode = SkipProofs }
-    | Delegate -> { delegation_mode = DelegateProofsToWorkers { number_of_workers = Option.get settings.proof.workers } }
+    | None     -> CheckProofsInMaster
+    | Skip     -> SkipProofs
+    | Delegate -> DelegateProofsToWorkers { number_of_workers = Option.get settings.proof.workers }
   in
-  Dm.ExecutionManager.set_options options;
+  Dm.ExecutionManager.set_options { delegation_mode; completion_options = { algorithm = LspData.Settings.Completion.RankingAlgoritm.StructuredSplitUnification }};
   check_mode := settings.proof.mode
 
 let send_configuration_request () =
@@ -276,7 +276,8 @@ let coqtopStepForward params =
   update_view uri st;
   inject_dm_events (uri,events) @ [ mk_proof_view_event uri None ]
   
-  let make_CompletionItem i (label, insertText, typ, path) : CompletionItem.t = 
+  let make_CompletionItem i item : CompletionItem.t = 
+    let (label, insertText, typ, path) = Dm.CompletionItems.pp_completion_item item in
     {
       label;
       insertText = Some insertText;
@@ -290,7 +291,7 @@ let coqtopStepForward params =
 let textDocumentCompletion ~id params =
   let Request.Client.CompletionParams.{ textDocument = { uri }; position } = params in
   let st = Hashtbl.find states (Uri.path uri) in
-  match Dm.CompletionSuggester.get_completion_items st position RankingAlgoritm.StructuredSplitUnification (5., 5.) with
+  match Dm.DocumentManager.get_completions st position with
   | Ok completionItems -> 
     let items = List.mapi make_CompletionItem completionItems in
     Ok Request.Client.CompletionResult.{isIncomplete = false; items = items;}, []

--- a/language-server/vscoqtop/lspManager.ml
+++ b/language-server/vscoqtop/lspManager.ml
@@ -111,7 +111,11 @@ let do_configuration settings =
     | Skip     -> SkipProofs
     | Delegate -> DelegateProofsToWorkers { number_of_workers = Option.get settings.proof.workers }
   in
-  Dm.ExecutionManager.set_options { delegation_mode; completion_options = settings.completion};
+  Dm.ExecutionManager.set_options {
+    delegation_mode;
+    completion_options = settings.completion;
+    enableDiagnostics = settings.enableDiagnostics
+  };
   check_mode := settings.proof.mode
 
 let send_configuration_request () =
@@ -183,8 +187,10 @@ let send_proof_view pv =
   output_jsonrpc @@ Notification Notification.Server.(jsonrpc_of_t notification)
 
 let update_view uri st =
-  send_highlights uri st;
-  publish_diagnostics uri st
+  if (Dm.ExecutionManager.is_diagnostics_enabled ()) then (
+    send_highlights uri st;
+    publish_diagnostics uri st
+  )
 
 let textDocumentDidOpen params =
   let Notification.Client.DidOpenTextDocumentParams.{ textDocument = { uri; text } } = params in

--- a/language-server/vscoqtop/lspManager.ml
+++ b/language-server/vscoqtop/lspManager.ml
@@ -111,7 +111,7 @@ let do_configuration settings =
     | Skip     -> SkipProofs
     | Delegate -> DelegateProofsToWorkers { number_of_workers = Option.get settings.proof.workers }
   in
-  Dm.ExecutionManager.set_options { delegation_mode; completion_options = { algorithm = LspData.Settings.Completion.RankingAlgoritm.StructuredSplitUnification }};
+  Dm.ExecutionManager.set_options { delegation_mode; completion_options = settings.completion};
   check_mode := settings.proof.mode
 
 let send_configuration_request () =


### PR DESCRIPTION
Here is the type-aware code completion we (@Hjaltesorgenfrei, @Jakobis and I) have made for our Master's thesis [which can be read here](https://github.com/Jakobis/vscoqComparison/blob/main/Expanding_Coq_with_Type_Aware_Code_Completion.pdf).
While we implemented 5 algorithms for our thesis, through benchmarking we found out there is not that big of a reason for keeping all of them, as they perform very similarly, and the user wouldn't know which one to use anyways. We kept the two which work best for `apply` and `rewrite` respectively, such that we can potentially improve completion by switching to the better one of them depending on what is already written.
The benchmarking was done in this repository: https://github.com/Jakobis/vscoqComparison

Closes #379