### PR TITLE
[VsCoq2] Added an explicit dependency on "jsonrpc"

### DIFF
--- a/language-server/vscoq-language-server.opam
+++ b/language-server/vscoq-language-server.opam
@@ -25,7 +25,7 @@ depends: [
   "ppx_yojson_conv"
   "ppx_import"
   "lsp"
-  "jsonrpc" { >= "1.16.2"}
+  "jsonrpc" { >= "1.12"}
   "sel" {>= "0.4.0"}
 ]
 synopsis: "VSCoq language server"

--- a/language-server/vscoq-language-server.opam
+++ b/language-server/vscoq-language-server.opam
@@ -25,6 +25,7 @@ depends: [
   "ppx_yojson_conv"
   "ppx_import"
   "lsp"
+  "jsonrpc" { >= "1.16.2"}
   "sel" {>= "0.4.0"}
 ]
 synopsis: "VSCoq language server"


### PR DESCRIPTION
- Added an explicit dependency on "jsonrpc" to resolve an error in [Opam-CI](https://opam.ci.ocaml.org/github/ocaml/opam-repository/commit/cf98a90438cfc279e2b04ce9f73ae43cb1ee758e/variant/compilers,5.1,vscoq-language-server.2.0.0+coq8.18,lower-bounds)