### PR TITLE
Coq 8.19

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
   workflow_dispatch:
 
+env:
+  PIN_COQ: fbaea89860348ca2b2ca485e52df7215bea27746 # Should be kept in sync with input in flake.nix
+
 jobs:
   build-extension:
     strategy:
@@ -130,6 +133,13 @@ jobs:
       uses: avsm/setup-ocaml@v2
       with:
         ocaml-compiler: ${{ matrix.ocaml-compiler }}
+
+    - name: Pin Coq
+      env:
+        OPAMYES: true
+      run: |
+        opam pin add coq-core.dev "https://github.com/coq/coq.git#$PIN_COQ"
+        opam pin add coq-stdlib.dev "https://github.com/coq/coq.git#$PIN_COQ"
 
     - name: Install deps
       env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         ocaml-compiler: [4.13.x]
+        coq: [8.18.0, 8.19+rc1]
     runs-on: ${{ matrix.os }}
     steps:
     - name: Checkout
@@ -73,6 +74,7 @@ jobs:
         OPAMYES: true
       run: |
         opam repo add coq-core-dev https://coq.inria.fr/opam/core-dev
+        opam pin add coq-core.${{ matrix.coq }}
         opam pin add vscoq-language-server ./language-server/ --with-doc --with-test -y
 
     - run: |

--- a/flake.lock
+++ b/flake.lock
@@ -8,17 +8,29 @@
         ]
       },
       "locked": {
+<<<<<<< HEAD
         "lastModified": 1694096282,
         "narHash": "sha256-WhiBs4nzPHQ0R24xAdM49kmxSCPOxiOVMA1iiMYunz4=",
         "owner": "coq",
         "repo": "coq",
         "rev": "f022d5d194cb42c2321ea91cecbcce703a9bcad3",
+=======
+        "lastModified": 1692621436,
+        "narHash": "sha256-fLkFHuL8vu4v7Oc9v2701d7pVM/eS/7mCJTEuAFfksA=",
+        "owner": "coq",
+        "repo": "coq",
+        "rev": "fbaea89860348ca2b2ca485e52df7215bea27746",
+>>>>>>> coq-master
         "type": "github"
       },
       "original": {
         "owner": "coq",
+<<<<<<< HEAD
         "ref": "V8.18.0",
+=======
+>>>>>>> coq-master
         "repo": "coq",
+        "rev": "fbaea89860348ca2b2ca485e52df7215bea27746",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -5,6 +5,7 @@
 
     flake-utils.url = "github:numtide/flake-utils";
 
+<<<<<<< HEAD
     coq-8_18 = {
       type = "github";
       owner = "coq";
@@ -13,6 +14,10 @@
     };
 
     coq-8_18.inputs.nixpkgs.follows = "nixpkgs";
+=======
+    coq-master = { url = "github:coq/coq/fbaea89860348ca2b2ca485e52df7215bea27746"; }; # Should be kept in sync with PIN_COQ in CI workflow
+    coq-master.inputs.nixpkgs.follows = "nixpkgs";
+>>>>>>> coq-master
 
   };
 

--- a/language-server/build-windows-platform.bat
+++ b/language-server/build-windows-platform.bat
@@ -31,9 +31,9 @@ call coq_platform_make_windows.bat ^
   -jobs=2 ^
   -switch=d ^
   -set-switch=y ^
-  -override-dev-pkg="coq-core=https://github.com/coq/coq/archive/%COQ_VERSION%.tar.gz" ^
-  -override-dev-pkg="coq-stdlib=https://github.com/coq/coq/archive/%COQ_VERSION%.tar.gz" ^
-  -override-dev-pkg="coq=https://github.com/coq/coq/archive/%COQ_VERSION%.tar.gz" ^
+  -override-dev-pkg="coq-core=https://github.com/coq/coq/archive/%PIN_COQ%.tar.gz" ^
+  -override-dev-pkg="coq-stdlib=https://github.com/coq/coq/archive/%PIN_COQ%.tar.gz" ^
+  -override-dev-pkg="coq=https://github.com/coq/coq/archive/%PIN_COQ%.tar.gz" ^
   || GOTO ErrorExit
 
 SET OPAMYES=yes

--- a/language-server/dm/completionSuggester.ml
+++ b/language-server/dm/completionSuggester.ml
@@ -418,10 +418,10 @@ let get_completion_items env proof lemmas options =
 let get_lemmas sigma env =
   let open CompletionItems in
   let results = ref [] in
-  let display ref _kind env c =
+  let display ref _kind env sigma c =
     results := mk_completion_item sigma ref env c :: results.contents;
   in
-  Search.generic_search env display;
+  Search.generic_search env sigma display;
   results.contents
 
 let get_completions options st =

--- a/language-server/dm/document.ml
+++ b/language-server/dm/document.ml
@@ -290,7 +290,7 @@ let rec parse_more synterp_state stream raw parsed errors =
           let loc = Loc.get_loc @@ info in
           handle_parse_error start (loc, Pp.string_of_ppcmds @@ CErrors.iprint_no_report (e,info))
         end
-    | exception (Stream.Error msg as exn) ->
+    | exception (Grammar.Error msg as exn) ->
       let loc = Loc.get_loc @@ Exninfo.info exn in
       junk_sentence_end stream;
       handle_parse_error start (loc,msg)

--- a/language-server/dm/dune
+++ b/language-server/dm/dune
@@ -2,6 +2,7 @@
  (name dm)
  (public_name vscoq-language-server.dm)
  (modules :standard \ vscoqtop_proof_worker vscoqtop_tactic_worker)
+ (preprocess (pps ppx_optcomp -- -cookie "ppx_optcomp.env=env ~coq:(Defined \"%{coq:version.major}.%{coq:version.minor}\")"))
  (libraries base coq-core.sysinit coq-core.vernac coq-core.parsing lsp sel protocol language))
 
 (executable

--- a/language-server/dm/executionManager.ml
+++ b/language-server/dm/executionManager.ml
@@ -183,13 +183,15 @@ let interp_ast ~doc_id ~state_id ~st ~error_recovery ast =
 
 (* This adapts the Future API with our event model *)
 let interp_qed_delayed ~proof_using ~state_id ~st =
+  let lemmas = Option.get @@ st.Vernacstate.interp.lemmas in
   let f proof =
     let proof =
       let env = Global.env () in
       let sigma, _ = Declare.Proof.get_current_context proof in
       let initial_goals pf = Proofview.initial_goals Proof.((data pf).entry) in
       let terms = List.map (fun (_,_,x) -> x) (initial_goals (Declare.Proof.get proof)) in
-      let using = Proof_using.definition_using env sigma ~using:proof_using ~terms in
+      let names = Vernacstate.LemmaStack.get_all_proof_names lemmas in
+      let using = Proof_using.definition_using env sigma ~fixnames:names ~using:proof_using ~terms in
       let vars = Environ.named_context env in
       Names.Id.Set.iter (fun id ->
           if not (List.exists Util.(Context.Named.Declaration.get_id %> Names.Id.equal id) vars) then
@@ -202,7 +204,6 @@ let interp_qed_delayed ~proof_using ~state_id ~st =
     let f, assign = Future.create_delegate ~blocking:false ~name:"XX" fix_exn in
     Declare.Proof.close_future_proof ~feedback_id:state_id proof f, assign
   in
-  let lemmas = Option.get @@ st.Vernacstate.interp.lemmas in
   let proof, assign = Vernacstate.LemmaStack.with_top lemmas ~f in
   let control = [] (* FIXME *) in
   let opaque = Vernacexpr.Opaque in

--- a/language-server/dm/searchQuery.ml
+++ b/language-server/dm/searchQuery.ml
@@ -15,8 +15,7 @@ open Util
 open Printer
 open Protocol.Printing
 open Protocol.LspWrapper
-open Vernacexpr
-open Pp
+
 (* Note: this queue is not very useful today, as we process results in the main
 vscoq process, which does not allow for real asynchronous processing of results. *)
 let query_results_queue = Queue.create ()
@@ -24,30 +23,19 @@ let query_results_queue = Queue.create ()
 let query_feedback : notification Sel.Event.t =
   Sel.On.queue query_results_queue (fun x -> QueryResultNotification x)
 
-(* TODO : remove these two functions when interp_search_restriction is 
-  added in the comSearch.mli in Coq (they're simply copied here for now) *)
-let global_module qid =
-    try Nametab.full_name_module qid
-    with Not_found ->  
-      CErrors.user_err ?loc:qid.CAst.loc
-       (str "Module/Section " ++ Ppconstr.pr_qualid qid ++ str " not found.")
-let interp_search_restriction = function
-  | SearchOutside l -> (List.map global_module l, true)
-  | SearchInside l -> (List.map global_module l, false)
-
 let interp_search ~id env sigma s r =
-  let pr_search ref _kind env c =
-    let name = pr_global ref in
+  let pr_search ref _kind env sigma c =
+    let pr = pr_global ref in
     let open Impargs in
     let impls = implicits_of_global ref in
     let impargs = select_stronger_impargs impls in
     let impargs = List.map binding_kind_of_status impargs in
-    let statement = pr_ltype_env env Evd.(from_env env) ~impargs c in
-    let name = pp_of_coqpp name in
-    let statement = pp_of_coqpp statement in
+    let pc = pr_ltype_env env sigma ~impargs c in
+    let name = pp_of_coqpp pr in
+    let statement = pp_of_coqpp pc in
     Queue.push { id; name; statement } query_results_queue
   in
-  let r = interp_search_restriction r in
-  (Search.search env sigma (List.map (ComSearch.interp_search_request env Evd.(from_env env)) s) r |>
+  let r = ComSearch.interp_search_restriction r in
+  (Search.search env sigma (List.map (ComSearch.interp_search_request env sigma) s) r |>
     Search.prioritize_search) pr_search;
   [query_feedback]

--- a/language-server/dm/searchQuery.mli
+++ b/language-server/dm/searchQuery.mli
@@ -20,5 +20,5 @@ val interp_search :
   Environ.env ->
   Evd.evar_map ->
   (bool * Vernacexpr.search_request) list ->
-  Vernacexpr.search_restriction ->
+  Libnames.qualid list Vernacexpr.search_restriction ->
   notification Sel.Event.t list

--- a/language-server/dune-project
+++ b/language-server/dune-project
@@ -1,5 +1,4 @@
-(lang dune 3.5)
-(using coq 0.6)
+(lang dune 3.2)
 (name vscoq-language-server)
 (license LGPL-2.1-only)
 (authors "The VsCoq development team")

--- a/language-server/dune-project
+++ b/language-server/dune-project
@@ -1,4 +1,5 @@
-(lang dune 3.2)
+(lang dune 3.5)
+(using coq 0.6)
 (name vscoq-language-server)
 (license LGPL-2.1-only)
 (authors "The VsCoq development team")

--- a/language-server/language/dune
+++ b/language-server/language/dune
@@ -1,4 +1,5 @@
 (library
  (name language)
  (public_name vscoq-language-server.language)
+ (preprocess (pps ppx_optcomp -- -cookie "ppx_optcomp.env=env ~coq:(Defined \"%{coq:version.major}.%{coq:version.minor}\")"))
  (libraries coq-core.sysinit lsp))

--- a/language-server/vscoq-language-server.opam
+++ b/language-server/vscoq-language-server.opam
@@ -12,7 +12,7 @@ build: [
 ]
 depends: [
   "ocaml" { >= "4.13.1" }
-  "dune" { >= "3.2" }
+  "dune" { >= "3.5" }
   "coq-core" { >= "8.18" < "8.19" }
   "coq-stdlib" { >= "8.18" < "8.19" }
   "yojson"
@@ -26,6 +26,7 @@ depends: [
   "sexplib"
   "ppx_yojson_conv"
   "ppx_import"
+  "ppx_optcomp"
   "result" { >= "1.5" }
   "lsp" { >= "1.15"}
   "sel" {>= "0.4.0"}


### PR DESCRIPTION
Since 8.19+rc1 is tagged, I tried to merge coq-master into main, and have a single branch as we discussed.
The only file I ported is language/hover.ml where you can see ppx_optcomp in action.

I have a weird problem with dune 3.5, not the version of the software, which seems required in order to have the `coq:version` variables, but with `(lang dune 3.5)` in dune-project. Mysterious sanboxing error.

Also nix/flake is broken, I did commit the merge error, since I have no clue.