### PR TITLE
Fix font-size in Coq Goals

### DIFF
--- a/client/goal-view-ui/src/components/atoms/PpString.module.css
+++ b/client/goal-view-ui/src/components/atoms/PpString.module.css
@@ -2,6 +2,7 @@
     margin-top: 12px;
     width: 100%;
     font-family: var(--vscode-editor-font-family);
+    font-size: var(--vscode-editor-font-size);
 }
 
 .Error {
@@ -22,6 +23,7 @@
 
 .Goal {
     font-family: var(--vscode-editor-font-family);
+    font-size: var(--vscode-editor-font-size);
     color: var(--vscode-editor-foreground);
     white-space: pre-wrap;
     width: 100%;


### PR DESCRIPTION
<img width="257" alt="Screenshot 2024-01-04 at 3 16 51 PM" src="https://github.com/coq-community/vscoq/assets/32090825/1a616535-1e0a-416e-97c4-6b7a4b0db62b">

It used to look like this, where the font size of the goal was much smaller than the hypothesis. 

<img width="254" alt="Screenshot 2024-01-04 at 3 15 37 PM" src="https://github.com/coq-community/vscoq/assets/32090825/fb37d132-2587-4361-8750-da446b82ca79">

By set font-size to `var(--vscode-editor-font-size)` in css, they are same size now!