### PR TITLE
Rename beta version to 1.9.0

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -4,7 +4,7 @@
   "description": "VsCoq is an extension for Visual Studio Code with support for the Coq Proof Assistant",
   "publisher": "maximedenes",
   "license": "MIT",
-  "version": "2.0.0-beta1",
+  "version": "1.9.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/coq-community/vscoq.git"

--- a/flake.nix
+++ b/flake.nix
@@ -25,7 +25,7 @@
       ocamlPackages.buildDunePackage {
         duneVersion = "3";
         pname = "vscoq-language-server";
-        version = "2.0.0-beta1";
+        version = "1.9.0";
         src = ./language-server;
         buildInputs = [
           coq

--- a/language-server/vscoqtop/lspManager.ml
+++ b/language-server/vscoqtop/lspManager.ml
@@ -38,7 +38,7 @@ let conf_request_id = 3456736879
 
 let server_info = ServerInfo.{
   name = "vscoq-language-server";
-  version = "2.0.0";
+  version = "1.9.0";
 } 
 
 type lsp_event = 


### PR DESCRIPTION
The vscode marketplace does not support -betaX suffixes, so we have to use a regular version number to denote the beta release series.