### PR TITLE
Add support for multiple byte UTF-8 characters

### DIFF
--- a/language-server/dm/rawDocument.ml
+++ b/language-server/dm/rawDocument.ml
@@ -29,13 +29,41 @@ let create text = { text; lines = compute_lines text }
 
 let text t = t.text
 
+let line_text raw i =
+  if i + 1 < Array.length raw.lines then
+    String.sub raw.text (raw.lines.(i)) (raw.lines.(i+1) - raw.lines.(i))
+  else
+    String.sub raw.text (raw.lines.(i)) (String.length raw.text - raw.lines.(i))
+
+let get_character_pos linestr loc =
+  let rec get_pos i p =
+    if i >= loc then
+      p
+    else
+      let char = String.get_utf_8_uchar linestr i in
+      get_pos (i + Uchar.utf_decode_length char) (p + 1) in
+  get_pos 0 0 
+
 let position_of_loc raw loc =
   let i = ref 0 in
   while (!i < Array.length raw.lines && raw.lines.(!i) <= loc) do incr(i) done;
-  Position.{ line = !i - 1; character = loc - raw.lines.(!i - 1) }
+  let line = !i - 1 in
+  let char = get_character_pos (line_text raw line) (loc - raw.lines.(line)) in
+  Position.{ line = line; character = char }
+
+let get_character_loc linestr character =
+  let rec get_loc i todo =
+    if todo = 0 then
+      i
+    else
+      let char = String.get_utf_8_uchar linestr i in
+      get_loc (i + Uchar.utf_decode_length char) (todo - 1) in
+  get_loc 0 character
 
 let loc_of_position raw Position.{ line; character } =
-  raw.lines.(line) + character
+  let linestr = line_text raw line in
+  let charloc = get_character_loc linestr character in
+  raw.lines.(line) + charloc
 
 let end_loc raw =
   String.length raw.text


### PR DESCRIPTION
Positions in LSP are defined as positions in UTF-8 (or 16) characters, rather than number of bytes. This causes issues when converting from positions to locations and back when using longer symbols, such as `Φ`. In lines with such symbols, the last tactic could not be interpreted to correctly (when using the cursor).

This changes the conversion from location to position and position to location in order to keep track of the length of UTF-8 characters.