### PR TITLE
Add better error message.

### DIFF
--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -51,19 +51,25 @@ export function activate(context: ExtensionContext) {
             switch(err.status) {
 
                 case ToolChainErrorCode.notFound: 
-                    window.showErrorMessage(err.message, {title: "Install the VsCoq language server", id: 0})
+                    window.showErrorMessage(err.message, {title: "Install the VsCoq language server", id: 0}, {title: "Downgrade to VsCoq 0.3.9", id: 1})
                     .then(act => {
                         if(act?.id === 0) {
                             commands.executeCommand("vscode.open", Uri.parse('https://github.com/coq-community/vscoq#installing-the-language-server'));
+                        }
+                        if(act?.id === 1) {
+                            commands.executeCommand("vscode.open", Uri.parse('https://github.com/coq-community/vscoq#problems-with-vscoq-2'));
                         }
                     });
                     break;
 
                 case ToolChainErrorCode.launchError: 
-                    window.showErrorMessage(err.message, {title: "Get Coq", id: 0})
+                    window.showErrorMessage(err.message, {title: "Get Coq", id: 0}, {title: "Downgrade to VsCoq 0.3.9", id: 1})
                     .then(act => {
                         if(act?.id === 0) {
                             commands.executeCommand("vscode.open", Uri.parse('https://coq.inria.fr/download'));
+                        }
+                        if(act?.id === 1) {
+                            commands.executeCommand("vscode.open", Uri.parse('https://github.com/coq-community/vscoq#problems-with-vscoq-2'));
                         }
                         
                     });

--- a/client/src/utilities/toolchain.ts
+++ b/client/src/utilities/toolchain.ts
@@ -9,7 +9,8 @@ import Client from '../client';
 
 export enum ToolChainErrorCode {
     notFound = 1, 
-    launchError = 2
+    launchError = 2,
+    coqVersionMissmatch = 3
 }
 
 export interface ToolchainError {
@@ -45,7 +46,7 @@ export default class VsCoqToolchainManager implements Disposable {
                     Client.writeToVscoq2Channel("[Toolchain] Did not find vscoqtop path");
                     reject({
                         status: ToolChainErrorCode.notFound, 
-                        message: "VsCoq couldn't launch because no language server was found."
+                        message: "VsCoq couldn't launch because no language server was found.  If you have Coq 8.17 or lower please downgrade to VsCoq 0.3.9."
                     });
                 }
             });
@@ -109,8 +110,8 @@ export default class VsCoqToolchainManager implements Disposable {
                 if(error) {
                     reject({
                         status: ToolChainErrorCode.launchError, 
-                        message: `${this._vscoqtopPath} crashed with the following message: ${stderr}\n
-                        This could be due to a bad coq installation.`
+                        message: `${this._vscoqtopPath} crashed with the following message: ${stderr}
+                        This could be due to a bad coq installation. If you have Coq 8.17 or lower please downgrade to VsCoq 0.3.9`
                     });
                 } else {
                     resolve();

--- a/client/src/utilities/versioning.ts
+++ b/client/src/utilities/versioning.ts
@@ -11,8 +11,8 @@ export const checkVersion = (client: Client, context: ExtensionContext) => {
         if(serverInfo !== undefined) {
             const {name, version} = serverInfo;
             Client.writeToVscoq2Channel("[Versioning] Intialized server " + name + " [" + version + "]");
-            if(extensionVersion !== version) {
-                window.showErrorMessage('This version of VsCoq requires version ' + extensionVersion + ' of ' + name);
+            if(!checkCompat(extensionVersion, version)) {
+                window.showErrorMessage('This version of VsCoq requires version ' + versionRequirements[extensionVersion] + ' of ' + name + '. Found version: ' + version);
             }
         } else {
             Client.writeToVscoq2Channel("Could not run compatibility tests: failed to get serverInfo");
@@ -23,12 +23,19 @@ export const checkVersion = (client: Client, context: ExtensionContext) => {
 
 };
 
+type VersionReq = {
+    [index: string]: string
+};
+
+const versionRequirements : VersionReq = {
+    '2.0.0': '2.0.0', 
+    '2.0.1': '2.0.0'
+};
+
 //We will add version ranges as we start releasing
 const checkCompat = (clientVersion: string, serverVersion: string|undefined) => {
     if(serverVersion !== undefined) {
-        if(compareVersions(clientVersion, '1.0.0') >= 1) {
-            return compareVersions(serverVersion, '1.0.0') >= 1;
-        }
+        return compareVersions(serverVersion, versionRequirements[clientVersion]) >= 0;
     }
     return false;
 };

--- a/flake.lock
+++ b/flake.lock
@@ -8,16 +8,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1691055276,
-        "narHash": "sha256-TmV0lzfzhpSnBoVyfTfVFUyBrXpUWSnyN1Le7b8IPTs=",
+        "lastModified": 1694096282,
+        "narHash": "sha256-WhiBs4nzPHQ0R24xAdM49kmxSCPOxiOVMA1iiMYunz4=",
         "owner": "coq",
         "repo": "coq",
-        "rev": "94523eefeae0c7acafaa42ccee2d6a6c01eedb26",
+        "rev": "f022d5d194cb42c2321ea91cecbcce703a9bcad3",
         "type": "github"
       },
       "original": {
         "owner": "coq",
-        "ref": "V8.18+rc1",
+        "ref": "V8.18.0",
         "repo": "coq",
         "type": "github"
       }


### PR DESCRIPTION
The error message now points to instructions on how to install vscoq 0.3.9 if the user has an older version of Coq.