### PR TITLE
Run `vscoq.path` as a shell command from the project directory

### DIFF
--- a/client/src/utilities/toolchain.ts
+++ b/client/src/utilities/toolchain.ts
@@ -63,7 +63,11 @@ export default class VsCoqToolchainManager implements Disposable {
         const config = workspace.getConfiguration('vscoq');
         const serverOptions : ServerOptions = {
             command: this._vscoqtopPath, 
-            args: config.args
+            args: config.args,
+            options: {
+                cwd: workspace.rootPath,
+                shell: true,
+            },
         };
         return serverOptions;
     };
@@ -125,7 +129,7 @@ export default class VsCoqToolchainManager implements Disposable {
         const cmd = [this._vscoqtopPath].concat(options).join(' ');
 
         return new Promise((resolve, reject: ((reason: ToolchainError) => void)) => {
-            exec(cmd, (error, stdout, stderr) => {
+            exec(cmd, {cwd: workspace.rootPath}, (error, stdout, stderr) => {
 
                 if(error) {
                     reject({
@@ -160,7 +164,7 @@ export default class VsCoqToolchainManager implements Disposable {
         const cmd = [this._vscoqtopPath].concat(options).join(' ');
 
         return new Promise((resolve, reject: (reason: string) => void) => {
-            exec(cmd, (error, stdout, stderr) => {
+            exec(cmd, {cwd: workspace.rootPath}, (error, stdout, stderr) => {
                 if(error) {
                     reject(stderr);
                 } else {


### PR DESCRIPTION
This fixes an inconsistency between using `child_process.exec`, which runs the provided string as a shell command, and `vscode-languageclient`, which by default did not.

Also, `vscoqtop` is now always run from the directory of the project.

All that allows to use VsCoq for Coq projects built with dune, by putting the following to `.vscode/settings.json` (where `theories/Theory.v` is some Coq file):
```json
{
    "vscoq.path": "dune coq top --toplevel vscoqtop theories/Theory.v --"
}
```