### PR TITLE
[VsCoq1] Fix IP issue with VS Code 1.82.0

### DIFF
--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -13,12 +13,17 @@ import * as coqproto from './protocol';
 import {Settings} from './protocol';
 import {CoqProject} from './CoqProject';
 import { RouteId } from './coqtop/coq-proto';
+import { setDefaultResultOrder } from 'dns';
 
 // Create a connection for the server. The connection uses 
 // stdin / stdout for message passing
 export let connection: IConnection = createConnection();
 
 export let project : CoqProject = null;
+
+// Tell node to prefer ipv4, this is necessary due to changes in node 18.x
+// since coqidetop and coqtop does not support ipv6
+setDefaultResultOrder('ipv4first');
 
 // // Create a simple text document manager. The text document manager
 // // supports full document sync only


### PR DESCRIPTION
In VS Code 1.82.0 ipv6 is preferred during DNS resolution which is problematic since coqidetop only works with ipv4.
This patch should make VsCoq1 work with VS Code 1.82.0

Fixes #613 