### PR TITLE
VsCoq downgrade message

### DIFF
--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -52,7 +52,7 @@ export function activate(context: ExtensionContext) {
             switch(err.status) {
 
                 case ToolChainErrorCode.notFound: 
-                    window.showErrorMessage(err.message, {title: "Install the VsCoq language server", id: 0}, {title: "Downgrade to VsCoq 0.3.9", id: 1})
+                    window.showErrorMessage("No language server found", {modal: true, detail: err.message}, {title: "Install the VsCoq language server (Recommended for Coq >= 8.18)", id: 0}, {title: "Install VsCoq Legacy (Required for Coq <= 8.17)", id: 1})
                     .then(act => {
                         if(act?.id === 0) {
                             commands.executeCommand("vscode.open", Uri.parse('https://github.com/coq-community/vscoq#installing-the-language-server'));
@@ -64,7 +64,7 @@ export function activate(context: ExtensionContext) {
                     break;
 
                 case ToolChainErrorCode.launchError: 
-                    window.showErrorMessage(err.message, {title: "Get Coq", id: 0}, {title: "Downgrade to VsCoq 0.4.0", id: 1})
+                    window.showErrorMessage("Could not launch language server", {modal: true, detail: err.message}, {title: "Get Coq", id: 0}, {title: "Install VsCoq Legacy (Required for Coq <= 8.17)", id: 1})
                     .then(act => {
                         if(act?.id === 0) {
                             commands.executeCommand("vscode.open", Uri.parse('https://coq.inria.fr/download'));

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -78,6 +78,26 @@ export function activate(context: ExtensionContext) {
             }
         }
     );
+    
+    // Detect if vscoq1 is installed and active
+    const vscoq1 = extensions.getExtension("coq-community.vscoq1");
+    if (vscoq1) {
+        if (vscoq1.isActive) {
+            const message = "VsCoq2 is incompatible with VsCoq1 it is recommended that you disable one of them.";
+            window.showErrorMessage(message, { title: "Disable VsCoq1", id: 0 }, { title: "Disable VsCoq2", id: 1 })
+                .then(act => {
+                    if (act?.id === 0) {
+                        commands.executeCommand("extension.open", "coq-community.vscoq1");
+                    }
+                    if (act?.id === 1) {
+                        commands.executeCommand("extension.open", "maximedenes.vscoq");
+                    }
+
+                });
+        }
+    }
+
+
 
     function registerVscoqTextCommand(command: string, callback: (textEditor: TextEditor, ...args: any[]) => void) {
         context.subscriptions.push(commands.registerTextEditorCommand('extension.coq.' + command, callback));

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -5,7 +5,8 @@ import {workspace, window, commands, ExtensionContext,
   ViewColumn,
   TextEditorRevealType,
   Selection,
-  Uri
+  Uri,
+  extensions
 } from 'vscode';
 
 import {
@@ -56,20 +57,20 @@ export function activate(context: ExtensionContext) {
                         if(act?.id === 0) {
                             commands.executeCommand("vscode.open", Uri.parse('https://github.com/coq-community/vscoq#installing-the-language-server'));
                         }
-                        if(act?.id === 1) {
-                            commands.executeCommand("vscode.open", Uri.parse('https://github.com/coq-community/vscoq#problems-with-vscoq-2'));
+                        if (act?.id === 1) {
+                            commands.executeCommand("extension.open", "coq-community.vscoq1");
                         }
                     });
                     break;
 
                 case ToolChainErrorCode.launchError: 
-                    window.showErrorMessage(err.message, {title: "Get Coq", id: 0}, {title: "Downgrade to VsCoq 0.3.9", id: 1})
+                    window.showErrorMessage(err.message, {title: "Get Coq", id: 0}, {title: "Downgrade to VsCoq 0.4.0", id: 1})
                     .then(act => {
                         if(act?.id === 0) {
                             commands.executeCommand("vscode.open", Uri.parse('https://coq.inria.fr/download'));
                         }
-                        if(act?.id === 1) {
-                            commands.executeCommand("vscode.open", Uri.parse('https://github.com/coq-community/vscoq#problems-with-vscoq-2'));
+                        if (act?.id === 1) {
+                            commands.executeCommand("extension.open", "coq-community.vscoq1");
                         }
                         
                     });

--- a/client/src/utilities/toolchain.ts
+++ b/client/src/utilities/toolchain.ts
@@ -46,7 +46,7 @@ export default class VsCoqToolchainManager implements Disposable {
                     Client.writeToVscoq2Channel("[Toolchain] Did not find vscoqtop path");
                     reject({
                         status: ToolChainErrorCode.notFound, 
-                        message: "VsCoq couldn't launch because no language server was found.  If you have Coq 8.17 or lower please downgrade to VsCoq 0.3.9."
+                        message: "VsCoq couldn't launch because no language server was found. You can install the language server (requires Coq 8.18 or higher) or use VsCoq Legacy."
                     });
                 }
             });
@@ -111,7 +111,7 @@ export default class VsCoqToolchainManager implements Disposable {
                     reject({
                         status: ToolChainErrorCode.launchError, 
                         message: `${this._vscoqtopPath} crashed with the following message: ${stderr}
-                        This could be due to a bad coq installation. If you have Coq 8.17 or lower please downgrade to VsCoq 0.3.9`
+                        This could be due to a bad Coq or installation or an incompatible Coq version.`
                     });
                 } else {
                     resolve();


### PR DESCRIPTION
Now that VsCoq 1 & 2 are different extensions on the marketplace it makes sense to point users directly to the installation page for VsCoq 1 in the error message.

Furthermore, it is now possible that both extension can be installed at the same time which is problematic. This PR attempts to detect if both extensions are enabled and warn the user that they should disable one of them.