### PR TITLE
Improve hover provider

### DIFF
--- a/language-server/dm/document.ml
+++ b/language-server/dm/document.ml
@@ -142,6 +142,18 @@ let find_sentence_after parsed loc =
   | Some (_, sentence) -> Some sentence
   | _ -> None
 
+let find_next_qed (parsed : document) loc =
+  let exception Found of sentence in
+  let f k sentence =
+    if loc <= k then
+    match sentence.ast.classification with
+    | VtQed _ -> raise (Found sentence)
+    | _ -> () in
+  (* We can't use find_first since f isn't monotone *)
+  match LM.iter f parsed.sentences_by_end with
+  | () -> None
+  | exception (Found n) -> Some n
+
 let get_first_sentence parsed = 
   Option.map snd @@ LM.find_first_opt (fun _ -> true) parsed.sentences_by_end
 

--- a/language-server/dm/document.ml
+++ b/language-server/dm/document.ml
@@ -142,7 +142,7 @@ let find_sentence_after parsed loc =
   | Some (_, sentence) -> Some sentence
   | _ -> None
 
-let find_next_qed (parsed : document) loc =
+let find_next_qed parsed loc =
   let exception Found of sentence in
   let f k sentence =
     if loc <= k then

--- a/language-server/dm/document.mli
+++ b/language-server/dm/document.mli
@@ -78,6 +78,9 @@ val find_sentence_before : document -> int -> sentence option
 val find_sentence_after : document -> int -> sentence option
 (** [find_sentence_after pos loc] finds the first sentence after the loc *)
 
+val find_next_qed : document -> int -> sentence option
+(** [find_next_qed parsed loc] finds the next proof end *)
+
 val get_first_sentence : document  -> sentence option
 (** [get_first_sentence doc] returns the first parsed sentence *)
 

--- a/language-server/dm/documentManager.ml
+++ b/language-server/dm/documentManager.ml
@@ -404,7 +404,12 @@ let hover st pos =
     log ("hover: found word at cursor: " ^ pattern);
     let loc = RawDocument.loc_of_position (Document.raw_document st.document) pos in
     match hover st loc pattern (get_context st pos) with
-    | None -> hover st loc pattern (get_next_context st pos) (* Try*)
+    | None -> 
+      (* No hover was found using context at the start of a the sentence,
+         In case of definition, this may be because we are hovering on things
+         that aren't yet defined. Try to get hover using context at the end of
+         the sentence *)
+      hover st loc pattern (get_next_context st pos)
     | x -> x
 
 let check st pos ~pattern =

--- a/language-server/language/hover.ml
+++ b/language-server/language/hover.ml
@@ -224,7 +224,7 @@ let ref_info env _sigma ref udecl =
   let path = Libnames.pr_path (Nametab.path_of_global ref) ++ canonical_name_info ref in
   let args = print_arguments ref in
   let args = if Pp.ismt args then [] else ["**Args:** " ^ (Pp.string_of_ppcmds (print_arguments ref))] in
-  String.concat "\n" @@ [md_code_block @@ compactify @@ Pp.string_of_ppcmds typ]@args@
+  String.concat "\n\n---\n\n" @@ [md_code_block @@ compactify @@ Pp.string_of_ppcmds typ]@args@
   [Format.sprintf "**%s** %s" (pr_globref_kind ref) (Pp.string_of_ppcmds path)]
 
 let mod_info mp =


### PR DESCRIPTION
Small PR that changes the hover provider a bit:
- Add a newline and a horizontal separator between arg and path section in hover
- Fix hover not appearing at definition sites. Hover now proceeds as follows
    - try getting hover in the context at the start of the current sentence
    - if that fails, try getting hover in the context of the next sentence (newly defined symbols)
    - if that fails, and the next sentence is in proof mode, try using context at next QED (for lemmas and anything defined with tactics).