### PR TITLE
Adapt to Coq PR #17987 which adds sigma to the API of search functions

### DIFF
--- a/language-server/dm/completionSuggester.ml
+++ b/language-server/dm/completionSuggester.ml
@@ -418,10 +418,10 @@ let get_completion_items env proof lemmas options =
 let get_lemmas sigma env =
   let open CompletionItems in
   let results = ref [] in
-  let display ref _kind env c =
+  let display ref _kind env sigma c =
     results := mk_completion_item sigma ref env c :: results.contents;
   in
-  Search.generic_search env display;
+  Search.generic_search env sigma display;
   results.contents
 
 let get_completions options st =

--- a/language-server/dm/searchQuery.ml
+++ b/language-server/dm/searchQuery.ml
@@ -24,18 +24,18 @@ let query_feedback : notification Sel.event =
   |> Sel.uncancellable
 
 let interp_search ~id env sigma s r =
-  let pr_search ref _kind env c =
+  let pr_search ref _kind env sigma c =
     let pr = pr_global ref in
     let open Impargs in
     let impls = implicits_of_global ref in
     let impargs = select_stronger_impargs impls in
     let impargs = List.map binding_kind_of_status impargs in
-    let pc = pr_ltype_env env Evd.(from_env env) ~impargs c in
+    let pc = pr_ltype_env env sigma ~impargs c in
     let name = Pp.string_of_ppcmds pr in
     let statement = Pp.string_of_ppcmds pc in
     Queue.push { id; name; statement } query_results_queue
   in
   let r = ComSearch.interp_search_restriction r in
-  (Search.search env sigma (List.map (ComSearch.interp_search_request env Evd.(from_env env)) s) r |>
+  (Search.search env sigma (List.map (ComSearch.interp_search_request env sigma) s) r |>
     Search.prioritize_search) pr_search;
   [query_feedback]


### PR DESCRIPTION
The Coq PR is to fix #17963: sigma has to be passed to search functions.

It has to be merged synchronously with coq/coq#17987.

Thanks in advance.