### PR TITLE
Search panel semantic problems

### DIFF
--- a/language-server/dm/documentManager.ml
+++ b/language-server/dm/documentManager.ml
@@ -303,8 +303,8 @@ let search st ~id pos pattern =
   match get_context st pos with
   | None -> [] (* TODO execute? *)
   | Some (sigma, env) ->
-    let query = parse_entry st loc (G_vernac.search_query) pattern in
-    SearchQuery.interp_search ~id env sigma query
+    let query, _r = parse_entry st loc (G_vernac.search_queries) pattern in
+    SearchQuery.interp_search ~id env sigma query 
 
 let hover st pos = 
   let opattern = RawDocument.word_at_position (Document.raw_document st.document) pos in

--- a/language-server/dm/documentManager.ml
+++ b/language-server/dm/documentManager.ml
@@ -303,8 +303,8 @@ let search st ~id pos pattern =
   match get_context st pos with
   | None -> [] (* TODO execute? *)
   | Some (sigma, env) ->
-    let query, _r = parse_entry st loc (G_vernac.search_queries) pattern in
-    SearchQuery.interp_search ~id env sigma query 
+    let query, r = parse_entry st loc (G_vernac.search_queries) pattern in
+    SearchQuery.interp_search ~id env sigma query r
 
 let hover st pos = 
   let opattern = RawDocument.word_at_position (Document.raw_document st.document) pos in

--- a/language-server/dm/searchQuery.ml
+++ b/language-server/dm/searchQuery.ml
@@ -24,6 +24,8 @@ let query_feedback : notification Sel.event =
   Sel.on_queue query_results_queue (fun x -> QueryResultNotification x)
   |> Sel.uncancellable
 
+(* TODO : remove these two functions when interp_search_restriction is 
+  added in the comSearch.mli in Coq (they're simply copied here for now) *)
 let global_module qid =
     try Nametab.full_name_module qid
     with Not_found ->  

--- a/language-server/dm/searchQuery.ml
+++ b/language-server/dm/searchQuery.ml
@@ -36,6 +36,6 @@ let interp_search ~id env sigma s =
     Queue.push { id; name; statement } query_results_queue
   in
   let no_restriction = [], true in
-  (Search.search env sigma [ComSearch.interp_search_request env Evd.(from_env env) s] no_restriction |>
+  (Search.search env sigma (List.map (ComSearch.interp_search_request env Evd.(from_env env)) s) no_restriction |>
     Search.prioritize_search) pr_search;
   [query_feedback]

--- a/language-server/dm/searchQuery.mli
+++ b/language-server/dm/searchQuery.mli
@@ -19,5 +19,5 @@ val interp_search :
   id:string ->
   Environ.env ->
   Evd.evar_map ->
-  (bool * Vernacexpr.search_request) ->
+  (bool * Vernacexpr.search_request) list ->
   notification Sel.event list

--- a/language-server/dm/searchQuery.mli
+++ b/language-server/dm/searchQuery.mli
@@ -20,4 +20,5 @@ val interp_search :
   Environ.env ->
   Evd.evar_map ->
   (bool * Vernacexpr.search_request) list ->
+  Vernacexpr.search_restriction ->
   notification Sel.event list


### PR DESCRIPTION
Fixes the problem in #524, when using the search panel command with multiple patterns. The other problem was with restrictions. This PR adds the possibility to use the arguments in/inside/outside (see : (https://coq.inria.fr/refman/proof-engine/vernacular-commands.html?highlight=search#coq:cmd.Search) for the semantics).
For now the needed function interp_search_restriction is copied because it's not available in the coq API but once it is it should be deleted here and properly called.