### PR TITLE
Adapt to Coq PR #18007: Proof_using.definition_using takes names of fixpoints being built

### DIFF
--- a/language-server/dm/executionManager.ml
+++ b/language-server/dm/executionManager.ml
@@ -188,8 +188,10 @@ let interp_qed_delayed ~proof_using ~state_id ~st =
       let env = Global.env () in
       let sigma, _ = Declare.Proof.get_current_context proof in
       let initial_goals pf = Proofview.initial_goals Proof.((data pf).entry) in
-      let terms = List.map (fun (_,_,x) -> x) (initial_goals (Declare.Proof.get proof)) in
-      let using = Proof_using.definition_using env sigma ~using:proof_using ~terms in
+      let initial_goals_pf = initial_goals (Declare.Proof.get proof) in
+      let terms = List.map (fun (_,_,x) -> x) initial_goals_pf in
+      let names = List.map (fun (id,_,_) -> id) initial_goals_pf in
+      let using = Proof_using.definition_using env sigma ~fixnames:names ~using:proof_using ~terms in
       let vars = Environ.named_context env in
       Names.Id.Set.iter (fun id ->
           if not (List.exists Util.(Context.Named.Declaration.get_id %> Names.Id.equal id) vars) then


### PR DESCRIPTION
This PR is to adapt to Coq [PR #18007](https://github.com/coq/coq/pull/18007). Its purpose is to ensure that the kernel does not receive names that are not available in the section.

When building fixpoints, the named context contains the name of the fixpoints being built (not sure this is a good way to do but it is how it is done now). So, we need to tell Proof_using.definition_using to exclude these variables.

I attempted a quick fix for vscoq which is to send to definition_using all the names of proofs being under construction (which are in the LemmaStack iiuc). This is a priori a superset of what is expected by Proof_using.definition_using, but I guess this should do the job.

Don't hesitate to propose another fix.

In any case, this is to be merged synchronously with coq/coq#18007.