### PR TITLE
Fix parse errors and highlight zone

### DIFF
--- a/language-server/dm/document.ml
+++ b/language-server/dm/document.ml
@@ -304,6 +304,10 @@ let rec parse_more synterp_state stream raw parsed errors =
       let loc = Loc.get_loc @@ Exninfo.info exn in
       junk_sentence_end stream;
       handle_parse_error start (loc,CLexer.Error.to_string e)
+    | exception exn ->
+      let e, info = Exninfo.capture exn in
+      let loc = Loc.get_loc @@ info in
+      handle_parse_error start (loc, "Unexpected parse error: " ^ Pp.string_of_ppcmds @@ CErrors.iprint_no_report (e,info))
   end
 
 let parse_more synterp_state stream raw =

--- a/language-server/dm/document.ml
+++ b/language-server/dm/document.ml
@@ -267,6 +267,7 @@ let rec parse_more synterp_state stream raw parsed errors =
     parse_more synterp_state stream raw parsed errors
   in
   let start = Stream.count stream in
+  log @@ "Start of parse is: " ^ (string_of_int start);
   begin
     (* FIXME should we save lexer state? *)
     match parse_one_sentence stream ~st:synterp_state with
@@ -307,6 +308,7 @@ let rec parse_more synterp_state stream raw parsed errors =
     | exception exn ->
       let e, info = Exninfo.capture exn in
       let loc = Loc.get_loc @@ info in
+      junk_sentence_end stream;
       handle_parse_error start (loc, "Unexpected parse error: " ^ Pp.string_of_ppcmds @@ CErrors.iprint_no_report (e,info))
   end
 

--- a/language-server/dm/document.ml
+++ b/language-server/dm/document.ml
@@ -125,27 +125,30 @@ type comment = {
   stop : int;
 }
 
-type item =
+type code_line =
   | Sentence of sentence
   | ParsingError of parsing_error
   | Comment of comment
   
-let start_of_item = function
+let start_of_code_line = function
   | Sentence { start = x } -> x
   | ParsingError  { start = x } -> x
   | Comment { start = x } -> x
 
-let compare_item x y =
-  let s1 = start_of_item x in
-  let s2 = start_of_item y in
+let compare_code_line x y =
+  let s1 = start_of_code_line x in
+  let s2 = start_of_code_line y in
   s1 - s2
 
-let sentences_sorted_by_loc parsed =
-  List.sort compare_item @@ List.concat [
+let code_lines_sorted_by_loc parsed =
+  List.sort compare_code_line @@ List.concat [
     (List.map (fun (_,x) -> Sentence x) @@ SM.bindings parsed.sentences_by_id) ;
     (List.map (fun (_,x) -> ParsingError x) @@ LM.bindings parsed.parsing_errors_by_end) ;
     []  (* todo comments *)
    ]
+
+let sentences_sorted_by_loc parsed =
+  List.sort (fun ({start = s1} : sentence) {start = s2} -> s1 - s2) @@ List.map snd @@ SM.bindings parsed.sentences_by_id
 
 let sentences_before parsed loc =
   let (before,ov,_after) = LM.split loc parsed.sentences_by_end in

--- a/language-server/dm/document.ml
+++ b/language-server/dm/document.ml
@@ -441,9 +441,16 @@ module Internal = struct
     sentence.start
     sentence.stop
 
-    let string_of_item = function
-      | Sentence sentence -> string_of_sentence sentence
-      | Comment _ -> "(* comment *)"
-      | ParsingError { msg = (_,str) } -> "Error:" ^ str
+  let string_of_error error =
+    let (_, str) = error.msg in
+    Format.sprintf "[parsing error] [%s] (%i -> %i)"
+    str
+    error.start
+    error.stop
+
+  let string_of_item = function
+    | Sentence sentence -> string_of_sentence sentence
+    | Comment _ -> "(* comment *)"
+    | ParsingError error -> string_of_error error
   
 end

--- a/language-server/dm/document.mli
+++ b/language-server/dm/document.mli
@@ -74,13 +74,14 @@ type comment = {
   stop : int;
 }
 
-type item =
+type code_line =
   | Sentence of sentence
   | ParsingError of parsing_error
   | Comment of comment
 
 val sentences : document -> sentence list
-val sentences_sorted_by_loc : document -> item list
+val code_lines_sorted_by_loc : document -> code_line list
+val sentences_sorted_by_loc : document -> sentence list
 
 val get_sentence : document -> sentence_id -> sentence option
 val sentences_before : document -> int -> sentence list
@@ -114,6 +115,6 @@ val range_of_id_with_blank_space : document -> Stateid.t -> Range.t
 module Internal : sig
 
   val string_of_sentence : sentence -> string
-  val string_of_item : item -> string
+  val string_of_item : code_line -> string
 
 end

--- a/language-server/dm/document.mli
+++ b/language-server/dm/document.mli
@@ -53,7 +53,13 @@ val apply_text_edits : document -> text_edit list -> document
 (** [apply_text_edits doc edits] updates the text of [doc] with [edits]. The new
     text is not parsed or executed. *)
 
+(* Example:                        *)
+(* "  Check 3. "                    *)
+(* ^  ^       ^---- end            *)
+(* |  |------------ start          *)
+(* |---------------- parsing_start *)
 type sentence = {
+  parsing_start : int;
   start : int;
   stop : int;
   synterp_state : Vernacstate.Synterp.t; (* synterp state after this sentence's synterp phase *)

--- a/language-server/dm/document.mli
+++ b/language-server/dm/document.mli
@@ -106,6 +106,10 @@ val get_last_sentence : document  -> sentence option
 val schedule : document -> Scheduler.schedule
 
 val range_of_id : document -> Stateid.t -> Range.t
+(** [range_of_id doc id] returns a Range object coressponding to the sentence id given in argument *)
+
+val range_of_id_with_blank_space : document -> Stateid.t -> Range.t
+(** [range_of_id_with_blank_space doc id] returns a Range object coressponding to the sentence id given in argument but with the white spaces before (until the previous sentence) *)
 
 module Internal : sig
 

--- a/language-server/dm/document.mli
+++ b/language-server/dm/document.mli
@@ -63,8 +63,18 @@ type sentence = {
   id : sentence_id;
 }
 
+type comment = {
+  start : int;
+  stop : int;
+}
+
+type item =
+  | Sentence of sentence
+  | ParsingError of parsing_error
+  | Comment of comment
+
 val sentences : document -> sentence list
-val sentences_sorted_by_loc : document -> sentence list
+val sentences_sorted_by_loc : document -> item list
 
 val get_sentence : document -> sentence_id -> sentence option
 val sentences_before : document -> int -> sentence list
@@ -94,5 +104,6 @@ val range_of_id : document -> Stateid.t -> Range.t
 module Internal : sig
 
   val string_of_sentence : sentence -> string
+  val string_of_item : item -> string
 
 end

--- a/language-server/dm/documentManager.ml
+++ b/language-server/dm/documentManager.ml
@@ -66,10 +66,10 @@ type exec_overview = {
   processed : Range.t list;
 }
 
-let merge_ranges doc (r1,l) r2 =
+let merge_adjacent_ranges doc (r1,l) r2 =
   let loc1 = RawDocument.loc_of_position doc r1.Range.end_ in
   let loc2 = RawDocument.loc_of_position doc r2.Range.start in
-  if RawDocument.only_whitespace_between doc (loc1+1) (loc2-1) then
+  if (loc1+1) = (loc2-1) then
     Range.{ start = r1.Range.start; end_ = r2.Range.end_ }, l
   else
     r2, r1 :: l
@@ -77,7 +77,7 @@ let merge_ranges doc (r1,l) r2 =
 let compress_sorted_ranges doc = function
   | [] -> []
   | range :: tl ->
-    let r, l = List.fold_left (merge_ranges doc) (range,[]) tl in
+    let r, l = List.fold_left (merge_adjacent_ranges doc) (range,[]) tl in
     r :: l
 
 let compress_ranges doc ranges =

--- a/language-server/dm/documentManager.ml
+++ b/language-server/dm/documentManager.ml
@@ -478,9 +478,12 @@ module Internal = struct
       else if ExecutionManager.is_remotely_executed st.execution_state id then "(executed in worker)"
       else "(not executed)"
     in
-    let string_of_sentence sentence =
-      Document.Internal.string_of_sentence sentence ^ " " ^ string_of_state sentence.id
+    let string_of_item item =
+      Document.Internal.string_of_item item ^ " " ^
+        match item with
+        | Sentence { id } -> string_of_state id
+        | _ -> ""
     in
-    String.concat "\n" @@ List.map string_of_sentence sentences
+    String.concat "\n" @@ List.map string_of_item sentences
 
 end

--- a/language-server/dm/documentManager.ml
+++ b/language-server/dm/documentManager.ml
@@ -470,7 +470,7 @@ module Internal = struct
     validate_document st
 
   let string_of_state st =
-    let sentences = Document.sentences_sorted_by_loc st.document in
+    let code_lines = Document.code_lines_sorted_by_loc st.document in
     let string_of_state id =
       if ExecutionManager.is_executed st.execution_state id then "(executed)"
       else if ExecutionManager.is_remotely_executed st.execution_state id then "(executed in worker)"
@@ -483,6 +483,6 @@ module Internal = struct
         | ParsingError _ -> "(error)"
         | Comment _ -> "(comment)"
     in
-    String.concat "\n" @@ List.map string_of_item sentences
+    String.concat "\n" @@ List.map string_of_item code_lines
 
 end

--- a/language-server/dm/documentManager.ml
+++ b/language-server/dm/documentManager.ml
@@ -480,7 +480,8 @@ module Internal = struct
       Document.Internal.string_of_item item ^ " " ^
         match item with
         | Sentence { id } -> string_of_state id
-        | _ -> ""
+        | ParsingError _ -> "(error)"
+        | Comment _ -> "(comment)"
     in
     String.concat "\n" @@ List.map string_of_item sentences
 

--- a/language-server/dm/documentManager.ml
+++ b/language-server/dm/documentManager.ml
@@ -66,27 +66,25 @@ type exec_overview = {
   processed : Range.t list;
 }
 
-let merge_adjacent_ranges doc (r1,l) r2 =
-  let loc1 = RawDocument.loc_of_position doc r1.Range.end_ in
-  let loc2 = RawDocument.loc_of_position doc r2.Range.start in
-  if (loc1+1) = (loc2-1) then
+let merge_adjacent_ranges (r1,l) r2 =
+  if Position.compare r1.Range.end_ r2.Range.start == 0 then
     Range.{ start = r1.Range.start; end_ = r2.Range.end_ }, l
   else
     r2, r1 :: l
 
-let compress_sorted_ranges doc = function
+let compress_sorted_ranges = function
   | [] -> []
   | range :: tl ->
-    let r, l = List.fold_left (merge_adjacent_ranges doc) (range,[]) tl in
+    let r, l = List.fold_left merge_adjacent_ranges (range,[]) tl in
     r :: l
 
-let compress_ranges doc ranges =
+let compress_ranges ranges =
   let ranges = List.sort (fun { Range.start = s1 } { Range.start = s2 } -> Position.compare s1 s2) ranges in
-  compress_sorted_ranges doc ranges
+  compress_sorted_ranges ranges
 
 let executed_ranges doc execution_state loc =
   let ranges_of l =
-    compress_ranges (Document.raw_document doc) @@ List.map (Document.range_of_id doc) l
+    compress_ranges @@ List.map (Document.range_of_id_with_blank_space doc) l
   in
   let ids_before_loc = List.map (fun s -> s.Document.id) @@ Document.sentences_before doc loc in
   let processed_ids = List.filter (fun x -> ExecutionManager.is_executed execution_state x || ExecutionManager.is_remotely_executed execution_state x) ids_before_loc in

--- a/language-server/dm/rawDocument.ml
+++ b/language-server/dm/rawDocument.ml
@@ -104,12 +104,3 @@ let apply_text_edit raw (Range.{start; end_}, editText) =
   let new_text = before ^ editText ^ after in (* FIXME avoid concatenation *)
   let new_lines = compute_lines new_text in (* FIXME compute this incrementally *)
   { text = new_text; lines = new_lines }, start
-
-let only_whitespace_between raw loc1 loc2 =
-  let res = ref true in
-  for i = loc1 to loc2 do
-    let code = Char.code raw.text.[i] in
-    if code <> 0x20 && code <> 0xD && code <> 0xA && code <> 0x9
-      then res := false
-  done;
-  !res

--- a/language-server/dm/rawDocument.mli
+++ b/language-server/dm/rawDocument.mli
@@ -29,7 +29,3 @@ val word_at_position: t -> Position.t -> string option
 
 (** Applies a text edit, and returns start location *)
 val apply_text_edit : t -> text_edit -> t * int
-
-(** Tests if document text contains only whitespace between the two provided
-    locations, included *)
-val only_whitespace_between : t -> int -> int -> bool

--- a/language-server/tests/common.ml
+++ b/language-server/tests/common.ml
@@ -65,7 +65,7 @@ let rec parse : type a. int -> int -> Document.sentence list -> Document.parsing
       Error ("fewer sentences than expected, only " ^ Int.to_string m ^ " list of errors:\n" ^ errors)
     | E _, _, [] -> Error ("fewer errors than expected, only " ^ Int.to_string n)
 
-let d_sentences doc spec = 
+let d_sentences doc spec =
   let sentences = Document.sentences_sorted_by_loc doc in
   let errors = Document.parse_errors doc in
   let r = run (parse 0 0 sentences errors spec) in

--- a/language-server/tests/dm_tests.ml
+++ b/language-server/tests/dm_tests.ml
@@ -33,7 +33,7 @@ let%test_unit "parse.init" =
   let doc = Document.raw_document @@ DocumentManager.Internal.document st in
   [%test_eq: int] (RawDocument.end_loc doc) 44;
   let sentences = Document.sentences @@ DocumentManager.Internal.document st in
-  let positions = Stdlib.List.map (fun s -> s.Document.start) sentences in
+  let positions = Stdlib.List.map (fun (s : Document.sentence) -> s.Document.start) sentences in
   [%test_eq: int list] positions [ 0; 22 ];
   check_no_diag st
 
@@ -41,7 +41,7 @@ let%test_unit "parse.insert" =
   let st, events = init_test_doc ~text:"Definition x := true. Definition y := false." in
   let st = insert_text st ~loc:0 ~text:"Definition z := 0. " in
   let sentences = Document.sentences @@ DocumentManager.Internal.document st in
-  let positions = Stdlib.List.map (fun s -> s.Document.start) sentences in
+  let positions = Stdlib.List.map (fun (s : Document.sentence) -> s.Document.start) sentences in
   [%test_eq: int list] positions [ 0; 19; 41 ];
   check_no_diag st
 
@@ -50,8 +50,8 @@ let%test_unit "parse.squash" =
   let st = edit_text st ~start:20 ~stop:21 ~text:"" in
   let doc = DocumentManager.Internal.document st in
   let sentences = Document.sentences doc in
-  let start_positions = Stdlib.List.map (fun s -> s.Document.start) sentences in
-  let stop_positions = Stdlib.List.map (fun s -> s.Document.stop) sentences in
+  let start_positions = Stdlib.List.map (fun (s : Document.sentence) -> s.Document.start) sentences in
+  let stop_positions = Stdlib.List.map (fun (s : Document.sentence) -> s.Document.stop) sentences in
   [%test_eq: int list] start_positions [ 44 ];
   [%test_eq: int list] stop_positions [ 62 ];
   [%test_eq: int] (List.length (Document.parse_errors doc)) 1
@@ -60,14 +60,14 @@ let%test_unit "parse.error_recovery" =
   let st, events = init_test_doc ~text:"## . Definition x := true. !! . Definition y := false." in
   let doc = DocumentManager.Internal.document st in
   let sentences = Document.sentences doc in
-  let start_positions = Stdlib.List.map (fun s -> s.Document.start) sentences in
+  let start_positions = Stdlib.List.map (fun (s : Document.sentence) -> s.Document.start) sentences in
   [%test_eq: int list] start_positions [ 5; 32 ];
   [%test_eq: int] (List.length (Document.parse_errors doc)) 2
 
 let%test_unit "parse.extensions" =
   let st, events = init_test_doc ~text:"Notation \"## x\" := x (at level 0). Definition f (x : nat) := ##xx." in
   let sentences = Document.sentences @@ DocumentManager.Internal.document st in
-  let start_positions = Stdlib.List.map (fun s -> s.Document.start) sentences in
+  let start_positions = Stdlib.List.map (fun (s : Document.sentence) -> s.Document.start) sentences in
   [%test_eq: int list] start_positions [ 0; 35 ];
   check_no_diag st
 

--- a/language-server/tests/dm_tests.ml
+++ b/language-server/tests/dm_tests.ml
@@ -117,7 +117,7 @@ let%test_unit "exec.require_error" =
   let st = handle_events todo st in
   let ranges = (DocumentManager.executed_ranges st).processed in
   let positions = Stdlib.List.map (fun s -> s.Lsp.Types.Range.start.character) ranges in
-  [%test_eq: int list] positions [ 19 ]
+  [%test_eq: int list] positions [ 18 ]
 
 let%test_unit "step_forward.delete_observe_id" =
   let st, init_events = init_test_doc ~text:"Definition x := 3. Lemma foo : x = 3." in 


### PR DESCRIPTION
This introduces a fix which handles previously uncaught parse errors and new functions which allow to highlight parts of the file which was unhandled before (comments and such).
Closes #638.
Closes #673. 