### PR TITLE
[VsCoq1] Fix #278: pass correct `-topfile` argument

### DIFF
--- a/package.json
+++ b/package.json
@@ -869,6 +869,7 @@
     "vscode-jsonrpc": "^4.0.0",
     "vscode-languageclient": "^5.2.1",
     "vscode-languageserver": "^5.2.1",
+    "vscode-uri": "3.0.7",
     "ws": "^7.4.6"
   }
 }


### PR DESCRIPTION
This also allows stepping through unsaved files; before this patch, we passed `-topfile untitled:Untitled-1`, which failed with:

```
coqtop-stderr: Error: Invalid character ':' in identifier "untitled:Untitled-1".
```
