### PR TITLE
Fix message panel colors

### DIFF
--- a/client/goal-view-ui/src/components/atoms/PpString.module.css
+++ b/client/goal-view-ui/src/components/atoms/PpString.module.css
@@ -13,11 +13,11 @@
 }
 
 .Info {
-    color: var(--vscode-editorInfo-background);
+    color: var(--vscode-editorInfo-foreground);
 }
 
 .Hint {
-    color: var(--vscode-editorInlayHint-background);
+    color: var(--vscode-editorInlayHint-foreground);
 }
 
 .Goal {


### PR DESCRIPTION
I've run into an issue when using VsCoq with a [custom theme](https://github.com/dlesbre/vscode-embers): most of the text in the Search panel (in the proof view) was black on black.

For some reason, this color is set to `editorInfo.background`, which is what was causing the issue (the background color being set to almost full transparency).

I fixed it to use `editorInfo.foreground` instead, and fixed a similar line for type hints. Note that the Search command itself still renders using `editorInfo.background` with this fix.

The issue doesn't crop up with most themes since they don't define `editorInfo.background` so the CSS probably inherits from parent elements that use `editor.foreground`.

