### PR TITLE
Improve flake.nix, add compatibility with pkgs.vscode extensions field

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,9 +45,13 @@ jobs:
         nix_path: nixpkgs=channel:nixos-unstable
     - name: Check each yarn.nix up to date
       run: |
-        cd client && nix-shell -p yarn2nix --run "yarn2nix > new_yarn.nix" && diff new_yarn.nix yarn.nix
-        cd goal-view-ui && nix-shell -p yarn2nix --run "yarn2nix > new_yarn.nix" && diff new_yarn.nix yarn.nix
-        cd ../search-ui && nix-shell -p yarn2nix --run "yarn2nix > new_yarn.nix" && diff new_yarn.nix yarn.nix
+        cd client && nix-shell -p yarn2nix --run "yarn2nix > new_yarn.nix"
+        cd goal-view-ui && nix-shell -p yarn2nix --run "yarn2nix > new_yarn.nix"
+        cd ../search-ui && nix-shell -p yarn2nix --run "yarn2nix > new_yarn.nix" && cd ..
+        nix fmt
+        diff new_yarn.nix yarn.nix
+        diff goal-view-ui/new_yarn.nix goal-view-ui/yarn.nix
+        diff search-ui/new_yarn.nix search-ui/yarn.nix
     - run: nix develop .#vscoq-language-server-${{ matrix.coq }} -c bash -c "cd language-server && dune build"
     - run: nix develop .#vscoq-client -c bash -c "cd client && yarn run install:all && yarn run build:all && yarn run compile"
     - run: xvfb-run nix develop .#vscoq-client -c bash -c "cd client && yarn test"

--- a/client/goal-view-ui/yarn.nix
+++ b/client/goal-view-ui/yarn.nix
@@ -1,11 +1,17 @@
-{ fetchurl, fetchgit, linkFarm, runCommand, gnutar }: rec {
+{
+  fetchurl,
+  fetchgit,
+  linkFarm,
+  runCommand,
+  gnutar,
+}: rec {
   offline_cache = linkFarm "offline" packages;
   packages = [
     {
       name = "https___registry.npmjs.org__ampproject_remapping___remapping_2.2.0.tgz";
       path = fetchurl {
         name = "https___registry.npmjs.org__ampproject_remapping___remapping_2.2.0.tgz";
-        url  = "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.0.tgz";
+        url = "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.0.tgz";
         sha512 = "qRmjj8nj9qmLTQXXmaR1cck3UXSRMPrbsLJAasZpF+t3riI71BXed5ebIOYwQntykeZuhjsdweEc9BxH5Jc26w==";
       };
     }
@@ -13,7 +19,7 @@
       name = "https___registry.npmjs.org__babel_code_frame___code_frame_7.18.6.tgz";
       path = fetchurl {
         name = "https___registry.npmjs.org__babel_code_frame___code_frame_7.18.6.tgz";
-        url  = "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.18.6.tgz";
+        url = "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.18.6.tgz";
         sha512 = "TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==";
       };
     }
@@ -21,7 +27,7 @@
       name = "_babel_code_frame___code_frame_7.22.13.tgz";
       path = fetchurl {
         name = "_babel_code_frame___code_frame_7.22.13.tgz";
-        url  = "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.22.13.tgz";
+        url = "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.22.13.tgz";
         sha512 = "XktuhWlJ5g+3TJXc5upd9Ks1HutSArik6jf2eAjYFyIOf4ej3RN+184cZbzDvbPnuTJIUhPKKJE3cIsYTiAT3w==";
       };
     }
@@ -29,7 +35,7 @@
       name = "https___registry.npmjs.org__babel_compat_data___compat_data_7.20.10.tgz";
       path = fetchurl {
         name = "https___registry.npmjs.org__babel_compat_data___compat_data_7.20.10.tgz";
-        url  = "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.20.10.tgz";
+        url = "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.20.10.tgz";
         sha512 = "sEnuDPpOJR/fcafHMjpcpGN5M2jbUGUHwmuWKM/YdPzeEDJg8bgmbcWQFUfE32MQjti1koACvoPVsDe8Uq+idg==";
       };
     }
@@ -37,7 +43,7 @@
       name = "https___registry.npmjs.org__babel_core___core_7.20.12.tgz";
       path = fetchurl {
         name = "https___registry.npmjs.org__babel_core___core_7.20.12.tgz";
-        url  = "https://registry.npmjs.org/@babel/core/-/core-7.20.12.tgz";
+        url = "https://registry.npmjs.org/@babel/core/-/core-7.20.12.tgz";
         sha512 = "XsMfHovsUYHFMdrIHkZphTN/2Hzzi78R08NuHfDBehym2VsPDL6Zn/JAD/JQdnRvbSsbQc4mVaU1m6JgtTEElg==";
       };
     }
@@ -45,7 +51,7 @@
       name = "https___registry.npmjs.org__babel_generator___generator_7.20.7.tgz";
       path = fetchurl {
         name = "https___registry.npmjs.org__babel_generator___generator_7.20.7.tgz";
-        url  = "https://registry.npmjs.org/@babel/generator/-/generator-7.20.7.tgz";
+        url = "https://registry.npmjs.org/@babel/generator/-/generator-7.20.7.tgz";
         sha512 = "7wqMOJq8doJMZmP4ApXTzLxSr7+oO2jroJURrVEp6XShrQUObV8Tq/D0NCcoYg2uHqUrjzO0zwBjoYzelxK+sw==";
       };
     }
@@ -53,7 +59,7 @@
       name = "_babel_generator___generator_7.23.0.tgz";
       path = fetchurl {
         name = "_babel_generator___generator_7.23.0.tgz";
-        url  = "https://registry.yarnpkg.com/@babel/generator/-/generator-7.23.0.tgz";
+        url = "https://registry.yarnpkg.com/@babel/generator/-/generator-7.23.0.tgz";
         sha512 = "lN85QRR+5IbYrMWM6Y4pE/noaQtg4pNiqeNGX60eqOfo6gtEj6uw/JagelB8vVztSd7R6M5n1+PQkDbHbBRU4g==";
       };
     }
@@ -61,7 +67,7 @@
       name = "https___registry.npmjs.org__babel_helper_annotate_as_pure___helper_annotate_as_pure_7.18.6.tgz";
       path = fetchurl {
         name = "https___registry.npmjs.org__babel_helper_annotate_as_pure___helper_annotate_as_pure_7.18.6.tgz";
-        url  = "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.18.6.tgz";
+        url = "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.18.6.tgz";
         sha512 = "duORpUiYrEpzKIop6iNbjnwKLAKnJ47csTyRACyEmWj0QdUrm5aqNJGHSSEQSUAvNW0ojX0dOmK9dZduvkfeXA==";
       };
     }
@@ -69,7 +75,7 @@
       name = "https___registry.npmjs.org__babel_helper_compilation_targets___helper_compilation_targets_7.20.7.tgz";
       path = fetchurl {
         name = "https___registry.npmjs.org__babel_helper_compilation_targets___helper_compilation_targets_7.20.7.tgz";
-        url  = "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.20.7.tgz";
+        url = "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.20.7.tgz";
         sha512 = "4tGORmfQcrc+bvrjb5y3dG9Mx1IOZjsHqQVUz7XCNHO+iTmqxWnVg3KRygjGmpRLJGdQSKuvFinbIb0CnZwHAQ==";
       };
     }
@@ -77,7 +83,7 @@
       name = "https___registry.npmjs.org__babel_helper_environment_visitor___helper_environment_visitor_7.18.9.tgz";
       path = fetchurl {
         name = "https___registry.npmjs.org__babel_helper_environment_visitor___helper_environment_visitor_7.18.9.tgz";
-        url  = "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.18.9.tgz";
+        url = "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.18.9.tgz";
         sha512 = "3r/aACDJ3fhQ/EVgFy0hpj8oHyHpQc+LPtJoY9SzTThAsStm4Ptegq92vqKoE3vD706ZVFWITnMnxucw+S9Ipg==";
       };
     }
@@ -85,7 +91,7 @@
       name = "_babel_helper_environment_visitor___helper_environment_visitor_7.22.20.tgz";
       path = fetchurl {
         name = "_babel_helper_environment_visitor___helper_environment_visitor_7.22.20.tgz";
-        url  = "https://registry.yarnpkg.com/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.20.tgz";
+        url = "https://registry.yarnpkg.com/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.20.tgz";
         sha512 = "zfedSIzFhat/gFhWfHtgWvlec0nqB9YEIVrpuwjruLlXfUSnA8cJB0miHKwqDnQ7d32aKo2xt88/xZptwxbfhA==";
       };
     }
@@ -93,7 +99,7 @@
       name = "_babel_helper_function_name___helper_function_name_7.23.0.tgz";
       path = fetchurl {
         name = "_babel_helper_function_name___helper_function_name_7.23.0.tgz";
-        url  = "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.23.0.tgz";
+        url = "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.23.0.tgz";
         sha512 = "OErEqsrxjZTJciZ4Oo+eoZqeW9UIiOcuYKRJA4ZAgV9myA+pOXhhmpfNCKjEH/auVfEYVFJ6y1Tc4r0eIApqiw==";
       };
     }
@@ -101,7 +107,7 @@
       name = "_babel_helper_hoist_variables___helper_hoist_variables_7.22.5.tgz";
       path = fetchurl {
         name = "_babel_helper_hoist_variables___helper_hoist_variables_7.22.5.tgz";
-        url  = "https://registry.yarnpkg.com/@babel/helper-hoist-variables/-/helper-hoist-variables-7.22.5.tgz";
+        url = "https://registry.yarnpkg.com/@babel/helper-hoist-variables/-/helper-hoist-variables-7.22.5.tgz";
         sha512 = "wGjk9QZVzvknA6yKIUURb8zY3grXCcOZt+/7Wcy8O2uctxhplmUPkOdlgoNhmdVee2c92JXbf1xpMtVNbfoxRw==";
       };
     }
@@ -109,7 +115,7 @@
       name = "https___registry.npmjs.org__babel_helper_module_imports___helper_module_imports_7.18.6.tgz";
       path = fetchurl {
         name = "https___registry.npmjs.org__babel_helper_module_imports___helper_module_imports_7.18.6.tgz";
-        url  = "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.18.6.tgz";
+        url = "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.18.6.tgz";
         sha512 = "0NFvs3VkuSYbFi1x2Vd6tKrywq+z/cLeYC/RJNFrIX/30Bf5aiGYbtvGXolEktzJH8o5E5KJ3tT+nkxuuZFVlA==";
       };
     }
@@ -117,7 +123,7 @@
       name = "https___registry.npmjs.org__babel_helper_module_transforms___helper_module_transforms_7.20.11.tgz";
       path = fetchurl {
         name = "https___registry.npmjs.org__babel_helper_module_transforms___helper_module_transforms_7.20.11.tgz";
-        url  = "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.20.11.tgz";
+        url = "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.20.11.tgz";
         sha512 = "uRy78kN4psmji1s2QtbtcCSaj/LILFDp0f/ymhpQH5QY3nljUZCaNWz9X1dEj/8MBdBEFECs7yRhKn8i7NjZgg==";
       };
     }
@@ -125,7 +131,7 @@
       name = "https___registry.npmjs.org__babel_helper_plugin_utils___helper_plugin_utils_7.20.2.tgz";
       path = fetchurl {
         name = "https___registry.npmjs.org__babel_helper_plugin_utils___helper_plugin_utils_7.20.2.tgz";
-        url  = "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.20.2.tgz";
+        url = "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.20.2.tgz";
         sha512 = "8RvlJG2mj4huQ4pZ+rU9lqKi9ZKiRmuvGuM2HlWmkmgOhbs6zEAw6IEiJ5cQqGbDzGZOhwuOQNtZMi/ENLjZoQ==";
       };
     }
@@ -133,7 +139,7 @@
       name = "https___registry.npmjs.org__babel_helper_simple_access___helper_simple_access_7.20.2.tgz";
       path = fetchurl {
         name = "https___registry.npmjs.org__babel_helper_simple_access___helper_simple_access_7.20.2.tgz";
-        url  = "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.20.2.tgz";
+        url = "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.20.2.tgz";
         sha512 = "+0woI/WPq59IrqDYbVGfshjT5Dmk/nnbdpcF8SnMhhXObpTq2KNBdLFRFrkVdbDOyUmHBCxzm5FHV1rACIkIbA==";
       };
     }
@@ -141,7 +147,7 @@
       name = "https___registry.npmjs.org__babel_helper_split_export_declaration___helper_split_export_declaration_7.18.6.tgz";
       path = fetchurl {
         name = "https___registry.npmjs.org__babel_helper_split_export_declaration___helper_split_export_declaration_7.18.6.tgz";
-        url  = "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.18.6.tgz";
+        url = "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.18.6.tgz";
         sha512 = "bde1etTx6ZyTmobl9LLMMQsaizFVZrquTEHOqKeQESMKo4PlObf+8+JA25ZsIpZhT/WEd39+vOdLXAFG/nELpA==";
       };
     }
@@ -149,7 +155,7 @@
       name = "_babel_helper_split_export_declaration___helper_split_export_declaration_7.22.6.tgz";
       path = fetchurl {
         name = "_babel_helper_split_export_declaration___helper_split_export_declaration_7.22.6.tgz";
-        url  = "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.22.6.tgz";
+        url = "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.22.6.tgz";
         sha512 = "AsUnxuLhRYsisFiaJwvp1QF+I3KjD5FOxut14q/GzovUe6orHLesW2C7d754kRm53h5gqrz6sFl6sxc4BVtE/g==";
       };
     }
@@ -157,7 +163,7 @@
       name = "https___registry.npmjs.org__babel_helper_string_parser___helper_string_parser_7.19.4.tgz";
       path = fetchurl {
         name = "https___registry.npmjs.org__babel_helper_string_parser___helper_string_parser_7.19.4.tgz";
-        url  = "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.19.4.tgz";
+        url = "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.19.4.tgz";
         sha512 = "nHtDoQcuqFmwYNYPz3Rah5ph2p8PFeFCsZk9A/48dPc/rGocJ5J3hAAZ7pb76VWX3fZKu+uEr/FhH5jLx7umrw==";
       };
     }
@@ -165,7 +171,7 @@
       name = "_babel_helper_string_parser___helper_string_parser_7.22.5.tgz";
       path = fetchurl {
         name = "_babel_helper_string_parser___helper_string_parser_7.22.5.tgz";
-        url  = "https://registry.yarnpkg.com/@babel/helper-string-parser/-/helper-string-parser-7.22.5.tgz";
+        url = "https://registry.yarnpkg.com/@babel/helper-string-parser/-/helper-string-parser-7.22.5.tgz";
         sha512 = "mM4COjgZox8U+JcXQwPijIZLElkgEpO5rsERVDJTc2qfCDfERyob6k5WegS14SX18IIjv+XD+GrqNumY5JRCDw==";
       };
     }
@@ -173,7 +179,7 @@
       name = "https___registry.npmjs.org__babel_helper_validator_identifier___helper_validator_identifier_7.19.1.tgz";
       path = fetchurl {
         name = "https___registry.npmjs.org__babel_helper_validator_identifier___helper_validator_identifier_7.19.1.tgz";
-        url  = "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.19.1.tgz";
+        url = "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.19.1.tgz";
         sha512 = "awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w==";
       };
     }
@@ -181,7 +187,7 @@
       name = "_babel_helper_validator_identifier___helper_validator_identifier_7.22.20.tgz";
       path = fetchurl {
         name = "_babel_helper_validator_identifier___helper_validator_identifier_7.22.20.tgz";
-        url  = "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz";
+        url = "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz";
         sha512 = "Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==";
       };
     }
@@ -189,7 +195,7 @@
       name = "https___registry.npmjs.org__babel_helper_validator_option___helper_validator_option_7.18.6.tgz";
       path = fetchurl {
         name = "https___registry.npmjs.org__babel_helper_validator_option___helper_validator_option_7.18.6.tgz";
-        url  = "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.18.6.tgz";
+        url = "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.18.6.tgz";
         sha512 = "XO7gESt5ouv/LRJdrVjkShckw6STTaB7l9BrpBaAHDeF5YZT+01PCwmR0SJHnkW6i8OwW/EVWRShfi4j2x+KQw==";
       };
     }
@@ -197,7 +203,7 @@
       name = "https___registry.npmjs.org__babel_helpers___helpers_7.20.13.tgz";
       path = fetchurl {
         name = "https___registry.npmjs.org__babel_helpers___helpers_7.20.13.tgz";
-        url  = "https://registry.npmjs.org/@babel/helpers/-/helpers-7.20.13.tgz";
+        url = "https://registry.npmjs.org/@babel/helpers/-/helpers-7.20.13.tgz";
         sha512 = "nzJ0DWCL3gB5RCXbUO3KIMMsBY2Eqbx8mBpKGE/02PgyRQFcPQLbkQ1vyy596mZLaP+dAfD+R4ckASzNVmW3jg==";
       };
     }
@@ -205,7 +211,7 @@
       name = "https___registry.npmjs.org__babel_highlight___highlight_7.18.6.tgz";
       path = fetchurl {
         name = "https___registry.npmjs.org__babel_highlight___highlight_7.18.6.tgz";
-        url  = "https://registry.npmjs.org/@babel/highlight/-/highlight-7.18.6.tgz";
+        url = "https://registry.npmjs.org/@babel/highlight/-/highlight-7.18.6.tgz";
         sha512 = "u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==";
       };
     }
@@ -213,7 +219,7 @@
       name = "_babel_highlight___highlight_7.22.20.tgz";
       path = fetchurl {
         name = "_babel_highlight___highlight_7.22.20.tgz";
-        url  = "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.22.20.tgz";
+        url = "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.22.20.tgz";
         sha512 = "dkdMCN3py0+ksCgYmGG8jKeGA/8Tk+gJwSYYlFGxG5lmhfKNoAy004YpLxpS1W2J8m/EK2Ew+yOs9pVRwO89mg==";
       };
     }
@@ -221,7 +227,7 @@
       name = "https___registry.npmjs.org__babel_parser___parser_7.20.13.tgz";
       path = fetchurl {
         name = "https___registry.npmjs.org__babel_parser___parser_7.20.13.tgz";
-        url  = "https://registry.npmjs.org/@babel/parser/-/parser-7.20.13.tgz";
+        url = "https://registry.npmjs.org/@babel/parser/-/parser-7.20.13.tgz";
         sha512 = "gFDLKMfpiXCsjt4za2JA9oTMn70CeseCehb11kRZgvd7+F67Hih3OHOK24cRrWECJ/ljfPGac6ygXAs/C8kIvw==";
       };
     }
@@ -229,7 +235,7 @@
       name = "_babel_parser___parser_7.23.0.tgz";
       path = fetchurl {
         name = "_babel_parser___parser_7.23.0.tgz";
-        url  = "https://registry.yarnpkg.com/@babel/parser/-/parser-7.23.0.tgz";
+        url = "https://registry.yarnpkg.com/@babel/parser/-/parser-7.23.0.tgz";
         sha512 = "vvPKKdMemU85V9WE/l5wZEmImpCtLqbnTvqDS2U1fJ96KrxoW7KrXhNsNCblQlg8Ck4b85yxdTyelsMUgFUXiw==";
       };
     }
@@ -237,7 +243,7 @@
       name = "https___registry.npmjs.org__babel_plugin_syntax_jsx___plugin_syntax_jsx_7.18.6.tgz";
       path = fetchurl {
         name = "https___registry.npmjs.org__babel_plugin_syntax_jsx___plugin_syntax_jsx_7.18.6.tgz";
-        url  = "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.18.6.tgz";
+        url = "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.18.6.tgz";
         sha512 = "6mmljtAedFGTWu2p/8WIORGwy+61PLgOMPOdazc7YoJ9ZCWUyFy3A6CpPkRKLKD1ToAesxX8KGEViAiLo9N+7Q==";
       };
     }
@@ -245,7 +251,7 @@
       name = "https___registry.npmjs.org__babel_plugin_transform_react_jsx_development___plugin_transform_react_jsx_development_7.18.6.tgz";
       path = fetchurl {
         name = "https___registry.npmjs.org__babel_plugin_transform_react_jsx_development___plugin_transform_react_jsx_development_7.18.6.tgz";
-        url  = "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-development/-/plugin-transform-react-jsx-development-7.18.6.tgz";
+        url = "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-development/-/plugin-transform-react-jsx-development-7.18.6.tgz";
         sha512 = "SA6HEjwYFKF7WDjWcMcMGUimmw/nhNRDWxr+KaLSCrkD/LMDBvWRmHAYgE1HDeF8KUuI8OAu+RT6EOtKxSW2qA==";
       };
     }
@@ -253,7 +259,7 @@
       name = "https___registry.npmjs.org__babel_plugin_transform_react_jsx_self___plugin_transform_react_jsx_self_7.18.6.tgz";
       path = fetchurl {
         name = "https___registry.npmjs.org__babel_plugin_transform_react_jsx_self___plugin_transform_react_jsx_self_7.18.6.tgz";
-        url  = "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.18.6.tgz";
+        url = "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.18.6.tgz";
         sha512 = "A0LQGx4+4Jv7u/tWzoJF7alZwnBDQd6cGLh9P+Ttk4dpiL+J5p7NSNv/9tlEFFJDq3kjxOavWmbm6t0Gk+A3Ig==";
       };
     }
@@ -261,7 +267,7 @@
       name = "https___registry.npmjs.org__babel_plugin_transform_react_jsx_source___plugin_transform_react_jsx_source_7.19.6.tgz";
       path = fetchurl {
         name = "https___registry.npmjs.org__babel_plugin_transform_react_jsx_source___plugin_transform_react_jsx_source_7.19.6.tgz";
-        url  = "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.19.6.tgz";
+        url = "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.19.6.tgz";
         sha512 = "RpAi004QyMNisst/pvSanoRdJ4q+jMCWyk9zdw/CyLB9j8RXEahodR6l2GyttDRyEVWZtbN+TpLiHJ3t34LbsQ==";
       };
     }
@@ -269,7 +275,7 @@
       name = "https___registry.npmjs.org__babel_plugin_transform_react_jsx___plugin_transform_react_jsx_7.20.13.tgz";
       path = fetchurl {
         name = "https___registry.npmjs.org__babel_plugin_transform_react_jsx___plugin_transform_react_jsx_7.20.13.tgz";
-        url  = "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.20.13.tgz";
+        url = "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.20.13.tgz";
         sha512 = "MmTZx/bkUrfJhhYAYt3Urjm+h8DQGrPrnKQ94jLo7NLuOU+T89a7IByhKmrb8SKhrIYIQ0FN0CHMbnFRen4qNw==";
       };
     }
@@ -277,7 +283,7 @@
       name = "https___registry.npmjs.org__babel_template___template_7.20.7.tgz";
       path = fetchurl {
         name = "https___registry.npmjs.org__babel_template___template_7.20.7.tgz";
-        url  = "https://registry.npmjs.org/@babel/template/-/template-7.20.7.tgz";
+        url = "https://registry.npmjs.org/@babel/template/-/template-7.20.7.tgz";
         sha512 = "8SegXApWe6VoNw0r9JHpSteLKTpTiLZ4rMlGIm9JQ18KiCtyQiAMEazujAHrUS5flrcqYZa75ukev3P6QmUwUw==";
       };
     }
@@ -285,7 +291,7 @@
       name = "_babel_template___template_7.22.15.tgz";
       path = fetchurl {
         name = "_babel_template___template_7.22.15.tgz";
-        url  = "https://registry.yarnpkg.com/@babel/template/-/template-7.22.15.tgz";
+        url = "https://registry.yarnpkg.com/@babel/template/-/template-7.22.15.tgz";
         sha512 = "QPErUVm4uyJa60rkI73qneDacvdvzxshT3kksGqlGWYdOTIUOwJ7RDUL8sGqslY1uXWSL6xMFKEXDS3ox2uF0w==";
       };
     }
@@ -293,7 +299,7 @@
       name = "_babel_traverse___traverse_7.23.2.tgz";
       path = fetchurl {
         name = "_babel_traverse___traverse_7.23.2.tgz";
-        url  = "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.23.2.tgz";
+        url = "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.23.2.tgz";
         sha512 = "azpe59SQ48qG6nu2CzcMLbxUudtN+dOM9kDbUqGq3HXUJRlo7i8fvPoxQUzYgLZ4cMVmuZgm8vvBpNeRhd6XSw==";
       };
     }
@@ -301,7 +307,7 @@
       name = "https___registry.npmjs.org__babel_types___types_7.20.7.tgz";
       path = fetchurl {
         name = "https___registry.npmjs.org__babel_types___types_7.20.7.tgz";
-        url  = "https://registry.npmjs.org/@babel/types/-/types-7.20.7.tgz";
+        url = "https://registry.npmjs.org/@babel/types/-/types-7.20.7.tgz";
         sha512 = "69OnhBxSSgK0OzTJai4kyPDiKTIe3j+ctaHdIGVbRahTLAT7L3R9oeXHC2aVSuGYt3cVnoAMDmOCgJ2yaiLMvg==";
       };
     }
@@ -309,7 +315,7 @@
       name = "_babel_types___types_7.23.0.tgz";
       path = fetchurl {
         name = "_babel_types___types_7.23.0.tgz";
-        url  = "https://registry.yarnpkg.com/@babel/types/-/types-7.23.0.tgz";
+        url = "https://registry.yarnpkg.com/@babel/types/-/types-7.23.0.tgz";
         sha512 = "0oIyUfKoI3mSqMvsxBdclDwxXKXAUA8v/apZbc+iSyARYou1o8ZGDxbUYyLFoW2arqS2jDGqJuZvv1d/io1axg==";
       };
     }
@@ -317,7 +323,7 @@
       name = "_esbuild_linux_loong64___linux_loong64_0.14.54.tgz";
       path = fetchurl {
         name = "_esbuild_linux_loong64___linux_loong64_0.14.54.tgz";
-        url  = "https://registry.yarnpkg.com/@esbuild/linux-loong64/-/linux-loong64-0.14.54.tgz";
+        url = "https://registry.yarnpkg.com/@esbuild/linux-loong64/-/linux-loong64-0.14.54.tgz";
         sha512 = "bZBrLAIX1kpWelV0XemxBZllyRmM6vgFQQG2GdNb+r3Fkp0FOh1NJSvekXDs7jq70k4euu1cryLMfU+mTXlEpw==";
       };
     }
@@ -325,7 +331,7 @@
       name = "https___registry.npmjs.org__jridgewell_gen_mapping___gen_mapping_0.1.1.tgz";
       path = fetchurl {
         name = "https___registry.npmjs.org__jridgewell_gen_mapping___gen_mapping_0.1.1.tgz";
-        url  = "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.1.1.tgz";
+        url = "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.1.1.tgz";
         sha512 = "sQXCasFk+U8lWYEe66WxRDOE9PjVz4vSM51fTu3Hw+ClTpUSQb718772vH3pyS5pShp6lvQM7SxgIDXXXmOX7w==";
       };
     }
@@ -333,7 +339,7 @@
       name = "https___registry.npmjs.org__jridgewell_gen_mapping___gen_mapping_0.3.2.tgz";
       path = fetchurl {
         name = "https___registry.npmjs.org__jridgewell_gen_mapping___gen_mapping_0.3.2.tgz";
-        url  = "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz";
+        url = "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz";
         sha512 = "mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==";
       };
     }
@@ -341,7 +347,7 @@
       name = "https___registry.npmjs.org__jridgewell_resolve_uri___resolve_uri_3.1.0.tgz";
       path = fetchurl {
         name = "https___registry.npmjs.org__jridgewell_resolve_uri___resolve_uri_3.1.0.tgz";
-        url  = "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz";
+        url = "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz";
         sha512 = "F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==";
       };
     }
@@ -349,7 +355,7 @@
       name = "_jridgewell_resolve_uri___resolve_uri_3.1.1.tgz";
       path = fetchurl {
         name = "_jridgewell_resolve_uri___resolve_uri_3.1.1.tgz";
-        url  = "https://registry.yarnpkg.com/@jridgewell/resolve-uri/-/resolve-uri-3.1.1.tgz";
+        url = "https://registry.yarnpkg.com/@jridgewell/resolve-uri/-/resolve-uri-3.1.1.tgz";
         sha512 = "dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA==";
       };
     }
@@ -357,7 +363,7 @@
       name = "https___registry.npmjs.org__jridgewell_set_array___set_array_1.1.2.tgz";
       path = fetchurl {
         name = "https___registry.npmjs.org__jridgewell_set_array___set_array_1.1.2.tgz";
-        url  = "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz";
+        url = "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz";
         sha512 = "xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==";
       };
     }
@@ -365,7 +371,7 @@
       name = "https___registry.npmjs.org__jridgewell_sourcemap_codec___sourcemap_codec_1.4.14.tgz";
       path = fetchurl {
         name = "https___registry.npmjs.org__jridgewell_sourcemap_codec___sourcemap_codec_1.4.14.tgz";
-        url  = "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz";
+        url = "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz";
         sha512 = "XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==";
       };
     }
@@ -373,7 +379,7 @@
       name = "_jridgewell_sourcemap_codec___sourcemap_codec_1.4.15.tgz";
       path = fetchurl {
         name = "_jridgewell_sourcemap_codec___sourcemap_codec_1.4.15.tgz";
-        url  = "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz";
+        url = "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz";
         sha512 = "eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==";
       };
     }
@@ -381,7 +387,7 @@
       name = "_jridgewell_trace_mapping___trace_mapping_0.3.20.tgz";
       path = fetchurl {
         name = "_jridgewell_trace_mapping___trace_mapping_0.3.20.tgz";
-        url  = "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.20.tgz";
+        url = "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.20.tgz";
         sha512 = "R8LcPeWZol2zR8mmH3JeKQ6QRCFb7XgUhV9ZlGhHLGyg4wpPiPZNQOOWhFZhxKw8u//yTbNGI42Bx/3paXEQ+Q==";
       };
     }
@@ -389,7 +395,7 @@
       name = "https___registry.npmjs.org__jridgewell_trace_mapping___trace_mapping_0.3.17.tgz";
       path = fetchurl {
         name = "https___registry.npmjs.org__jridgewell_trace_mapping___trace_mapping_0.3.17.tgz";
-        url  = "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.17.tgz";
+        url = "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.17.tgz";
         sha512 = "MCNzAp77qzKca9+W/+I0+sEpaUnZoeasnghNeVc41VZCEKaCH73Vq3BZZ/SzWIgrqE4H4ceI+p+b6C0mHf9T4g==";
       };
     }
@@ -397,7 +403,7 @@
       name = "https___registry.npmjs.org__microsoft_fast_element___fast_element_1.11.0.tgz";
       path = fetchurl {
         name = "https___registry.npmjs.org__microsoft_fast_element___fast_element_1.11.0.tgz";
-        url  = "https://registry.npmjs.org/@microsoft/fast-element/-/fast-element-1.11.0.tgz";
+        url = "https://registry.npmjs.org/@microsoft/fast-element/-/fast-element-1.11.0.tgz";
         sha512 = "VKJYMkS5zgzHHb66sY7AFpYv6IfFhXrjQcAyNgi2ivD65My1XOhtjfKez5ELcLFRJfgZNAxvI8kE69apXERTkw==";
       };
     }
@@ -405,7 +411,7 @@
       name = "https___registry.npmjs.org__microsoft_fast_foundation___fast_foundation_2.47.0.tgz";
       path = fetchurl {
         name = "https___registry.npmjs.org__microsoft_fast_foundation___fast_foundation_2.47.0.tgz";
-        url  = "https://registry.npmjs.org/@microsoft/fast-foundation/-/fast-foundation-2.47.0.tgz";
+        url = "https://registry.npmjs.org/@microsoft/fast-foundation/-/fast-foundation-2.47.0.tgz";
         sha512 = "EyFuioaZQ9ngjUNRQi8R3dIPPsaNQdUOS+tP0G7b1MJRhXmQWIitBM6IeveQA6ZvXG6H21dqgrfEWlsYrUZ2sw==";
       };
     }
@@ -413,7 +419,7 @@
       name = "https___registry.npmjs.org__microsoft_fast_react_wrapper___fast_react_wrapper_0.1.48.tgz";
       path = fetchurl {
         name = "https___registry.npmjs.org__microsoft_fast_react_wrapper___fast_react_wrapper_0.1.48.tgz";
-        url  = "https://registry.npmjs.org/@microsoft/fast-react-wrapper/-/fast-react-wrapper-0.1.48.tgz";
+        url = "https://registry.npmjs.org/@microsoft/fast-react-wrapper/-/fast-react-wrapper-0.1.48.tgz";
         sha512 = "9NvEjru9Kn5ZKjomAMX6v+eF0DR+eDkxKDwDfi+Wb73kTbrNzcnmlwd4diN15ygH97kldgj2+lpvI4CKLQQWLg==";
       };
     }
@@ -421,7 +427,7 @@
       name = "https___registry.npmjs.org__microsoft_fast_web_utilities___fast_web_utilities_5.4.1.tgz";
       path = fetchurl {
         name = "https___registry.npmjs.org__microsoft_fast_web_utilities___fast_web_utilities_5.4.1.tgz";
-        url  = "https://registry.npmjs.org/@microsoft/fast-web-utilities/-/fast-web-utilities-5.4.1.tgz";
+        url = "https://registry.npmjs.org/@microsoft/fast-web-utilities/-/fast-web-utilities-5.4.1.tgz";
         sha512 = "ReWYncndjV3c8D8iq9tp7NcFNc1vbVHvcBFPME2nNFKNbS1XCesYZGlIlf3ot5EmuOXPlrzUHOWzQ2vFpIkqDg==";
       };
     }
@@ -429,7 +435,7 @@
       name = "https___registry.npmjs.org__rollup_pluginutils___pluginutils_4.2.1.tgz";
       path = fetchurl {
         name = "https___registry.npmjs.org__rollup_pluginutils___pluginutils_4.2.1.tgz";
-        url  = "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-4.2.1.tgz";
+        url = "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-4.2.1.tgz";
         sha512 = "iKnFXr7NkdZAIHiIWE+BX5ULi/ucVFYWD6TbAV+rZctiRTY2PL6tsIKhoIOaoskiWAkgu+VsbXgUVDNLHf+InQ==";
       };
     }
@@ -437,7 +443,7 @@
       name = "https___registry.npmjs.org__types_prop_types___prop_types_15.7.5.tgz";
       path = fetchurl {
         name = "https___registry.npmjs.org__types_prop_types___prop_types_15.7.5.tgz";
-        url  = "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.5.tgz";
+        url = "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.5.tgz";
         sha512 = "JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==";
       };
     }
@@ -445,7 +451,7 @@
       name = "https___registry.npmjs.org__types_react_dom___react_dom_17.0.18.tgz";
       path = fetchurl {
         name = "https___registry.npmjs.org__types_react_dom___react_dom_17.0.18.tgz";
-        url  = "https://registry.npmjs.org/@types/react-dom/-/react-dom-17.0.18.tgz";
+        url = "https://registry.npmjs.org/@types/react-dom/-/react-dom-17.0.18.tgz";
         sha512 = "rLVtIfbwyur2iFKykP2w0pl/1unw26b5td16d5xMgp7/yjTHomkyxPYChFoCr/FtEX1lN9wY6lFj1qvKdS5kDw==";
       };
     }
@@ -453,7 +459,7 @@
       name = "https___registry.npmjs.org__types_react___react_17.0.53.tgz";
       path = fetchurl {
         name = "https___registry.npmjs.org__types_react___react_17.0.53.tgz";
-        url  = "https://registry.npmjs.org/@types/react/-/react-17.0.53.tgz";
+        url = "https://registry.npmjs.org/@types/react/-/react-17.0.53.tgz";
         sha512 = "1yIpQR2zdYu1Z/dc1OxC+MA6GR240u3gcnP4l6mvj/PJiVaqHsQPmWttsvHsfnhfPbU2FuGmo0wSITPygjBmsw==";
       };
     }
@@ -461,7 +467,7 @@
       name = "https___registry.npmjs.org__types_scheduler___scheduler_0.16.2.tgz";
       path = fetchurl {
         name = "https___registry.npmjs.org__types_scheduler___scheduler_0.16.2.tgz";
-        url  = "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz";
+        url = "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz";
         sha512 = "hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==";
       };
     }
@@ -469,7 +475,7 @@
       name = "https___registry.npmjs.org__types_vscode_webview___vscode_webview_1.57.1.tgz";
       path = fetchurl {
         name = "https___registry.npmjs.org__types_vscode_webview___vscode_webview_1.57.1.tgz";
-        url  = "https://registry.npmjs.org/@types/vscode-webview/-/vscode-webview-1.57.1.tgz";
+        url = "https://registry.npmjs.org/@types/vscode-webview/-/vscode-webview-1.57.1.tgz";
         sha512 = "ghW5SfuDmsGDS2A4xkvGsLwDRNc3Vj5rS6rPOyPm/IryZuf3wceZKxgYaUoW+k9f0f/CB7y2c1rRsdOWZWn0PQ==";
       };
     }
@@ -477,7 +483,7 @@
       name = "https___registry.npmjs.org__vitejs_plugin_react___plugin_react_1.3.2.tgz";
       path = fetchurl {
         name = "https___registry.npmjs.org__vitejs_plugin_react___plugin_react_1.3.2.tgz";
-        url  = "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-1.3.2.tgz";
+        url = "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-1.3.2.tgz";
         sha512 = "aurBNmMo0kz1O4qRoY+FM4epSA39y3ShWGuqfLRA/3z0oEJAdtoSfgA3aO98/PCCHAqMaduLxIxErWrVKIFzXA==";
       };
     }
@@ -485,7 +491,7 @@
       name = "https___registry.npmjs.org__vscode_codicons___codicons_0.0.32.tgz";
       path = fetchurl {
         name = "https___registry.npmjs.org__vscode_codicons___codicons_0.0.32.tgz";
-        url  = "https://registry.npmjs.org/@vscode/codicons/-/codicons-0.0.32.tgz";
+        url = "https://registry.npmjs.org/@vscode/codicons/-/codicons-0.0.32.tgz";
         sha512 = "3lgSTWhAzzWN/EPURoY4ZDBEA80OPmnaknNujA3qnI4Iu7AONWd9xF3iE4L+4prIe8E3TUnLQ4pxoaFTEEZNwg==";
       };
     }
@@ -493,7 +499,7 @@
       name = "https___registry.npmjs.org__vscode_webview_ui_toolkit___webview_ui_toolkit_1.2.1.tgz";
       path = fetchurl {
         name = "https___registry.npmjs.org__vscode_webview_ui_toolkit___webview_ui_toolkit_1.2.1.tgz";
-        url  = "https://registry.npmjs.org/@vscode/webview-ui-toolkit/-/webview-ui-toolkit-1.2.1.tgz";
+        url = "https://registry.npmjs.org/@vscode/webview-ui-toolkit/-/webview-ui-toolkit-1.2.1.tgz";
         sha512 = "ZpVqLxoFWWk8mmAN7jr1v9yjD6NGBIoflAedNSusmaViqwHZ2znKBwAwcumLOlNlqmST6QMkiTVys7O8rzfd0w==";
       };
     }
@@ -501,7 +507,7 @@
       name = "https___registry.npmjs.org_ansi_styles___ansi_styles_3.2.1.tgz";
       path = fetchurl {
         name = "https___registry.npmjs.org_ansi_styles___ansi_styles_3.2.1.tgz";
-        url  = "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz";
+        url = "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz";
         sha512 = "VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==";
       };
     }
@@ -509,7 +515,7 @@
       name = "https___registry.npmjs.org_browserslist___browserslist_4.21.4.tgz";
       path = fetchurl {
         name = "https___registry.npmjs.org_browserslist___browserslist_4.21.4.tgz";
-        url  = "https://registry.npmjs.org/browserslist/-/browserslist-4.21.4.tgz";
+        url = "https://registry.npmjs.org/browserslist/-/browserslist-4.21.4.tgz";
         sha512 = "CBHJJdDmgjl3daYjN5Cp5kbTf1mUhZoS+beLklHIvkOWscs83YAhLlF3Wsh/lciQYAcbBJgTOD44VtG31ZM4Hw==";
       };
     }
@@ -517,7 +523,7 @@
       name = "https___registry.npmjs.org_caniuse_lite___caniuse_lite_1.0.30001447.tgz";
       path = fetchurl {
         name = "https___registry.npmjs.org_caniuse_lite___caniuse_lite_1.0.30001447.tgz";
-        url  = "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001447.tgz";
+        url = "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001447.tgz";
         sha512 = "bdKU1BQDPeEXe9A39xJnGtY0uRq/z5osrnXUw0TcK+EYno45Y+U7QU9HhHEyzvMDffpYadFXi3idnSNkcwLkTw==";
       };
     }
@@ -525,7 +531,7 @@
       name = "https___registry.npmjs.org_chalk___chalk_2.4.2.tgz";
       path = fetchurl {
         name = "https___registry.npmjs.org_chalk___chalk_2.4.2.tgz";
-        url  = "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz";
+        url = "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz";
         sha512 = "Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==";
       };
     }
@@ -533,7 +539,7 @@
       name = "https___registry.npmjs.org_color_convert___color_convert_1.9.3.tgz";
       path = fetchurl {
         name = "https___registry.npmjs.org_color_convert___color_convert_1.9.3.tgz";
-        url  = "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz";
+        url = "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz";
         sha512 = "QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==";
       };
     }
@@ -541,7 +547,7 @@
       name = "https___registry.npmjs.org_color_name___color_name_1.1.3.tgz";
       path = fetchurl {
         name = "https___registry.npmjs.org_color_name___color_name_1.1.3.tgz";
-        url  = "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz";
+        url = "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz";
         sha512 = "72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==";
       };
     }
@@ -549,7 +555,7 @@
       name = "https___registry.npmjs.org_convert_source_map___convert_source_map_1.9.0.tgz";
       path = fetchurl {
         name = "https___registry.npmjs.org_convert_source_map___convert_source_map_1.9.0.tgz";
-        url  = "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz";
+        url = "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz";
         sha512 = "ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==";
       };
     }
@@ -557,7 +563,7 @@
       name = "https___registry.npmjs.org_csstype___csstype_3.1.1.tgz";
       path = fetchurl {
         name = "https___registry.npmjs.org_csstype___csstype_3.1.1.tgz";
-        url  = "https://registry.npmjs.org/csstype/-/csstype-3.1.1.tgz";
+        url = "https://registry.npmjs.org/csstype/-/csstype-3.1.1.tgz";
         sha512 = "DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw==";
       };
     }
@@ -565,7 +571,7 @@
       name = "https___registry.npmjs.org_debug___debug_4.3.4.tgz";
       path = fetchurl {
         name = "https___registry.npmjs.org_debug___debug_4.3.4.tgz";
-        url  = "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz";
+        url = "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz";
         sha512 = "PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==";
       };
     }
@@ -573,7 +579,7 @@
       name = "https___registry.npmjs.org_electron_to_chromium___electron_to_chromium_1.4.284.tgz";
       path = fetchurl {
         name = "https___registry.npmjs.org_electron_to_chromium___electron_to_chromium_1.4.284.tgz";
-        url  = "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.284.tgz";
+        url = "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.284.tgz";
         sha512 = "M8WEXFuKXMYMVr45fo8mq0wUrrJHheiKZf6BArTKk9ZBYCKJEOU5H8cdWgDT+qCVZf7Na4lVUaZsA+h6uA9+PA==";
       };
     }
@@ -581,7 +587,7 @@
       name = "esbuild_android_64___esbuild_android_64_0.14.54.tgz";
       path = fetchurl {
         name = "esbuild_android_64___esbuild_android_64_0.14.54.tgz";
-        url  = "https://registry.yarnpkg.com/esbuild-android-64/-/esbuild-android-64-0.14.54.tgz";
+        url = "https://registry.yarnpkg.com/esbuild-android-64/-/esbuild-android-64-0.14.54.tgz";
         sha512 = "Tz2++Aqqz0rJ7kYBfz+iqyE3QMycD4vk7LBRyWaAVFgFtQ/O8EJOnVmTOiDWYZ/uYzB4kvP+bqejYdVKzE5lAQ==";
       };
     }
@@ -589,7 +595,7 @@
       name = "esbuild_android_arm64___esbuild_android_arm64_0.14.54.tgz";
       path = fetchurl {
         name = "esbuild_android_arm64___esbuild_android_arm64_0.14.54.tgz";
-        url  = "https://registry.yarnpkg.com/esbuild-android-arm64/-/esbuild-android-arm64-0.14.54.tgz";
+        url = "https://registry.yarnpkg.com/esbuild-android-arm64/-/esbuild-android-arm64-0.14.54.tgz";
         sha512 = "F9E+/QDi9sSkLaClO8SOV6etqPd+5DgJje1F9lOWoNncDdOBL2YF59IhsWATSt0TLZbYCf3pNlTHvVV5VfHdvg==";
       };
     }
@@ -597,7 +603,7 @@
       name = "esbuild_darwin_64___esbuild_darwin_64_0.14.54.tgz";
       path = fetchurl {
         name = "esbuild_darwin_64___esbuild_darwin_64_0.14.54.tgz";
-        url  = "https://registry.yarnpkg.com/esbuild-darwin-64/-/esbuild-darwin-64-0.14.54.tgz";
+        url = "https://registry.yarnpkg.com/esbuild-darwin-64/-/esbuild-darwin-64-0.14.54.tgz";
         sha512 = "jtdKWV3nBviOd5v4hOpkVmpxsBy90CGzebpbO9beiqUYVMBtSc0AL9zGftFuBon7PNDcdvNCEuQqw2x0wP9yug==";
       };
     }
@@ -605,7 +611,7 @@
       name = "esbuild_darwin_arm64___esbuild_darwin_arm64_0.14.54.tgz";
       path = fetchurl {
         name = "esbuild_darwin_arm64___esbuild_darwin_arm64_0.14.54.tgz";
-        url  = "https://registry.yarnpkg.com/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.54.tgz";
+        url = "https://registry.yarnpkg.com/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.54.tgz";
         sha512 = "OPafJHD2oUPyvJMrsCvDGkRrVCar5aVyHfWGQzY1dWnzErjrDuSETxwA2HSsyg2jORLY8yBfzc1MIpUkXlctmw==";
       };
     }
@@ -613,7 +619,7 @@
       name = "esbuild_freebsd_64___esbuild_freebsd_64_0.14.54.tgz";
       path = fetchurl {
         name = "esbuild_freebsd_64___esbuild_freebsd_64_0.14.54.tgz";
-        url  = "https://registry.yarnpkg.com/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.54.tgz";
+        url = "https://registry.yarnpkg.com/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.54.tgz";
         sha512 = "OKwd4gmwHqOTp4mOGZKe/XUlbDJ4Q9TjX0hMPIDBUWWu/kwhBAudJdBoxnjNf9ocIB6GN6CPowYpR/hRCbSYAg==";
       };
     }
@@ -621,7 +627,7 @@
       name = "esbuild_freebsd_arm64___esbuild_freebsd_arm64_0.14.54.tgz";
       path = fetchurl {
         name = "esbuild_freebsd_arm64___esbuild_freebsd_arm64_0.14.54.tgz";
-        url  = "https://registry.yarnpkg.com/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.54.tgz";
+        url = "https://registry.yarnpkg.com/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.54.tgz";
         sha512 = "sFwueGr7OvIFiQT6WeG0jRLjkjdqWWSrfbVwZp8iMP+8UHEHRBvlaxL6IuKNDwAozNUmbb8nIMXa7oAOARGs1Q==";
       };
     }
@@ -629,7 +635,7 @@
       name = "esbuild_linux_32___esbuild_linux_32_0.14.54.tgz";
       path = fetchurl {
         name = "esbuild_linux_32___esbuild_linux_32_0.14.54.tgz";
-        url  = "https://registry.yarnpkg.com/esbuild-linux-32/-/esbuild-linux-32-0.14.54.tgz";
+        url = "https://registry.yarnpkg.com/esbuild-linux-32/-/esbuild-linux-32-0.14.54.tgz";
         sha512 = "1ZuY+JDI//WmklKlBgJnglpUL1owm2OX+8E1syCD6UAxcMM/XoWd76OHSjl/0MR0LisSAXDqgjT3uJqT67O3qw==";
       };
     }
@@ -637,7 +643,7 @@
       name = "https___registry.npmjs.org_esbuild_linux_64___esbuild_linux_64_0.14.54.tgz";
       path = fetchurl {
         name = "https___registry.npmjs.org_esbuild_linux_64___esbuild_linux_64_0.14.54.tgz";
-        url  = "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.14.54.tgz";
+        url = "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.14.54.tgz";
         sha512 = "EgjAgH5HwTbtNsTqQOXWApBaPVdDn7XcK+/PtJwZLT1UmpLoznPd8c5CxqsH2dQK3j05YsB3L17T8vE7cp4cCg==";
       };
     }
@@ -645,7 +651,7 @@
       name = "esbuild_linux_arm64___esbuild_linux_arm64_0.14.54.tgz";
       path = fetchurl {
         name = "esbuild_linux_arm64___esbuild_linux_arm64_0.14.54.tgz";
-        url  = "https://registry.yarnpkg.com/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.54.tgz";
+        url = "https://registry.yarnpkg.com/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.54.tgz";
         sha512 = "WL71L+0Rwv+Gv/HTmxTEmpv0UgmxYa5ftZILVi2QmZBgX3q7+tDeOQNqGtdXSdsL8TQi1vIaVFHUPDe0O0kdig==";
       };
     }
@@ -653,7 +659,7 @@
       name = "esbuild_linux_arm___esbuild_linux_arm_0.14.54.tgz";
       path = fetchurl {
         name = "esbuild_linux_arm___esbuild_linux_arm_0.14.54.tgz";
-        url  = "https://registry.yarnpkg.com/esbuild-linux-arm/-/esbuild-linux-arm-0.14.54.tgz";
+        url = "https://registry.yarnpkg.com/esbuild-linux-arm/-/esbuild-linux-arm-0.14.54.tgz";
         sha512 = "qqz/SjemQhVMTnvcLGoLOdFpCYbz4v4fUo+TfsWG+1aOu70/80RV6bgNpR2JCrppV2moUQkww+6bWxXRL9YMGw==";
       };
     }
@@ -661,7 +667,7 @@
       name = "esbuild_linux_mips64le___esbuild_linux_mips64le_0.14.54.tgz";
       path = fetchurl {
         name = "esbuild_linux_mips64le___esbuild_linux_mips64le_0.14.54.tgz";
-        url  = "https://registry.yarnpkg.com/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.54.tgz";
+        url = "https://registry.yarnpkg.com/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.54.tgz";
         sha512 = "qTHGQB8D1etd0u1+sB6p0ikLKRVuCWhYQhAHRPkO+OF3I/iSlTKNNS0Lh2Oc0g0UFGguaFZZiPJdJey3AGpAlw==";
       };
     }
@@ -669,7 +675,7 @@
       name = "esbuild_linux_ppc64le___esbuild_linux_ppc64le_0.14.54.tgz";
       path = fetchurl {
         name = "esbuild_linux_ppc64le___esbuild_linux_ppc64le_0.14.54.tgz";
-        url  = "https://registry.yarnpkg.com/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.54.tgz";
+        url = "https://registry.yarnpkg.com/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.54.tgz";
         sha512 = "j3OMlzHiqwZBDPRCDFKcx595XVfOfOnv68Ax3U4UKZ3MTYQB5Yz3X1mn5GnodEVYzhtZgxEBidLWeIs8FDSfrQ==";
       };
     }
@@ -677,7 +683,7 @@
       name = "esbuild_linux_riscv64___esbuild_linux_riscv64_0.14.54.tgz";
       path = fetchurl {
         name = "esbuild_linux_riscv64___esbuild_linux_riscv64_0.14.54.tgz";
-        url  = "https://registry.yarnpkg.com/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.14.54.tgz";
+        url = "https://registry.yarnpkg.com/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.14.54.tgz";
         sha512 = "y7Vt7Wl9dkOGZjxQZnDAqqn+XOqFD7IMWiewY5SPlNlzMX39ocPQlOaoxvT4FllA5viyV26/QzHtvTjVNOxHZg==";
       };
     }
@@ -685,7 +691,7 @@
       name = "esbuild_linux_s390x___esbuild_linux_s390x_0.14.54.tgz";
       path = fetchurl {
         name = "esbuild_linux_s390x___esbuild_linux_s390x_0.14.54.tgz";
-        url  = "https://registry.yarnpkg.com/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.54.tgz";
+        url = "https://registry.yarnpkg.com/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.54.tgz";
         sha512 = "zaHpW9dziAsi7lRcyV4r8dhfG1qBidQWUXweUjnw+lliChJqQr+6XD71K41oEIC3Mx1KStovEmlzm+MkGZHnHA==";
       };
     }
@@ -693,7 +699,7 @@
       name = "esbuild_netbsd_64___esbuild_netbsd_64_0.14.54.tgz";
       path = fetchurl {
         name = "esbuild_netbsd_64___esbuild_netbsd_64_0.14.54.tgz";
-        url  = "https://registry.yarnpkg.com/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.54.tgz";
+        url = "https://registry.yarnpkg.com/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.54.tgz";
         sha512 = "PR01lmIMnfJTgeU9VJTDY9ZerDWVFIUzAtJuDHwwceppW7cQWjBBqP48NdeRtoP04/AtO9a7w3viI+PIDr6d+w==";
       };
     }
@@ -701,7 +707,7 @@
       name = "esbuild_openbsd_64___esbuild_openbsd_64_0.14.54.tgz";
       path = fetchurl {
         name = "esbuild_openbsd_64___esbuild_openbsd_64_0.14.54.tgz";
-        url  = "https://registry.yarnpkg.com/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.54.tgz";
+        url = "https://registry.yarnpkg.com/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.54.tgz";
         sha512 = "Qyk7ikT2o7Wu76UsvvDS5q0amJvmRzDyVlL0qf5VLsLchjCa1+IAvd8kTBgUxD7VBUUVgItLkk609ZHUc1oCaw==";
       };
     }
@@ -709,7 +715,7 @@
       name = "esbuild_sunos_64___esbuild_sunos_64_0.14.54.tgz";
       path = fetchurl {
         name = "esbuild_sunos_64___esbuild_sunos_64_0.14.54.tgz";
-        url  = "https://registry.yarnpkg.com/esbuild-sunos-64/-/esbuild-sunos-64-0.14.54.tgz";
+        url = "https://registry.yarnpkg.com/esbuild-sunos-64/-/esbuild-sunos-64-0.14.54.tgz";
         sha512 = "28GZ24KmMSeKi5ueWzMcco6EBHStL3B6ubM7M51RmPwXQGLe0teBGJocmWhgwccA1GeFXqxzILIxXpHbl9Q/Kw==";
       };
     }
@@ -717,7 +723,7 @@
       name = "esbuild_windows_32___esbuild_windows_32_0.14.54.tgz";
       path = fetchurl {
         name = "esbuild_windows_32___esbuild_windows_32_0.14.54.tgz";
-        url  = "https://registry.yarnpkg.com/esbuild-windows-32/-/esbuild-windows-32-0.14.54.tgz";
+        url = "https://registry.yarnpkg.com/esbuild-windows-32/-/esbuild-windows-32-0.14.54.tgz";
         sha512 = "T+rdZW19ql9MjS7pixmZYVObd9G7kcaZo+sETqNH4RCkuuYSuv9AGHUVnPoP9hhuE1WM1ZimHz1CIBHBboLU7w==";
       };
     }
@@ -725,7 +731,7 @@
       name = "esbuild_windows_64___esbuild_windows_64_0.14.54.tgz";
       path = fetchurl {
         name = "esbuild_windows_64___esbuild_windows_64_0.14.54.tgz";
-        url  = "https://registry.yarnpkg.com/esbuild-windows-64/-/esbuild-windows-64-0.14.54.tgz";
+        url = "https://registry.yarnpkg.com/esbuild-windows-64/-/esbuild-windows-64-0.14.54.tgz";
         sha512 = "AoHTRBUuYwXtZhjXZbA1pGfTo8cJo3vZIcWGLiUcTNgHpJJMC1rVA44ZereBHMJtotyN71S8Qw0npiCIkW96cQ==";
       };
     }
@@ -733,7 +739,7 @@
       name = "esbuild_windows_arm64___esbuild_windows_arm64_0.14.54.tgz";
       path = fetchurl {
         name = "esbuild_windows_arm64___esbuild_windows_arm64_0.14.54.tgz";
-        url  = "https://registry.yarnpkg.com/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.54.tgz";
+        url = "https://registry.yarnpkg.com/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.54.tgz";
         sha512 = "M0kuUvXhot1zOISQGXwWn6YtS+Y/1RT9WrVIOywZnJHo3jCDyewAc79aKNQWFCQm+xNHVTq9h8dZKvygoXQQRg==";
       };
     }
@@ -741,7 +747,7 @@
       name = "https___registry.npmjs.org_esbuild___esbuild_0.14.54.tgz";
       path = fetchurl {
         name = "https___registry.npmjs.org_esbuild___esbuild_0.14.54.tgz";
-        url  = "https://registry.npmjs.org/esbuild/-/esbuild-0.14.54.tgz";
+        url = "https://registry.npmjs.org/esbuild/-/esbuild-0.14.54.tgz";
         sha512 = "Cy9llcy8DvET5uznocPyqL3BFRrFXSVqbgpMJ9Wz8oVjZlh/zUSNbPRbov0VX7VxN2JH1Oa0uNxZ7eLRb62pJA==";
       };
     }
@@ -749,7 +755,7 @@
       name = "https___registry.npmjs.org_escalade___escalade_3.1.1.tgz";
       path = fetchurl {
         name = "https___registry.npmjs.org_escalade___escalade_3.1.1.tgz";
-        url  = "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz";
+        url = "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz";
         sha512 = "k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==";
       };
     }
@@ -757,7 +763,7 @@
       name = "https___registry.npmjs.org_escape_string_regexp___escape_string_regexp_1.0.5.tgz";
       path = fetchurl {
         name = "https___registry.npmjs.org_escape_string_regexp___escape_string_regexp_1.0.5.tgz";
-        url  = "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz";
+        url = "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz";
         sha512 = "vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==";
       };
     }
@@ -765,7 +771,7 @@
       name = "https___registry.npmjs.org_estree_walker___estree_walker_2.0.2.tgz";
       path = fetchurl {
         name = "https___registry.npmjs.org_estree_walker___estree_walker_2.0.2.tgz";
-        url  = "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz";
+        url = "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz";
         sha512 = "Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==";
       };
     }
@@ -773,7 +779,7 @@
       name = "https___registry.npmjs.org_exenv_es6___exenv_es6_1.1.1.tgz";
       path = fetchurl {
         name = "https___registry.npmjs.org_exenv_es6___exenv_es6_1.1.1.tgz";
-        url  = "https://registry.npmjs.org/exenv-es6/-/exenv-es6-1.1.1.tgz";
+        url = "https://registry.npmjs.org/exenv-es6/-/exenv-es6-1.1.1.tgz";
         sha512 = "vlVu3N8d6yEMpMsEm+7sUBAI81aqYYuEvfK0jNqmdb/OPXzzH7QWDDnVjMvDSY47JdHEqx/dfC/q8WkfoTmpGQ==";
       };
     }
@@ -781,7 +787,7 @@
       name = "fsevents___fsevents_2.3.2.tgz";
       path = fetchurl {
         name = "fsevents___fsevents_2.3.2.tgz";
-        url  = "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.2.tgz";
+        url = "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.2.tgz";
         sha512 = "xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==";
       };
     }
@@ -789,7 +795,7 @@
       name = "https___registry.npmjs.org_function_bind___function_bind_1.1.1.tgz";
       path = fetchurl {
         name = "https___registry.npmjs.org_function_bind___function_bind_1.1.1.tgz";
-        url  = "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz";
+        url = "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz";
         sha512 = "yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==";
       };
     }
@@ -797,7 +803,7 @@
       name = "https___registry.npmjs.org_gensync___gensync_1.0.0_beta.2.tgz";
       path = fetchurl {
         name = "https___registry.npmjs.org_gensync___gensync_1.0.0_beta.2.tgz";
-        url  = "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz";
+        url = "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz";
         sha512 = "3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==";
       };
     }
@@ -805,7 +811,7 @@
       name = "https___registry.npmjs.org_globals___globals_11.12.0.tgz";
       path = fetchurl {
         name = "https___registry.npmjs.org_globals___globals_11.12.0.tgz";
-        url  = "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz";
+        url = "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz";
         sha512 = "WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==";
       };
     }
@@ -813,7 +819,7 @@
       name = "https___registry.npmjs.org_has_flag___has_flag_3.0.0.tgz";
       path = fetchurl {
         name = "https___registry.npmjs.org_has_flag___has_flag_3.0.0.tgz";
-        url  = "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz";
+        url = "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz";
         sha512 = "sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==";
       };
     }
@@ -821,7 +827,7 @@
       name = "https___registry.npmjs.org_has___has_1.0.3.tgz";
       path = fetchurl {
         name = "https___registry.npmjs.org_has___has_1.0.3.tgz";
-        url  = "https://registry.npmjs.org/has/-/has-1.0.3.tgz";
+        url = "https://registry.npmjs.org/has/-/has-1.0.3.tgz";
         sha512 = "f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==";
       };
     }
@@ -829,7 +835,7 @@
       name = "https___registry.npmjs.org_is_core_module___is_core_module_2.11.0.tgz";
       path = fetchurl {
         name = "https___registry.npmjs.org_is_core_module___is_core_module_2.11.0.tgz";
-        url  = "https://registry.npmjs.org/is-core-module/-/is-core-module-2.11.0.tgz";
+        url = "https://registry.npmjs.org/is-core-module/-/is-core-module-2.11.0.tgz";
         sha512 = "RRjxlvLDkD1YJwDbroBHMb+cukurkDWNyHx7D3oNB5x9rb5ogcksMC5wHCadcXoo67gVr/+3GFySh3134zi6rw==";
       };
     }
@@ -837,7 +843,7 @@
       name = "https___registry.npmjs.org_js_tokens___js_tokens_4.0.0.tgz";
       path = fetchurl {
         name = "https___registry.npmjs.org_js_tokens___js_tokens_4.0.0.tgz";
-        url  = "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz";
+        url = "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz";
         sha512 = "RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==";
       };
     }
@@ -845,7 +851,7 @@
       name = "https___registry.npmjs.org_jsesc___jsesc_2.5.2.tgz";
       path = fetchurl {
         name = "https___registry.npmjs.org_jsesc___jsesc_2.5.2.tgz";
-        url  = "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz";
+        url = "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz";
         sha512 = "OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==";
       };
     }
@@ -853,7 +859,7 @@
       name = "https___registry.npmjs.org_json5___json5_2.2.3.tgz";
       path = fetchurl {
         name = "https___registry.npmjs.org_json5___json5_2.2.3.tgz";
-        url  = "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz";
+        url = "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz";
         sha512 = "XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==";
       };
     }
@@ -861,7 +867,7 @@
       name = "https___registry.npmjs.org_loose_envify___loose_envify_1.4.0.tgz";
       path = fetchurl {
         name = "https___registry.npmjs.org_loose_envify___loose_envify_1.4.0.tgz";
-        url  = "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz";
+        url = "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz";
         sha512 = "lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==";
       };
     }
@@ -869,7 +875,7 @@
       name = "https___registry.npmjs.org_lru_cache___lru_cache_5.1.1.tgz";
       path = fetchurl {
         name = "https___registry.npmjs.org_lru_cache___lru_cache_5.1.1.tgz";
-        url  = "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz";
+        url = "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz";
         sha512 = "KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==";
       };
     }
@@ -877,7 +883,7 @@
       name = "https___registry.npmjs.org_ms___ms_2.1.2.tgz";
       path = fetchurl {
         name = "https___registry.npmjs.org_ms___ms_2.1.2.tgz";
-        url  = "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz";
+        url = "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz";
         sha512 = "sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==";
       };
     }
@@ -885,7 +891,7 @@
       name = "nanoid___nanoid_3.3.6.tgz";
       path = fetchurl {
         name = "nanoid___nanoid_3.3.6.tgz";
-        url  = "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.6.tgz";
+        url = "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.6.tgz";
         sha512 = "BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==";
       };
     }
@@ -893,7 +899,7 @@
       name = "https___registry.npmjs.org_node_releases___node_releases_2.0.8.tgz";
       path = fetchurl {
         name = "https___registry.npmjs.org_node_releases___node_releases_2.0.8.tgz";
-        url  = "https://registry.npmjs.org/node-releases/-/node-releases-2.0.8.tgz";
+        url = "https://registry.npmjs.org/node-releases/-/node-releases-2.0.8.tgz";
         sha512 = "dFSmB8fFHEH/s81Xi+Y/15DQY6VHW81nXRj86EMSL3lmuTmK1e+aT4wrFCkTbm+gSwkw4KpX+rT/pMM2c1mF+A==";
       };
     }
@@ -901,7 +907,7 @@
       name = "https___registry.npmjs.org_object_assign___object_assign_4.1.1.tgz";
       path = fetchurl {
         name = "https___registry.npmjs.org_object_assign___object_assign_4.1.1.tgz";
-        url  = "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz";
+        url = "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz";
         sha512 = "rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==";
       };
     }
@@ -909,7 +915,7 @@
       name = "https___registry.npmjs.org_path_parse___path_parse_1.0.7.tgz";
       path = fetchurl {
         name = "https___registry.npmjs.org_path_parse___path_parse_1.0.7.tgz";
-        url  = "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz";
+        url = "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz";
         sha512 = "LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==";
       };
     }
@@ -917,7 +923,7 @@
       name = "https___registry.npmjs.org_picocolors___picocolors_1.0.0.tgz";
       path = fetchurl {
         name = "https___registry.npmjs.org_picocolors___picocolors_1.0.0.tgz";
-        url  = "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz";
+        url = "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz";
         sha512 = "1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==";
       };
     }
@@ -925,7 +931,7 @@
       name = "https___registry.npmjs.org_picomatch___picomatch_2.3.1.tgz";
       path = fetchurl {
         name = "https___registry.npmjs.org_picomatch___picomatch_2.3.1.tgz";
-        url  = "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz";
+        url = "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz";
         sha512 = "JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==";
       };
     }
@@ -933,7 +939,7 @@
       name = "postcss___postcss_8.4.31.tgz";
       path = fetchurl {
         name = "postcss___postcss_8.4.31.tgz";
-        url  = "https://registry.yarnpkg.com/postcss/-/postcss-8.4.31.tgz";
+        url = "https://registry.yarnpkg.com/postcss/-/postcss-8.4.31.tgz";
         sha512 = "PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==";
       };
     }
@@ -941,7 +947,7 @@
       name = "https___registry.npmjs.org_react_dom___react_dom_17.0.2.tgz";
       path = fetchurl {
         name = "https___registry.npmjs.org_react_dom___react_dom_17.0.2.tgz";
-        url  = "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz";
+        url = "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz";
         sha512 = "s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==";
       };
     }
@@ -949,7 +955,7 @@
       name = "react_icons___react_icons_4.7.1.tgz";
       path = fetchurl {
         name = "react_icons___react_icons_4.7.1.tgz";
-        url  = "https://registry.yarnpkg.com/react-icons/-/react-icons-4.7.1.tgz";
+        url = "https://registry.yarnpkg.com/react-icons/-/react-icons-4.7.1.tgz";
         sha512 = "yHd3oKGMgm7zxo3EA7H2n7vxSoiGmHk5t6Ou4bXsfcgWyhfDKMpyKfhHR6Bjnn63c+YXBLBPUql9H4wPJM6sXw==";
       };
     }
@@ -957,7 +963,7 @@
       name = "https___registry.npmjs.org_react_refresh___react_refresh_0.13.0.tgz";
       path = fetchurl {
         name = "https___registry.npmjs.org_react_refresh___react_refresh_0.13.0.tgz";
-        url  = "https://registry.npmjs.org/react-refresh/-/react-refresh-0.13.0.tgz";
+        url = "https://registry.npmjs.org/react-refresh/-/react-refresh-0.13.0.tgz";
         sha512 = "XP8A9BT0CpRBD+NYLLeIhld/RqG9+gktUjW1FkE+Vm7OCinbG1SshcK5tb9ls4kzvjZr9mOQc7HYgBngEyPAXg==";
       };
     }
@@ -965,7 +971,7 @@
       name = "https___registry.npmjs.org_react___react_17.0.2.tgz";
       path = fetchurl {
         name = "https___registry.npmjs.org_react___react_17.0.2.tgz";
-        url  = "https://registry.npmjs.org/react/-/react-17.0.2.tgz";
+        url = "https://registry.npmjs.org/react/-/react-17.0.2.tgz";
         sha512 = "gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==";
       };
     }
@@ -973,7 +979,7 @@
       name = "https___registry.npmjs.org_resolve___resolve_1.22.1.tgz";
       path = fetchurl {
         name = "https___registry.npmjs.org_resolve___resolve_1.22.1.tgz";
-        url  = "https://registry.npmjs.org/resolve/-/resolve-1.22.1.tgz";
+        url = "https://registry.npmjs.org/resolve/-/resolve-1.22.1.tgz";
         sha512 = "nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==";
       };
     }
@@ -981,7 +987,7 @@
       name = "https___registry.npmjs.org_rollup___rollup_2.77.3.tgz";
       path = fetchurl {
         name = "https___registry.npmjs.org_rollup___rollup_2.77.3.tgz";
-        url  = "https://registry.npmjs.org/rollup/-/rollup-2.77.3.tgz";
+        url = "https://registry.npmjs.org/rollup/-/rollup-2.77.3.tgz";
         sha512 = "/qxNTG7FbmefJWoeeYJFbHehJ2HNWnjkAFRKzWN/45eNBBF/r8lo992CwcJXEzyVxs5FmfId+vTSTQDb+bxA+g==";
       };
     }
@@ -989,7 +995,7 @@
       name = "https___registry.npmjs.org_scheduler___scheduler_0.20.2.tgz";
       path = fetchurl {
         name = "https___registry.npmjs.org_scheduler___scheduler_0.20.2.tgz";
-        url  = "https://registry.npmjs.org/scheduler/-/scheduler-0.20.2.tgz";
+        url = "https://registry.npmjs.org/scheduler/-/scheduler-0.20.2.tgz";
         sha512 = "2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==";
       };
     }
@@ -997,7 +1003,7 @@
       name = "semver___semver_6.3.1.tgz";
       path = fetchurl {
         name = "semver___semver_6.3.1.tgz";
-        url  = "https://registry.yarnpkg.com/semver/-/semver-6.3.1.tgz";
+        url = "https://registry.yarnpkg.com/semver/-/semver-6.3.1.tgz";
         sha512 = "BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==";
       };
     }
@@ -1005,7 +1011,7 @@
       name = "https___registry.npmjs.org_source_map_js___source_map_js_1.0.2.tgz";
       path = fetchurl {
         name = "https___registry.npmjs.org_source_map_js___source_map_js_1.0.2.tgz";
-        url  = "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz";
+        url = "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz";
         sha512 = "R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==";
       };
     }
@@ -1013,7 +1019,7 @@
       name = "https___registry.npmjs.org_supports_color___supports_color_5.5.0.tgz";
       path = fetchurl {
         name = "https___registry.npmjs.org_supports_color___supports_color_5.5.0.tgz";
-        url  = "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz";
+        url = "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz";
         sha512 = "QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==";
       };
     }
@@ -1021,7 +1027,7 @@
       name = "https___registry.npmjs.org_supports_preserve_symlinks_flag___supports_preserve_symlinks_flag_1.0.0.tgz";
       path = fetchurl {
         name = "https___registry.npmjs.org_supports_preserve_symlinks_flag___supports_preserve_symlinks_flag_1.0.0.tgz";
-        url  = "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz";
+        url = "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz";
         sha512 = "ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==";
       };
     }
@@ -1029,7 +1035,7 @@
       name = "https___registry.npmjs.org_tabbable___tabbable_5.3.3.tgz";
       path = fetchurl {
         name = "https___registry.npmjs.org_tabbable___tabbable_5.3.3.tgz";
-        url  = "https://registry.npmjs.org/tabbable/-/tabbable-5.3.3.tgz";
+        url = "https://registry.npmjs.org/tabbable/-/tabbable-5.3.3.tgz";
         sha512 = "QD9qKY3StfbZqWOPLp0++pOrAVb/HbUi5xCc8cUo4XjP19808oaMiDzn0leBY5mCespIBM0CIZePzZjgzR83kA==";
       };
     }
@@ -1037,7 +1043,7 @@
       name = "https___registry.npmjs.org_to_fast_properties___to_fast_properties_2.0.0.tgz";
       path = fetchurl {
         name = "https___registry.npmjs.org_to_fast_properties___to_fast_properties_2.0.0.tgz";
-        url  = "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz";
+        url = "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz";
         sha512 = "/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==";
       };
     }
@@ -1045,7 +1051,7 @@
       name = "https___registry.npmjs.org_tslib___tslib_1.14.1.tgz";
       path = fetchurl {
         name = "https___registry.npmjs.org_tslib___tslib_1.14.1.tgz";
-        url  = "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz";
+        url = "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz";
         sha512 = "Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==";
       };
     }
@@ -1053,7 +1059,7 @@
       name = "https___registry.npmjs.org_typescript___typescript_4.9.4.tgz";
       path = fetchurl {
         name = "https___registry.npmjs.org_typescript___typescript_4.9.4.tgz";
-        url  = "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz";
+        url = "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz";
         sha512 = "Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==";
       };
     }
@@ -1061,7 +1067,7 @@
       name = "https___registry.npmjs.org_update_browserslist_db___update_browserslist_db_1.0.10.tgz";
       path = fetchurl {
         name = "https___registry.npmjs.org_update_browserslist_db___update_browserslist_db_1.0.10.tgz";
-        url  = "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.10.tgz";
+        url = "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.10.tgz";
         sha512 = "OztqDenkfFkbSG+tRxBeAnCVPckDBcvibKd35yDONx6OU8N7sqgwc7rCbkJ/WcYtVRZ4ba68d6byhC21GFh7sQ==";
       };
     }
@@ -1069,7 +1075,7 @@
       name = "vite___vite_2.9.17.tgz";
       path = fetchurl {
         name = "vite___vite_2.9.17.tgz";
-        url  = "https://registry.yarnpkg.com/vite/-/vite-2.9.17.tgz";
+        url = "https://registry.yarnpkg.com/vite/-/vite-2.9.17.tgz";
         sha512 = "XxcRzra6d7xrKXH66jZUgb+srThoPu+TLJc06GifUyKq9JmjHkc1Numc8ra0h56rju2jfVWw3B3fs5l3OFMvUw==";
       };
     }
@@ -1077,7 +1083,7 @@
       name = "https___registry.npmjs.org_yallist___yallist_3.1.1.tgz";
       path = fetchurl {
         name = "https___registry.npmjs.org_yallist___yallist_3.1.1.tgz";
-        url  = "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz";
+        url = "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz";
         sha512 = "a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==";
       };
     }

--- a/client/search-ui/yarn.nix
+++ b/client/search-ui/yarn.nix
@@ -1,11 +1,17 @@
-{ fetchurl, fetchgit, linkFarm, runCommand, gnutar }: rec {
+{
+  fetchurl,
+  fetchgit,
+  linkFarm,
+  runCommand,
+  gnutar,
+}: rec {
   offline_cache = linkFarm "offline" packages;
   packages = [
     {
       name = "_ampproject_remapping___remapping_2.2.0.tgz";
       path = fetchurl {
         name = "_ampproject_remapping___remapping_2.2.0.tgz";
-        url  = "https://registry.yarnpkg.com/@ampproject/remapping/-/remapping-2.2.0.tgz";
+        url = "https://registry.yarnpkg.com/@ampproject/remapping/-/remapping-2.2.0.tgz";
         sha512 = "qRmjj8nj9qmLTQXXmaR1cck3UXSRMPrbsLJAasZpF+t3riI71BXed5ebIOYwQntykeZuhjsdweEc9BxH5Jc26w==";
       };
     }
@@ -13,7 +19,7 @@
       name = "_babel_code_frame___code_frame_7.18.6.tgz";
       path = fetchurl {
         name = "_babel_code_frame___code_frame_7.18.6.tgz";
-        url  = "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.18.6.tgz";
+        url = "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.18.6.tgz";
         sha512 = "TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==";
       };
     }
@@ -21,7 +27,7 @@
       name = "_babel_code_frame___code_frame_7.22.13.tgz";
       path = fetchurl {
         name = "_babel_code_frame___code_frame_7.22.13.tgz";
-        url  = "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.22.13.tgz";
+        url = "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.22.13.tgz";
         sha512 = "XktuhWlJ5g+3TJXc5upd9Ks1HutSArik6jf2eAjYFyIOf4ej3RN+184cZbzDvbPnuTJIUhPKKJE3cIsYTiAT3w==";
       };
     }
@@ -29,7 +35,7 @@
       name = "_babel_compat_data___compat_data_7.20.10.tgz";
       path = fetchurl {
         name = "_babel_compat_data___compat_data_7.20.10.tgz";
-        url  = "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.20.10.tgz";
+        url = "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.20.10.tgz";
         sha512 = "sEnuDPpOJR/fcafHMjpcpGN5M2jbUGUHwmuWKM/YdPzeEDJg8bgmbcWQFUfE32MQjti1koACvoPVsDe8Uq+idg==";
       };
     }
@@ -37,7 +43,7 @@
       name = "_babel_core___core_7.20.12.tgz";
       path = fetchurl {
         name = "_babel_core___core_7.20.12.tgz";
-        url  = "https://registry.yarnpkg.com/@babel/core/-/core-7.20.12.tgz";
+        url = "https://registry.yarnpkg.com/@babel/core/-/core-7.20.12.tgz";
         sha512 = "XsMfHovsUYHFMdrIHkZphTN/2Hzzi78R08NuHfDBehym2VsPDL6Zn/JAD/JQdnRvbSsbQc4mVaU1m6JgtTEElg==";
       };
     }
@@ -45,7 +51,7 @@
       name = "_babel_generator___generator_7.20.7.tgz";
       path = fetchurl {
         name = "_babel_generator___generator_7.20.7.tgz";
-        url  = "https://registry.yarnpkg.com/@babel/generator/-/generator-7.20.7.tgz";
+        url = "https://registry.yarnpkg.com/@babel/generator/-/generator-7.20.7.tgz";
         sha512 = "7wqMOJq8doJMZmP4ApXTzLxSr7+oO2jroJURrVEp6XShrQUObV8Tq/D0NCcoYg2uHqUrjzO0zwBjoYzelxK+sw==";
       };
     }
@@ -53,7 +59,7 @@
       name = "_babel_generator___generator_7.23.0.tgz";
       path = fetchurl {
         name = "_babel_generator___generator_7.23.0.tgz";
-        url  = "https://registry.yarnpkg.com/@babel/generator/-/generator-7.23.0.tgz";
+        url = "https://registry.yarnpkg.com/@babel/generator/-/generator-7.23.0.tgz";
         sha512 = "lN85QRR+5IbYrMWM6Y4pE/noaQtg4pNiqeNGX60eqOfo6gtEj6uw/JagelB8vVztSd7R6M5n1+PQkDbHbBRU4g==";
       };
     }
@@ -61,7 +67,7 @@
       name = "_babel_helper_annotate_as_pure___helper_annotate_as_pure_7.18.6.tgz";
       path = fetchurl {
         name = "_babel_helper_annotate_as_pure___helper_annotate_as_pure_7.18.6.tgz";
-        url  = "https://registry.yarnpkg.com/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.18.6.tgz";
+        url = "https://registry.yarnpkg.com/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.18.6.tgz";
         sha512 = "duORpUiYrEpzKIop6iNbjnwKLAKnJ47csTyRACyEmWj0QdUrm5aqNJGHSSEQSUAvNW0ojX0dOmK9dZduvkfeXA==";
       };
     }
@@ -69,7 +75,7 @@
       name = "_babel_helper_compilation_targets___helper_compilation_targets_7.20.7.tgz";
       path = fetchurl {
         name = "_babel_helper_compilation_targets___helper_compilation_targets_7.20.7.tgz";
-        url  = "https://registry.yarnpkg.com/@babel/helper-compilation-targets/-/helper-compilation-targets-7.20.7.tgz";
+        url = "https://registry.yarnpkg.com/@babel/helper-compilation-targets/-/helper-compilation-targets-7.20.7.tgz";
         sha512 = "4tGORmfQcrc+bvrjb5y3dG9Mx1IOZjsHqQVUz7XCNHO+iTmqxWnVg3KRygjGmpRLJGdQSKuvFinbIb0CnZwHAQ==";
       };
     }
@@ -77,7 +83,7 @@
       name = "_babel_helper_environment_visitor___helper_environment_visitor_7.18.9.tgz";
       path = fetchurl {
         name = "_babel_helper_environment_visitor___helper_environment_visitor_7.18.9.tgz";
-        url  = "https://registry.yarnpkg.com/@babel/helper-environment-visitor/-/helper-environment-visitor-7.18.9.tgz";
+        url = "https://registry.yarnpkg.com/@babel/helper-environment-visitor/-/helper-environment-visitor-7.18.9.tgz";
         sha512 = "3r/aACDJ3fhQ/EVgFy0hpj8oHyHpQc+LPtJoY9SzTThAsStm4Ptegq92vqKoE3vD706ZVFWITnMnxucw+S9Ipg==";
       };
     }
@@ -85,7 +91,7 @@
       name = "_babel_helper_environment_visitor___helper_environment_visitor_7.22.20.tgz";
       path = fetchurl {
         name = "_babel_helper_environment_visitor___helper_environment_visitor_7.22.20.tgz";
-        url  = "https://registry.yarnpkg.com/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.20.tgz";
+        url = "https://registry.yarnpkg.com/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.20.tgz";
         sha512 = "zfedSIzFhat/gFhWfHtgWvlec0nqB9YEIVrpuwjruLlXfUSnA8cJB0miHKwqDnQ7d32aKo2xt88/xZptwxbfhA==";
       };
     }
@@ -93,7 +99,7 @@
       name = "_babel_helper_function_name___helper_function_name_7.23.0.tgz";
       path = fetchurl {
         name = "_babel_helper_function_name___helper_function_name_7.23.0.tgz";
-        url  = "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.23.0.tgz";
+        url = "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.23.0.tgz";
         sha512 = "OErEqsrxjZTJciZ4Oo+eoZqeW9UIiOcuYKRJA4ZAgV9myA+pOXhhmpfNCKjEH/auVfEYVFJ6y1Tc4r0eIApqiw==";
       };
     }
@@ -101,7 +107,7 @@
       name = "_babel_helper_hoist_variables___helper_hoist_variables_7.22.5.tgz";
       path = fetchurl {
         name = "_babel_helper_hoist_variables___helper_hoist_variables_7.22.5.tgz";
-        url  = "https://registry.yarnpkg.com/@babel/helper-hoist-variables/-/helper-hoist-variables-7.22.5.tgz";
+        url = "https://registry.yarnpkg.com/@babel/helper-hoist-variables/-/helper-hoist-variables-7.22.5.tgz";
         sha512 = "wGjk9QZVzvknA6yKIUURb8zY3grXCcOZt+/7Wcy8O2uctxhplmUPkOdlgoNhmdVee2c92JXbf1xpMtVNbfoxRw==";
       };
     }
@@ -109,7 +115,7 @@
       name = "_babel_helper_module_imports___helper_module_imports_7.18.6.tgz";
       path = fetchurl {
         name = "_babel_helper_module_imports___helper_module_imports_7.18.6.tgz";
-        url  = "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.18.6.tgz";
+        url = "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.18.6.tgz";
         sha512 = "0NFvs3VkuSYbFi1x2Vd6tKrywq+z/cLeYC/RJNFrIX/30Bf5aiGYbtvGXolEktzJH8o5E5KJ3tT+nkxuuZFVlA==";
       };
     }
@@ -117,7 +123,7 @@
       name = "_babel_helper_module_transforms___helper_module_transforms_7.20.11.tgz";
       path = fetchurl {
         name = "_babel_helper_module_transforms___helper_module_transforms_7.20.11.tgz";
-        url  = "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.20.11.tgz";
+        url = "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.20.11.tgz";
         sha512 = "uRy78kN4psmji1s2QtbtcCSaj/LILFDp0f/ymhpQH5QY3nljUZCaNWz9X1dEj/8MBdBEFECs7yRhKn8i7NjZgg==";
       };
     }
@@ -125,7 +131,7 @@
       name = "_babel_helper_plugin_utils___helper_plugin_utils_7.20.2.tgz";
       path = fetchurl {
         name = "_babel_helper_plugin_utils___helper_plugin_utils_7.20.2.tgz";
-        url  = "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.20.2.tgz";
+        url = "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.20.2.tgz";
         sha512 = "8RvlJG2mj4huQ4pZ+rU9lqKi9ZKiRmuvGuM2HlWmkmgOhbs6zEAw6IEiJ5cQqGbDzGZOhwuOQNtZMi/ENLjZoQ==";
       };
     }
@@ -133,7 +139,7 @@
       name = "_babel_helper_simple_access___helper_simple_access_7.20.2.tgz";
       path = fetchurl {
         name = "_babel_helper_simple_access___helper_simple_access_7.20.2.tgz";
-        url  = "https://registry.yarnpkg.com/@babel/helper-simple-access/-/helper-simple-access-7.20.2.tgz";
+        url = "https://registry.yarnpkg.com/@babel/helper-simple-access/-/helper-simple-access-7.20.2.tgz";
         sha512 = "+0woI/WPq59IrqDYbVGfshjT5Dmk/nnbdpcF8SnMhhXObpTq2KNBdLFRFrkVdbDOyUmHBCxzm5FHV1rACIkIbA==";
       };
     }
@@ -141,7 +147,7 @@
       name = "_babel_helper_split_export_declaration___helper_split_export_declaration_7.18.6.tgz";
       path = fetchurl {
         name = "_babel_helper_split_export_declaration___helper_split_export_declaration_7.18.6.tgz";
-        url  = "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.18.6.tgz";
+        url = "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.18.6.tgz";
         sha512 = "bde1etTx6ZyTmobl9LLMMQsaizFVZrquTEHOqKeQESMKo4PlObf+8+JA25ZsIpZhT/WEd39+vOdLXAFG/nELpA==";
       };
     }
@@ -149,7 +155,7 @@
       name = "_babel_helper_split_export_declaration___helper_split_export_declaration_7.22.6.tgz";
       path = fetchurl {
         name = "_babel_helper_split_export_declaration___helper_split_export_declaration_7.22.6.tgz";
-        url  = "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.22.6.tgz";
+        url = "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.22.6.tgz";
         sha512 = "AsUnxuLhRYsisFiaJwvp1QF+I3KjD5FOxut14q/GzovUe6orHLesW2C7d754kRm53h5gqrz6sFl6sxc4BVtE/g==";
       };
     }
@@ -157,7 +163,7 @@
       name = "_babel_helper_string_parser___helper_string_parser_7.19.4.tgz";
       path = fetchurl {
         name = "_babel_helper_string_parser___helper_string_parser_7.19.4.tgz";
-        url  = "https://registry.yarnpkg.com/@babel/helper-string-parser/-/helper-string-parser-7.19.4.tgz";
+        url = "https://registry.yarnpkg.com/@babel/helper-string-parser/-/helper-string-parser-7.19.4.tgz";
         sha512 = "nHtDoQcuqFmwYNYPz3Rah5ph2p8PFeFCsZk9A/48dPc/rGocJ5J3hAAZ7pb76VWX3fZKu+uEr/FhH5jLx7umrw==";
       };
     }
@@ -165,7 +171,7 @@
       name = "_babel_helper_string_parser___helper_string_parser_7.22.5.tgz";
       path = fetchurl {
         name = "_babel_helper_string_parser___helper_string_parser_7.22.5.tgz";
-        url  = "https://registry.yarnpkg.com/@babel/helper-string-parser/-/helper-string-parser-7.22.5.tgz";
+        url = "https://registry.yarnpkg.com/@babel/helper-string-parser/-/helper-string-parser-7.22.5.tgz";
         sha512 = "mM4COjgZox8U+JcXQwPijIZLElkgEpO5rsERVDJTc2qfCDfERyob6k5WegS14SX18IIjv+XD+GrqNumY5JRCDw==";
       };
     }
@@ -173,7 +179,7 @@
       name = "_babel_helper_validator_identifier___helper_validator_identifier_7.19.1.tgz";
       path = fetchurl {
         name = "_babel_helper_validator_identifier___helper_validator_identifier_7.19.1.tgz";
-        url  = "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.19.1.tgz";
+        url = "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.19.1.tgz";
         sha512 = "awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w==";
       };
     }
@@ -181,7 +187,7 @@
       name = "_babel_helper_validator_identifier___helper_validator_identifier_7.22.20.tgz";
       path = fetchurl {
         name = "_babel_helper_validator_identifier___helper_validator_identifier_7.22.20.tgz";
-        url  = "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz";
+        url = "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz";
         sha512 = "Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==";
       };
     }
@@ -189,7 +195,7 @@
       name = "_babel_helper_validator_option___helper_validator_option_7.18.6.tgz";
       path = fetchurl {
         name = "_babel_helper_validator_option___helper_validator_option_7.18.6.tgz";
-        url  = "https://registry.yarnpkg.com/@babel/helper-validator-option/-/helper-validator-option-7.18.6.tgz";
+        url = "https://registry.yarnpkg.com/@babel/helper-validator-option/-/helper-validator-option-7.18.6.tgz";
         sha512 = "XO7gESt5ouv/LRJdrVjkShckw6STTaB7l9BrpBaAHDeF5YZT+01PCwmR0SJHnkW6i8OwW/EVWRShfi4j2x+KQw==";
       };
     }
@@ -197,7 +203,7 @@
       name = "_babel_helpers___helpers_7.20.13.tgz";
       path = fetchurl {
         name = "_babel_helpers___helpers_7.20.13.tgz";
-        url  = "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.20.13.tgz";
+        url = "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.20.13.tgz";
         sha512 = "nzJ0DWCL3gB5RCXbUO3KIMMsBY2Eqbx8mBpKGE/02PgyRQFcPQLbkQ1vyy596mZLaP+dAfD+R4ckASzNVmW3jg==";
       };
     }
@@ -205,7 +211,7 @@
       name = "_babel_highlight___highlight_7.18.6.tgz";
       path = fetchurl {
         name = "_babel_highlight___highlight_7.18.6.tgz";
-        url  = "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.18.6.tgz";
+        url = "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.18.6.tgz";
         sha512 = "u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==";
       };
     }
@@ -213,7 +219,7 @@
       name = "_babel_highlight___highlight_7.22.20.tgz";
       path = fetchurl {
         name = "_babel_highlight___highlight_7.22.20.tgz";
-        url  = "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.22.20.tgz";
+        url = "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.22.20.tgz";
         sha512 = "dkdMCN3py0+ksCgYmGG8jKeGA/8Tk+gJwSYYlFGxG5lmhfKNoAy004YpLxpS1W2J8m/EK2Ew+yOs9pVRwO89mg==";
       };
     }
@@ -221,7 +227,7 @@
       name = "_babel_parser___parser_7.20.13.tgz";
       path = fetchurl {
         name = "_babel_parser___parser_7.20.13.tgz";
-        url  = "https://registry.yarnpkg.com/@babel/parser/-/parser-7.20.13.tgz";
+        url = "https://registry.yarnpkg.com/@babel/parser/-/parser-7.20.13.tgz";
         sha512 = "gFDLKMfpiXCsjt4za2JA9oTMn70CeseCehb11kRZgvd7+F67Hih3OHOK24cRrWECJ/ljfPGac6ygXAs/C8kIvw==";
       };
     }
@@ -229,7 +235,7 @@
       name = "_babel_parser___parser_7.23.0.tgz";
       path = fetchurl {
         name = "_babel_parser___parser_7.23.0.tgz";
-        url  = "https://registry.yarnpkg.com/@babel/parser/-/parser-7.23.0.tgz";
+        url = "https://registry.yarnpkg.com/@babel/parser/-/parser-7.23.0.tgz";
         sha512 = "vvPKKdMemU85V9WE/l5wZEmImpCtLqbnTvqDS2U1fJ96KrxoW7KrXhNsNCblQlg8Ck4b85yxdTyelsMUgFUXiw==";
       };
     }
@@ -237,7 +243,7 @@
       name = "_babel_plugin_syntax_jsx___plugin_syntax_jsx_7.18.6.tgz";
       path = fetchurl {
         name = "_babel_plugin_syntax_jsx___plugin_syntax_jsx_7.18.6.tgz";
-        url  = "https://registry.yarnpkg.com/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.18.6.tgz";
+        url = "https://registry.yarnpkg.com/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.18.6.tgz";
         sha512 = "6mmljtAedFGTWu2p/8WIORGwy+61PLgOMPOdazc7YoJ9ZCWUyFy3A6CpPkRKLKD1ToAesxX8KGEViAiLo9N+7Q==";
       };
     }
@@ -245,7 +251,7 @@
       name = "_babel_plugin_transform_react_jsx_development___plugin_transform_react_jsx_development_7.18.6.tgz";
       path = fetchurl {
         name = "_babel_plugin_transform_react_jsx_development___plugin_transform_react_jsx_development_7.18.6.tgz";
-        url  = "https://registry.yarnpkg.com/@babel/plugin-transform-react-jsx-development/-/plugin-transform-react-jsx-development-7.18.6.tgz";
+        url = "https://registry.yarnpkg.com/@babel/plugin-transform-react-jsx-development/-/plugin-transform-react-jsx-development-7.18.6.tgz";
         sha512 = "SA6HEjwYFKF7WDjWcMcMGUimmw/nhNRDWxr+KaLSCrkD/LMDBvWRmHAYgE1HDeF8KUuI8OAu+RT6EOtKxSW2qA==";
       };
     }
@@ -253,7 +259,7 @@
       name = "_babel_plugin_transform_react_jsx_self___plugin_transform_react_jsx_self_7.18.6.tgz";
       path = fetchurl {
         name = "_babel_plugin_transform_react_jsx_self___plugin_transform_react_jsx_self_7.18.6.tgz";
-        url  = "https://registry.yarnpkg.com/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.18.6.tgz";
+        url = "https://registry.yarnpkg.com/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.18.6.tgz";
         sha512 = "A0LQGx4+4Jv7u/tWzoJF7alZwnBDQd6cGLh9P+Ttk4dpiL+J5p7NSNv/9tlEFFJDq3kjxOavWmbm6t0Gk+A3Ig==";
       };
     }
@@ -261,7 +267,7 @@
       name = "_babel_plugin_transform_react_jsx_source___plugin_transform_react_jsx_source_7.19.6.tgz";
       path = fetchurl {
         name = "_babel_plugin_transform_react_jsx_source___plugin_transform_react_jsx_source_7.19.6.tgz";
-        url  = "https://registry.yarnpkg.com/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.19.6.tgz";
+        url = "https://registry.yarnpkg.com/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.19.6.tgz";
         sha512 = "RpAi004QyMNisst/pvSanoRdJ4q+jMCWyk9zdw/CyLB9j8RXEahodR6l2GyttDRyEVWZtbN+TpLiHJ3t34LbsQ==";
       };
     }
@@ -269,7 +275,7 @@
       name = "_babel_plugin_transform_react_jsx___plugin_transform_react_jsx_7.20.13.tgz";
       path = fetchurl {
         name = "_babel_plugin_transform_react_jsx___plugin_transform_react_jsx_7.20.13.tgz";
-        url  = "https://registry.yarnpkg.com/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.20.13.tgz";
+        url = "https://registry.yarnpkg.com/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.20.13.tgz";
         sha512 = "MmTZx/bkUrfJhhYAYt3Urjm+h8DQGrPrnKQ94jLo7NLuOU+T89a7IByhKmrb8SKhrIYIQ0FN0CHMbnFRen4qNw==";
       };
     }
@@ -277,7 +283,7 @@
       name = "_babel_template___template_7.20.7.tgz";
       path = fetchurl {
         name = "_babel_template___template_7.20.7.tgz";
-        url  = "https://registry.yarnpkg.com/@babel/template/-/template-7.20.7.tgz";
+        url = "https://registry.yarnpkg.com/@babel/template/-/template-7.20.7.tgz";
         sha512 = "8SegXApWe6VoNw0r9JHpSteLKTpTiLZ4rMlGIm9JQ18KiCtyQiAMEazujAHrUS5flrcqYZa75ukev3P6QmUwUw==";
       };
     }
@@ -285,7 +291,7 @@
       name = "_babel_template___template_7.22.15.tgz";
       path = fetchurl {
         name = "_babel_template___template_7.22.15.tgz";
-        url  = "https://registry.yarnpkg.com/@babel/template/-/template-7.22.15.tgz";
+        url = "https://registry.yarnpkg.com/@babel/template/-/template-7.22.15.tgz";
         sha512 = "QPErUVm4uyJa60rkI73qneDacvdvzxshT3kksGqlGWYdOTIUOwJ7RDUL8sGqslY1uXWSL6xMFKEXDS3ox2uF0w==";
       };
     }
@@ -293,7 +299,7 @@
       name = "_babel_traverse___traverse_7.23.2.tgz";
       path = fetchurl {
         name = "_babel_traverse___traverse_7.23.2.tgz";
-        url  = "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.23.2.tgz";
+        url = "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.23.2.tgz";
         sha512 = "azpe59SQ48qG6nu2CzcMLbxUudtN+dOM9kDbUqGq3HXUJRlo7i8fvPoxQUzYgLZ4cMVmuZgm8vvBpNeRhd6XSw==";
       };
     }
@@ -301,7 +307,7 @@
       name = "_babel_types___types_7.20.7.tgz";
       path = fetchurl {
         name = "_babel_types___types_7.20.7.tgz";
-        url  = "https://registry.yarnpkg.com/@babel/types/-/types-7.20.7.tgz";
+        url = "https://registry.yarnpkg.com/@babel/types/-/types-7.20.7.tgz";
         sha512 = "69OnhBxSSgK0OzTJai4kyPDiKTIe3j+ctaHdIGVbRahTLAT7L3R9oeXHC2aVSuGYt3cVnoAMDmOCgJ2yaiLMvg==";
       };
     }
@@ -309,7 +315,7 @@
       name = "_babel_types___types_7.23.0.tgz";
       path = fetchurl {
         name = "_babel_types___types_7.23.0.tgz";
-        url  = "https://registry.yarnpkg.com/@babel/types/-/types-7.23.0.tgz";
+        url = "https://registry.yarnpkg.com/@babel/types/-/types-7.23.0.tgz";
         sha512 = "0oIyUfKoI3mSqMvsxBdclDwxXKXAUA8v/apZbc+iSyARYou1o8ZGDxbUYyLFoW2arqS2jDGqJuZvv1d/io1axg==";
       };
     }
@@ -317,7 +323,7 @@
       name = "_esbuild_linux_loong64___linux_loong64_0.14.54.tgz";
       path = fetchurl {
         name = "_esbuild_linux_loong64___linux_loong64_0.14.54.tgz";
-        url  = "https://registry.yarnpkg.com/@esbuild/linux-loong64/-/linux-loong64-0.14.54.tgz";
+        url = "https://registry.yarnpkg.com/@esbuild/linux-loong64/-/linux-loong64-0.14.54.tgz";
         sha512 = "bZBrLAIX1kpWelV0XemxBZllyRmM6vgFQQG2GdNb+r3Fkp0FOh1NJSvekXDs7jq70k4euu1cryLMfU+mTXlEpw==";
       };
     }
@@ -325,7 +331,7 @@
       name = "_jridgewell_gen_mapping___gen_mapping_0.1.1.tgz";
       path = fetchurl {
         name = "_jridgewell_gen_mapping___gen_mapping_0.1.1.tgz";
-        url  = "https://registry.yarnpkg.com/@jridgewell/gen-mapping/-/gen-mapping-0.1.1.tgz";
+        url = "https://registry.yarnpkg.com/@jridgewell/gen-mapping/-/gen-mapping-0.1.1.tgz";
         sha512 = "sQXCasFk+U8lWYEe66WxRDOE9PjVz4vSM51fTu3Hw+ClTpUSQb718772vH3pyS5pShp6lvQM7SxgIDXXXmOX7w==";
       };
     }
@@ -333,7 +339,7 @@
       name = "_jridgewell_gen_mapping___gen_mapping_0.3.2.tgz";
       path = fetchurl {
         name = "_jridgewell_gen_mapping___gen_mapping_0.3.2.tgz";
-        url  = "https://registry.yarnpkg.com/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz";
+        url = "https://registry.yarnpkg.com/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz";
         sha512 = "mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==";
       };
     }
@@ -341,7 +347,7 @@
       name = "_jridgewell_resolve_uri___resolve_uri_3.1.0.tgz";
       path = fetchurl {
         name = "_jridgewell_resolve_uri___resolve_uri_3.1.0.tgz";
-        url  = "https://registry.yarnpkg.com/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz";
+        url = "https://registry.yarnpkg.com/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz";
         sha512 = "F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==";
       };
     }
@@ -349,7 +355,7 @@
       name = "_jridgewell_resolve_uri___resolve_uri_3.1.1.tgz";
       path = fetchurl {
         name = "_jridgewell_resolve_uri___resolve_uri_3.1.1.tgz";
-        url  = "https://registry.yarnpkg.com/@jridgewell/resolve-uri/-/resolve-uri-3.1.1.tgz";
+        url = "https://registry.yarnpkg.com/@jridgewell/resolve-uri/-/resolve-uri-3.1.1.tgz";
         sha512 = "dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA==";
       };
     }
@@ -357,7 +363,7 @@
       name = "_jridgewell_set_array___set_array_1.1.2.tgz";
       path = fetchurl {
         name = "_jridgewell_set_array___set_array_1.1.2.tgz";
-        url  = "https://registry.yarnpkg.com/@jridgewell/set-array/-/set-array-1.1.2.tgz";
+        url = "https://registry.yarnpkg.com/@jridgewell/set-array/-/set-array-1.1.2.tgz";
         sha512 = "xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==";
       };
     }
@@ -365,7 +371,7 @@
       name = "_jridgewell_sourcemap_codec___sourcemap_codec_1.4.14.tgz";
       path = fetchurl {
         name = "_jridgewell_sourcemap_codec___sourcemap_codec_1.4.14.tgz";
-        url  = "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz";
+        url = "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz";
         sha512 = "XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==";
       };
     }
@@ -373,7 +379,7 @@
       name = "_jridgewell_sourcemap_codec___sourcemap_codec_1.4.15.tgz";
       path = fetchurl {
         name = "_jridgewell_sourcemap_codec___sourcemap_codec_1.4.15.tgz";
-        url  = "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz";
+        url = "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz";
         sha512 = "eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==";
       };
     }
@@ -381,7 +387,7 @@
       name = "_jridgewell_trace_mapping___trace_mapping_0.3.20.tgz";
       path = fetchurl {
         name = "_jridgewell_trace_mapping___trace_mapping_0.3.20.tgz";
-        url  = "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.20.tgz";
+        url = "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.20.tgz";
         sha512 = "R8LcPeWZol2zR8mmH3JeKQ6QRCFb7XgUhV9ZlGhHLGyg4wpPiPZNQOOWhFZhxKw8u//yTbNGI42Bx/3paXEQ+Q==";
       };
     }
@@ -389,7 +395,7 @@
       name = "_jridgewell_trace_mapping___trace_mapping_0.3.17.tgz";
       path = fetchurl {
         name = "_jridgewell_trace_mapping___trace_mapping_0.3.17.tgz";
-        url  = "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.17.tgz";
+        url = "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.17.tgz";
         sha512 = "MCNzAp77qzKca9+W/+I0+sEpaUnZoeasnghNeVc41VZCEKaCH73Vq3BZZ/SzWIgrqE4H4ceI+p+b6C0mHf9T4g==";
       };
     }
@@ -397,7 +403,7 @@
       name = "_microsoft_fast_element___fast_element_1.11.0.tgz";
       path = fetchurl {
         name = "_microsoft_fast_element___fast_element_1.11.0.tgz";
-        url  = "https://registry.yarnpkg.com/@microsoft/fast-element/-/fast-element-1.11.0.tgz";
+        url = "https://registry.yarnpkg.com/@microsoft/fast-element/-/fast-element-1.11.0.tgz";
         sha512 = "VKJYMkS5zgzHHb66sY7AFpYv6IfFhXrjQcAyNgi2ivD65My1XOhtjfKez5ELcLFRJfgZNAxvI8kE69apXERTkw==";
       };
     }
@@ -405,7 +411,7 @@
       name = "_microsoft_fast_foundation___fast_foundation_2.47.0.tgz";
       path = fetchurl {
         name = "_microsoft_fast_foundation___fast_foundation_2.47.0.tgz";
-        url  = "https://registry.yarnpkg.com/@microsoft/fast-foundation/-/fast-foundation-2.47.0.tgz";
+        url = "https://registry.yarnpkg.com/@microsoft/fast-foundation/-/fast-foundation-2.47.0.tgz";
         sha512 = "EyFuioaZQ9ngjUNRQi8R3dIPPsaNQdUOS+tP0G7b1MJRhXmQWIitBM6IeveQA6ZvXG6H21dqgrfEWlsYrUZ2sw==";
       };
     }
@@ -413,7 +419,7 @@
       name = "_microsoft_fast_react_wrapper___fast_react_wrapper_0.1.48.tgz";
       path = fetchurl {
         name = "_microsoft_fast_react_wrapper___fast_react_wrapper_0.1.48.tgz";
-        url  = "https://registry.yarnpkg.com/@microsoft/fast-react-wrapper/-/fast-react-wrapper-0.1.48.tgz";
+        url = "https://registry.yarnpkg.com/@microsoft/fast-react-wrapper/-/fast-react-wrapper-0.1.48.tgz";
         sha512 = "9NvEjru9Kn5ZKjomAMX6v+eF0DR+eDkxKDwDfi+Wb73kTbrNzcnmlwd4diN15ygH97kldgj2+lpvI4CKLQQWLg==";
       };
     }
@@ -421,7 +427,7 @@
       name = "_microsoft_fast_web_utilities___fast_web_utilities_5.4.1.tgz";
       path = fetchurl {
         name = "_microsoft_fast_web_utilities___fast_web_utilities_5.4.1.tgz";
-        url  = "https://registry.yarnpkg.com/@microsoft/fast-web-utilities/-/fast-web-utilities-5.4.1.tgz";
+        url = "https://registry.yarnpkg.com/@microsoft/fast-web-utilities/-/fast-web-utilities-5.4.1.tgz";
         sha512 = "ReWYncndjV3c8D8iq9tp7NcFNc1vbVHvcBFPME2nNFKNbS1XCesYZGlIlf3ot5EmuOXPlrzUHOWzQ2vFpIkqDg==";
       };
     }
@@ -429,7 +435,7 @@
       name = "_rollup_pluginutils___pluginutils_4.2.1.tgz";
       path = fetchurl {
         name = "_rollup_pluginutils___pluginutils_4.2.1.tgz";
-        url  = "https://registry.yarnpkg.com/@rollup/pluginutils/-/pluginutils-4.2.1.tgz";
+        url = "https://registry.yarnpkg.com/@rollup/pluginutils/-/pluginutils-4.2.1.tgz";
         sha512 = "iKnFXr7NkdZAIHiIWE+BX5ULi/ucVFYWD6TbAV+rZctiRTY2PL6tsIKhoIOaoskiWAkgu+VsbXgUVDNLHf+InQ==";
       };
     }
@@ -437,7 +443,7 @@
       name = "_types_prop_types___prop_types_15.7.5.tgz";
       path = fetchurl {
         name = "_types_prop_types___prop_types_15.7.5.tgz";
-        url  = "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.5.tgz";
+        url = "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.5.tgz";
         sha512 = "JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==";
       };
     }
@@ -445,7 +451,7 @@
       name = "_types_react_dom___react_dom_17.0.18.tgz";
       path = fetchurl {
         name = "_types_react_dom___react_dom_17.0.18.tgz";
-        url  = "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-17.0.18.tgz";
+        url = "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-17.0.18.tgz";
         sha512 = "rLVtIfbwyur2iFKykP2w0pl/1unw26b5td16d5xMgp7/yjTHomkyxPYChFoCr/FtEX1lN9wY6lFj1qvKdS5kDw==";
       };
     }
@@ -453,7 +459,7 @@
       name = "_types_react___react_17.0.53.tgz";
       path = fetchurl {
         name = "_types_react___react_17.0.53.tgz";
-        url  = "https://registry.yarnpkg.com/@types/react/-/react-17.0.53.tgz";
+        url = "https://registry.yarnpkg.com/@types/react/-/react-17.0.53.tgz";
         sha512 = "1yIpQR2zdYu1Z/dc1OxC+MA6GR240u3gcnP4l6mvj/PJiVaqHsQPmWttsvHsfnhfPbU2FuGmo0wSITPygjBmsw==";
       };
     }
@@ -461,7 +467,7 @@
       name = "_types_scheduler___scheduler_0.16.2.tgz";
       path = fetchurl {
         name = "_types_scheduler___scheduler_0.16.2.tgz";
-        url  = "https://registry.yarnpkg.com/@types/scheduler/-/scheduler-0.16.2.tgz";
+        url = "https://registry.yarnpkg.com/@types/scheduler/-/scheduler-0.16.2.tgz";
         sha512 = "hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==";
       };
     }
@@ -469,7 +475,7 @@
       name = "_types_uuid___uuid_8.3.4.tgz";
       path = fetchurl {
         name = "_types_uuid___uuid_8.3.4.tgz";
-        url  = "https://registry.yarnpkg.com/@types/uuid/-/uuid-8.3.4.tgz";
+        url = "https://registry.yarnpkg.com/@types/uuid/-/uuid-8.3.4.tgz";
         sha512 = "c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==";
       };
     }
@@ -477,7 +483,7 @@
       name = "_types_vscode_webview___vscode_webview_1.57.1.tgz";
       path = fetchurl {
         name = "_types_vscode_webview___vscode_webview_1.57.1.tgz";
-        url  = "https://registry.yarnpkg.com/@types/vscode-webview/-/vscode-webview-1.57.1.tgz";
+        url = "https://registry.yarnpkg.com/@types/vscode-webview/-/vscode-webview-1.57.1.tgz";
         sha512 = "ghW5SfuDmsGDS2A4xkvGsLwDRNc3Vj5rS6rPOyPm/IryZuf3wceZKxgYaUoW+k9f0f/CB7y2c1rRsdOWZWn0PQ==";
       };
     }
@@ -485,7 +491,7 @@
       name = "_vitejs_plugin_react___plugin_react_1.3.2.tgz";
       path = fetchurl {
         name = "_vitejs_plugin_react___plugin_react_1.3.2.tgz";
-        url  = "https://registry.yarnpkg.com/@vitejs/plugin-react/-/plugin-react-1.3.2.tgz";
+        url = "https://registry.yarnpkg.com/@vitejs/plugin-react/-/plugin-react-1.3.2.tgz";
         sha512 = "aurBNmMo0kz1O4qRoY+FM4epSA39y3ShWGuqfLRA/3z0oEJAdtoSfgA3aO98/PCCHAqMaduLxIxErWrVKIFzXA==";
       };
     }
@@ -493,7 +499,7 @@
       name = "_vscode_codicons___codicons_0.0.32.tgz";
       path = fetchurl {
         name = "_vscode_codicons___codicons_0.0.32.tgz";
-        url  = "https://registry.yarnpkg.com/@vscode/codicons/-/codicons-0.0.32.tgz";
+        url = "https://registry.yarnpkg.com/@vscode/codicons/-/codicons-0.0.32.tgz";
         sha512 = "3lgSTWhAzzWN/EPURoY4ZDBEA80OPmnaknNujA3qnI4Iu7AONWd9xF3iE4L+4prIe8E3TUnLQ4pxoaFTEEZNwg==";
       };
     }
@@ -501,7 +507,7 @@
       name = "_vscode_webview_ui_toolkit___webview_ui_toolkit_1.2.1.tgz";
       path = fetchurl {
         name = "_vscode_webview_ui_toolkit___webview_ui_toolkit_1.2.1.tgz";
-        url  = "https://registry.yarnpkg.com/@vscode/webview-ui-toolkit/-/webview-ui-toolkit-1.2.1.tgz";
+        url = "https://registry.yarnpkg.com/@vscode/webview-ui-toolkit/-/webview-ui-toolkit-1.2.1.tgz";
         sha512 = "ZpVqLxoFWWk8mmAN7jr1v9yjD6NGBIoflAedNSusmaViqwHZ2znKBwAwcumLOlNlqmST6QMkiTVys7O8rzfd0w==";
       };
     }
@@ -509,7 +515,7 @@
       name = "ansi_styles___ansi_styles_3.2.1.tgz";
       path = fetchurl {
         name = "ansi_styles___ansi_styles_3.2.1.tgz";
-        url  = "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.1.tgz";
+        url = "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.1.tgz";
         sha512 = "VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==";
       };
     }
@@ -517,7 +523,7 @@
       name = "browserslist___browserslist_4.21.4.tgz";
       path = fetchurl {
         name = "browserslist___browserslist_4.21.4.tgz";
-        url  = "https://registry.yarnpkg.com/browserslist/-/browserslist-4.21.4.tgz";
+        url = "https://registry.yarnpkg.com/browserslist/-/browserslist-4.21.4.tgz";
         sha512 = "CBHJJdDmgjl3daYjN5Cp5kbTf1mUhZoS+beLklHIvkOWscs83YAhLlF3Wsh/lciQYAcbBJgTOD44VtG31ZM4Hw==";
       };
     }
@@ -525,7 +531,7 @@
       name = "caniuse_lite___caniuse_lite_1.0.30001448.tgz";
       path = fetchurl {
         name = "caniuse_lite___caniuse_lite_1.0.30001448.tgz";
-        url  = "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001448.tgz";
+        url = "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001448.tgz";
         sha512 = "tq2YI+MJnooG96XpbTRYkBxLxklZPOdLmNIOdIhvf7SNJan6u5vCKum8iT7ZfCt70m1GPkuC7P3TtX6UuhupuA==";
       };
     }
@@ -533,7 +539,7 @@
       name = "chalk___chalk_2.4.2.tgz";
       path = fetchurl {
         name = "chalk___chalk_2.4.2.tgz";
-        url  = "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz";
+        url = "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz";
         sha512 = "Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==";
       };
     }
@@ -541,7 +547,7 @@
       name = "color_convert___color_convert_1.9.3.tgz";
       path = fetchurl {
         name = "color_convert___color_convert_1.9.3.tgz";
-        url  = "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.3.tgz";
+        url = "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.3.tgz";
         sha512 = "QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==";
       };
     }
@@ -549,7 +555,7 @@
       name = "color_name___color_name_1.1.3.tgz";
       path = fetchurl {
         name = "color_name___color_name_1.1.3.tgz";
-        url  = "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz";
+        url = "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz";
         sha512 = "72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==";
       };
     }
@@ -557,7 +563,7 @@
       name = "convert_source_map___convert_source_map_1.9.0.tgz";
       path = fetchurl {
         name = "convert_source_map___convert_source_map_1.9.0.tgz";
-        url  = "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.9.0.tgz";
+        url = "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.9.0.tgz";
         sha512 = "ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==";
       };
     }
@@ -565,7 +571,7 @@
       name = "csstype___csstype_3.1.1.tgz";
       path = fetchurl {
         name = "csstype___csstype_3.1.1.tgz";
-        url  = "https://registry.yarnpkg.com/csstype/-/csstype-3.1.1.tgz";
+        url = "https://registry.yarnpkg.com/csstype/-/csstype-3.1.1.tgz";
         sha512 = "DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw==";
       };
     }
@@ -573,7 +579,7 @@
       name = "debug___debug_4.3.4.tgz";
       path = fetchurl {
         name = "debug___debug_4.3.4.tgz";
-        url  = "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz";
+        url = "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz";
         sha512 = "PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==";
       };
     }
@@ -581,7 +587,7 @@
       name = "electron_to_chromium___electron_to_chromium_1.4.284.tgz";
       path = fetchurl {
         name = "electron_to_chromium___electron_to_chromium_1.4.284.tgz";
-        url  = "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.284.tgz";
+        url = "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.284.tgz";
         sha512 = "M8WEXFuKXMYMVr45fo8mq0wUrrJHheiKZf6BArTKk9ZBYCKJEOU5H8cdWgDT+qCVZf7Na4lVUaZsA+h6uA9+PA==";
       };
     }
@@ -589,7 +595,7 @@
       name = "esbuild_android_64___esbuild_android_64_0.14.54.tgz";
       path = fetchurl {
         name = "esbuild_android_64___esbuild_android_64_0.14.54.tgz";
-        url  = "https://registry.yarnpkg.com/esbuild-android-64/-/esbuild-android-64-0.14.54.tgz";
+        url = "https://registry.yarnpkg.com/esbuild-android-64/-/esbuild-android-64-0.14.54.tgz";
         sha512 = "Tz2++Aqqz0rJ7kYBfz+iqyE3QMycD4vk7LBRyWaAVFgFtQ/O8EJOnVmTOiDWYZ/uYzB4kvP+bqejYdVKzE5lAQ==";
       };
     }
@@ -597,7 +603,7 @@
       name = "esbuild_android_arm64___esbuild_android_arm64_0.14.54.tgz";
       path = fetchurl {
         name = "esbuild_android_arm64___esbuild_android_arm64_0.14.54.tgz";
-        url  = "https://registry.yarnpkg.com/esbuild-android-arm64/-/esbuild-android-arm64-0.14.54.tgz";
+        url = "https://registry.yarnpkg.com/esbuild-android-arm64/-/esbuild-android-arm64-0.14.54.tgz";
         sha512 = "F9E+/QDi9sSkLaClO8SOV6etqPd+5DgJje1F9lOWoNncDdOBL2YF59IhsWATSt0TLZbYCf3pNlTHvVV5VfHdvg==";
       };
     }
@@ -605,7 +611,7 @@
       name = "esbuild_darwin_64___esbuild_darwin_64_0.14.54.tgz";
       path = fetchurl {
         name = "esbuild_darwin_64___esbuild_darwin_64_0.14.54.tgz";
-        url  = "https://registry.yarnpkg.com/esbuild-darwin-64/-/esbuild-darwin-64-0.14.54.tgz";
+        url = "https://registry.yarnpkg.com/esbuild-darwin-64/-/esbuild-darwin-64-0.14.54.tgz";
         sha512 = "jtdKWV3nBviOd5v4hOpkVmpxsBy90CGzebpbO9beiqUYVMBtSc0AL9zGftFuBon7PNDcdvNCEuQqw2x0wP9yug==";
       };
     }
@@ -613,7 +619,7 @@
       name = "esbuild_darwin_arm64___esbuild_darwin_arm64_0.14.54.tgz";
       path = fetchurl {
         name = "esbuild_darwin_arm64___esbuild_darwin_arm64_0.14.54.tgz";
-        url  = "https://registry.yarnpkg.com/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.54.tgz";
+        url = "https://registry.yarnpkg.com/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.54.tgz";
         sha512 = "OPafJHD2oUPyvJMrsCvDGkRrVCar5aVyHfWGQzY1dWnzErjrDuSETxwA2HSsyg2jORLY8yBfzc1MIpUkXlctmw==";
       };
     }
@@ -621,7 +627,7 @@
       name = "esbuild_freebsd_64___esbuild_freebsd_64_0.14.54.tgz";
       path = fetchurl {
         name = "esbuild_freebsd_64___esbuild_freebsd_64_0.14.54.tgz";
-        url  = "https://registry.yarnpkg.com/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.54.tgz";
+        url = "https://registry.yarnpkg.com/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.54.tgz";
         sha512 = "OKwd4gmwHqOTp4mOGZKe/XUlbDJ4Q9TjX0hMPIDBUWWu/kwhBAudJdBoxnjNf9ocIB6GN6CPowYpR/hRCbSYAg==";
       };
     }
@@ -629,7 +635,7 @@
       name = "esbuild_freebsd_arm64___esbuild_freebsd_arm64_0.14.54.tgz";
       path = fetchurl {
         name = "esbuild_freebsd_arm64___esbuild_freebsd_arm64_0.14.54.tgz";
-        url  = "https://registry.yarnpkg.com/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.54.tgz";
+        url = "https://registry.yarnpkg.com/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.54.tgz";
         sha512 = "sFwueGr7OvIFiQT6WeG0jRLjkjdqWWSrfbVwZp8iMP+8UHEHRBvlaxL6IuKNDwAozNUmbb8nIMXa7oAOARGs1Q==";
       };
     }
@@ -637,7 +643,7 @@
       name = "esbuild_linux_32___esbuild_linux_32_0.14.54.tgz";
       path = fetchurl {
         name = "esbuild_linux_32___esbuild_linux_32_0.14.54.tgz";
-        url  = "https://registry.yarnpkg.com/esbuild-linux-32/-/esbuild-linux-32-0.14.54.tgz";
+        url = "https://registry.yarnpkg.com/esbuild-linux-32/-/esbuild-linux-32-0.14.54.tgz";
         sha512 = "1ZuY+JDI//WmklKlBgJnglpUL1owm2OX+8E1syCD6UAxcMM/XoWd76OHSjl/0MR0LisSAXDqgjT3uJqT67O3qw==";
       };
     }
@@ -645,7 +651,7 @@
       name = "esbuild_linux_64___esbuild_linux_64_0.14.54.tgz";
       path = fetchurl {
         name = "esbuild_linux_64___esbuild_linux_64_0.14.54.tgz";
-        url  = "https://registry.yarnpkg.com/esbuild-linux-64/-/esbuild-linux-64-0.14.54.tgz";
+        url = "https://registry.yarnpkg.com/esbuild-linux-64/-/esbuild-linux-64-0.14.54.tgz";
         sha512 = "EgjAgH5HwTbtNsTqQOXWApBaPVdDn7XcK+/PtJwZLT1UmpLoznPd8c5CxqsH2dQK3j05YsB3L17T8vE7cp4cCg==";
       };
     }
@@ -653,7 +659,7 @@
       name = "esbuild_linux_arm64___esbuild_linux_arm64_0.14.54.tgz";
       path = fetchurl {
         name = "esbuild_linux_arm64___esbuild_linux_arm64_0.14.54.tgz";
-        url  = "https://registry.yarnpkg.com/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.54.tgz";
+        url = "https://registry.yarnpkg.com/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.54.tgz";
         sha512 = "WL71L+0Rwv+Gv/HTmxTEmpv0UgmxYa5ftZILVi2QmZBgX3q7+tDeOQNqGtdXSdsL8TQi1vIaVFHUPDe0O0kdig==";
       };
     }
@@ -661,7 +667,7 @@
       name = "esbuild_linux_arm___esbuild_linux_arm_0.14.54.tgz";
       path = fetchurl {
         name = "esbuild_linux_arm___esbuild_linux_arm_0.14.54.tgz";
-        url  = "https://registry.yarnpkg.com/esbuild-linux-arm/-/esbuild-linux-arm-0.14.54.tgz";
+        url = "https://registry.yarnpkg.com/esbuild-linux-arm/-/esbuild-linux-arm-0.14.54.tgz";
         sha512 = "qqz/SjemQhVMTnvcLGoLOdFpCYbz4v4fUo+TfsWG+1aOu70/80RV6bgNpR2JCrppV2moUQkww+6bWxXRL9YMGw==";
       };
     }
@@ -669,7 +675,7 @@
       name = "esbuild_linux_mips64le___esbuild_linux_mips64le_0.14.54.tgz";
       path = fetchurl {
         name = "esbuild_linux_mips64le___esbuild_linux_mips64le_0.14.54.tgz";
-        url  = "https://registry.yarnpkg.com/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.54.tgz";
+        url = "https://registry.yarnpkg.com/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.54.tgz";
         sha512 = "qTHGQB8D1etd0u1+sB6p0ikLKRVuCWhYQhAHRPkO+OF3I/iSlTKNNS0Lh2Oc0g0UFGguaFZZiPJdJey3AGpAlw==";
       };
     }
@@ -677,7 +683,7 @@
       name = "esbuild_linux_ppc64le___esbuild_linux_ppc64le_0.14.54.tgz";
       path = fetchurl {
         name = "esbuild_linux_ppc64le___esbuild_linux_ppc64le_0.14.54.tgz";
-        url  = "https://registry.yarnpkg.com/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.54.tgz";
+        url = "https://registry.yarnpkg.com/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.54.tgz";
         sha512 = "j3OMlzHiqwZBDPRCDFKcx595XVfOfOnv68Ax3U4UKZ3MTYQB5Yz3X1mn5GnodEVYzhtZgxEBidLWeIs8FDSfrQ==";
       };
     }
@@ -685,7 +691,7 @@
       name = "esbuild_linux_riscv64___esbuild_linux_riscv64_0.14.54.tgz";
       path = fetchurl {
         name = "esbuild_linux_riscv64___esbuild_linux_riscv64_0.14.54.tgz";
-        url  = "https://registry.yarnpkg.com/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.14.54.tgz";
+        url = "https://registry.yarnpkg.com/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.14.54.tgz";
         sha512 = "y7Vt7Wl9dkOGZjxQZnDAqqn+XOqFD7IMWiewY5SPlNlzMX39ocPQlOaoxvT4FllA5viyV26/QzHtvTjVNOxHZg==";
       };
     }
@@ -693,7 +699,7 @@
       name = "esbuild_linux_s390x___esbuild_linux_s390x_0.14.54.tgz";
       path = fetchurl {
         name = "esbuild_linux_s390x___esbuild_linux_s390x_0.14.54.tgz";
-        url  = "https://registry.yarnpkg.com/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.54.tgz";
+        url = "https://registry.yarnpkg.com/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.54.tgz";
         sha512 = "zaHpW9dziAsi7lRcyV4r8dhfG1qBidQWUXweUjnw+lliChJqQr+6XD71K41oEIC3Mx1KStovEmlzm+MkGZHnHA==";
       };
     }
@@ -701,7 +707,7 @@
       name = "esbuild_netbsd_64___esbuild_netbsd_64_0.14.54.tgz";
       path = fetchurl {
         name = "esbuild_netbsd_64___esbuild_netbsd_64_0.14.54.tgz";
-        url  = "https://registry.yarnpkg.com/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.54.tgz";
+        url = "https://registry.yarnpkg.com/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.54.tgz";
         sha512 = "PR01lmIMnfJTgeU9VJTDY9ZerDWVFIUzAtJuDHwwceppW7cQWjBBqP48NdeRtoP04/AtO9a7w3viI+PIDr6d+w==";
       };
     }
@@ -709,7 +715,7 @@
       name = "esbuild_openbsd_64___esbuild_openbsd_64_0.14.54.tgz";
       path = fetchurl {
         name = "esbuild_openbsd_64___esbuild_openbsd_64_0.14.54.tgz";
-        url  = "https://registry.yarnpkg.com/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.54.tgz";
+        url = "https://registry.yarnpkg.com/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.54.tgz";
         sha512 = "Qyk7ikT2o7Wu76UsvvDS5q0amJvmRzDyVlL0qf5VLsLchjCa1+IAvd8kTBgUxD7VBUUVgItLkk609ZHUc1oCaw==";
       };
     }
@@ -717,7 +723,7 @@
       name = "esbuild_sunos_64___esbuild_sunos_64_0.14.54.tgz";
       path = fetchurl {
         name = "esbuild_sunos_64___esbuild_sunos_64_0.14.54.tgz";
-        url  = "https://registry.yarnpkg.com/esbuild-sunos-64/-/esbuild-sunos-64-0.14.54.tgz";
+        url = "https://registry.yarnpkg.com/esbuild-sunos-64/-/esbuild-sunos-64-0.14.54.tgz";
         sha512 = "28GZ24KmMSeKi5ueWzMcco6EBHStL3B6ubM7M51RmPwXQGLe0teBGJocmWhgwccA1GeFXqxzILIxXpHbl9Q/Kw==";
       };
     }
@@ -725,7 +731,7 @@
       name = "esbuild_windows_32___esbuild_windows_32_0.14.54.tgz";
       path = fetchurl {
         name = "esbuild_windows_32___esbuild_windows_32_0.14.54.tgz";
-        url  = "https://registry.yarnpkg.com/esbuild-windows-32/-/esbuild-windows-32-0.14.54.tgz";
+        url = "https://registry.yarnpkg.com/esbuild-windows-32/-/esbuild-windows-32-0.14.54.tgz";
         sha512 = "T+rdZW19ql9MjS7pixmZYVObd9G7kcaZo+sETqNH4RCkuuYSuv9AGHUVnPoP9hhuE1WM1ZimHz1CIBHBboLU7w==";
       };
     }
@@ -733,7 +739,7 @@
       name = "esbuild_windows_64___esbuild_windows_64_0.14.54.tgz";
       path = fetchurl {
         name = "esbuild_windows_64___esbuild_windows_64_0.14.54.tgz";
-        url  = "https://registry.yarnpkg.com/esbuild-windows-64/-/esbuild-windows-64-0.14.54.tgz";
+        url = "https://registry.yarnpkg.com/esbuild-windows-64/-/esbuild-windows-64-0.14.54.tgz";
         sha512 = "AoHTRBUuYwXtZhjXZbA1pGfTo8cJo3vZIcWGLiUcTNgHpJJMC1rVA44ZereBHMJtotyN71S8Qw0npiCIkW96cQ==";
       };
     }
@@ -741,7 +747,7 @@
       name = "esbuild_windows_arm64___esbuild_windows_arm64_0.14.54.tgz";
       path = fetchurl {
         name = "esbuild_windows_arm64___esbuild_windows_arm64_0.14.54.tgz";
-        url  = "https://registry.yarnpkg.com/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.54.tgz";
+        url = "https://registry.yarnpkg.com/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.54.tgz";
         sha512 = "M0kuUvXhot1zOISQGXwWn6YtS+Y/1RT9WrVIOywZnJHo3jCDyewAc79aKNQWFCQm+xNHVTq9h8dZKvygoXQQRg==";
       };
     }
@@ -749,7 +755,7 @@
       name = "esbuild___esbuild_0.14.54.tgz";
       path = fetchurl {
         name = "esbuild___esbuild_0.14.54.tgz";
-        url  = "https://registry.yarnpkg.com/esbuild/-/esbuild-0.14.54.tgz";
+        url = "https://registry.yarnpkg.com/esbuild/-/esbuild-0.14.54.tgz";
         sha512 = "Cy9llcy8DvET5uznocPyqL3BFRrFXSVqbgpMJ9Wz8oVjZlh/zUSNbPRbov0VX7VxN2JH1Oa0uNxZ7eLRb62pJA==";
       };
     }
@@ -757,7 +763,7 @@
       name = "escalade___escalade_3.1.1.tgz";
       path = fetchurl {
         name = "escalade___escalade_3.1.1.tgz";
-        url  = "https://registry.yarnpkg.com/escalade/-/escalade-3.1.1.tgz";
+        url = "https://registry.yarnpkg.com/escalade/-/escalade-3.1.1.tgz";
         sha512 = "k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==";
       };
     }
@@ -765,7 +771,7 @@
       name = "escape_string_regexp___escape_string_regexp_1.0.5.tgz";
       path = fetchurl {
         name = "escape_string_regexp___escape_string_regexp_1.0.5.tgz";
-        url  = "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz";
+        url = "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz";
         sha512 = "vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==";
       };
     }
@@ -773,7 +779,7 @@
       name = "estree_walker___estree_walker_2.0.2.tgz";
       path = fetchurl {
         name = "estree_walker___estree_walker_2.0.2.tgz";
-        url  = "https://registry.yarnpkg.com/estree-walker/-/estree-walker-2.0.2.tgz";
+        url = "https://registry.yarnpkg.com/estree-walker/-/estree-walker-2.0.2.tgz";
         sha512 = "Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==";
       };
     }
@@ -781,7 +787,7 @@
       name = "exenv_es6___exenv_es6_1.1.1.tgz";
       path = fetchurl {
         name = "exenv_es6___exenv_es6_1.1.1.tgz";
-        url  = "https://registry.yarnpkg.com/exenv-es6/-/exenv-es6-1.1.1.tgz";
+        url = "https://registry.yarnpkg.com/exenv-es6/-/exenv-es6-1.1.1.tgz";
         sha512 = "vlVu3N8d6yEMpMsEm+7sUBAI81aqYYuEvfK0jNqmdb/OPXzzH7QWDDnVjMvDSY47JdHEqx/dfC/q8WkfoTmpGQ==";
       };
     }
@@ -789,7 +795,7 @@
       name = "fsevents___fsevents_2.3.2.tgz";
       path = fetchurl {
         name = "fsevents___fsevents_2.3.2.tgz";
-        url  = "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.2.tgz";
+        url = "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.2.tgz";
         sha512 = "xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==";
       };
     }
@@ -797,7 +803,7 @@
       name = "function_bind___function_bind_1.1.1.tgz";
       path = fetchurl {
         name = "function_bind___function_bind_1.1.1.tgz";
-        url  = "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz";
+        url = "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz";
         sha512 = "yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==";
       };
     }
@@ -805,7 +811,7 @@
       name = "gensync___gensync_1.0.0_beta.2.tgz";
       path = fetchurl {
         name = "gensync___gensync_1.0.0_beta.2.tgz";
-        url  = "https://registry.yarnpkg.com/gensync/-/gensync-1.0.0-beta.2.tgz";
+        url = "https://registry.yarnpkg.com/gensync/-/gensync-1.0.0-beta.2.tgz";
         sha512 = "3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==";
       };
     }
@@ -813,7 +819,7 @@
       name = "globals___globals_11.12.0.tgz";
       path = fetchurl {
         name = "globals___globals_11.12.0.tgz";
-        url  = "https://registry.yarnpkg.com/globals/-/globals-11.12.0.tgz";
+        url = "https://registry.yarnpkg.com/globals/-/globals-11.12.0.tgz";
         sha512 = "WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==";
       };
     }
@@ -821,7 +827,7 @@
       name = "has_flag___has_flag_3.0.0.tgz";
       path = fetchurl {
         name = "has_flag___has_flag_3.0.0.tgz";
-        url  = "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz";
+        url = "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz";
         sha512 = "sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==";
       };
     }
@@ -829,7 +835,7 @@
       name = "has___has_1.0.3.tgz";
       path = fetchurl {
         name = "has___has_1.0.3.tgz";
-        url  = "https://registry.yarnpkg.com/has/-/has-1.0.3.tgz";
+        url = "https://registry.yarnpkg.com/has/-/has-1.0.3.tgz";
         sha512 = "f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==";
       };
     }
@@ -837,7 +843,7 @@
       name = "is_core_module___is_core_module_2.11.0.tgz";
       path = fetchurl {
         name = "is_core_module___is_core_module_2.11.0.tgz";
-        url  = "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.11.0.tgz";
+        url = "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.11.0.tgz";
         sha512 = "RRjxlvLDkD1YJwDbroBHMb+cukurkDWNyHx7D3oNB5x9rb5ogcksMC5wHCadcXoo67gVr/+3GFySh3134zi6rw==";
       };
     }
@@ -845,7 +851,7 @@
       name = "js_tokens___js_tokens_4.0.0.tgz";
       path = fetchurl {
         name = "js_tokens___js_tokens_4.0.0.tgz";
-        url  = "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz";
+        url = "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz";
         sha512 = "RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==";
       };
     }
@@ -853,7 +859,7 @@
       name = "jsesc___jsesc_2.5.2.tgz";
       path = fetchurl {
         name = "jsesc___jsesc_2.5.2.tgz";
-        url  = "https://registry.yarnpkg.com/jsesc/-/jsesc-2.5.2.tgz";
+        url = "https://registry.yarnpkg.com/jsesc/-/jsesc-2.5.2.tgz";
         sha512 = "OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==";
       };
     }
@@ -861,7 +867,7 @@
       name = "json5___json5_2.2.3.tgz";
       path = fetchurl {
         name = "json5___json5_2.2.3.tgz";
-        url  = "https://registry.yarnpkg.com/json5/-/json5-2.2.3.tgz";
+        url = "https://registry.yarnpkg.com/json5/-/json5-2.2.3.tgz";
         sha512 = "XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==";
       };
     }
@@ -869,7 +875,7 @@
       name = "loose_envify___loose_envify_1.4.0.tgz";
       path = fetchurl {
         name = "loose_envify___loose_envify_1.4.0.tgz";
-        url  = "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz";
+        url = "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz";
         sha512 = "lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==";
       };
     }
@@ -877,7 +883,7 @@
       name = "lru_cache___lru_cache_5.1.1.tgz";
       path = fetchurl {
         name = "lru_cache___lru_cache_5.1.1.tgz";
-        url  = "https://registry.yarnpkg.com/lru-cache/-/lru-cache-5.1.1.tgz";
+        url = "https://registry.yarnpkg.com/lru-cache/-/lru-cache-5.1.1.tgz";
         sha512 = "KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==";
       };
     }
@@ -885,7 +891,7 @@
       name = "ms___ms_2.1.2.tgz";
       path = fetchurl {
         name = "ms___ms_2.1.2.tgz";
-        url  = "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz";
+        url = "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz";
         sha512 = "sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==";
       };
     }
@@ -893,7 +899,7 @@
       name = "nanoid___nanoid_3.3.6.tgz";
       path = fetchurl {
         name = "nanoid___nanoid_3.3.6.tgz";
-        url  = "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.6.tgz";
+        url = "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.6.tgz";
         sha512 = "BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==";
       };
     }
@@ -901,7 +907,7 @@
       name = "node_releases___node_releases_2.0.8.tgz";
       path = fetchurl {
         name = "node_releases___node_releases_2.0.8.tgz";
-        url  = "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.8.tgz";
+        url = "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.8.tgz";
         sha512 = "dFSmB8fFHEH/s81Xi+Y/15DQY6VHW81nXRj86EMSL3lmuTmK1e+aT4wrFCkTbm+gSwkw4KpX+rT/pMM2c1mF+A==";
       };
     }
@@ -909,7 +915,7 @@
       name = "object_assign___object_assign_4.1.1.tgz";
       path = fetchurl {
         name = "object_assign___object_assign_4.1.1.tgz";
-        url  = "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz";
+        url = "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz";
         sha512 = "rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==";
       };
     }
@@ -917,7 +923,7 @@
       name = "path_parse___path_parse_1.0.7.tgz";
       path = fetchurl {
         name = "path_parse___path_parse_1.0.7.tgz";
-        url  = "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.7.tgz";
+        url = "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.7.tgz";
         sha512 = "LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==";
       };
     }
@@ -925,7 +931,7 @@
       name = "picocolors___picocolors_1.0.0.tgz";
       path = fetchurl {
         name = "picocolors___picocolors_1.0.0.tgz";
-        url  = "https://registry.yarnpkg.com/picocolors/-/picocolors-1.0.0.tgz";
+        url = "https://registry.yarnpkg.com/picocolors/-/picocolors-1.0.0.tgz";
         sha512 = "1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==";
       };
     }
@@ -933,7 +939,7 @@
       name = "picomatch___picomatch_2.3.1.tgz";
       path = fetchurl {
         name = "picomatch___picomatch_2.3.1.tgz";
-        url  = "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz";
+        url = "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz";
         sha512 = "JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==";
       };
     }
@@ -941,7 +947,7 @@
       name = "postcss___postcss_8.4.31.tgz";
       path = fetchurl {
         name = "postcss___postcss_8.4.31.tgz";
-        url  = "https://registry.yarnpkg.com/postcss/-/postcss-8.4.31.tgz";
+        url = "https://registry.yarnpkg.com/postcss/-/postcss-8.4.31.tgz";
         sha512 = "PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==";
       };
     }
@@ -949,7 +955,7 @@
       name = "react_dom___react_dom_17.0.2.tgz";
       path = fetchurl {
         name = "react_dom___react_dom_17.0.2.tgz";
-        url  = "https://registry.yarnpkg.com/react-dom/-/react-dom-17.0.2.tgz";
+        url = "https://registry.yarnpkg.com/react-dom/-/react-dom-17.0.2.tgz";
         sha512 = "s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==";
       };
     }
@@ -957,7 +963,7 @@
       name = "react_icons___react_icons_4.7.1.tgz";
       path = fetchurl {
         name = "react_icons___react_icons_4.7.1.tgz";
-        url  = "https://registry.yarnpkg.com/react-icons/-/react-icons-4.7.1.tgz";
+        url = "https://registry.yarnpkg.com/react-icons/-/react-icons-4.7.1.tgz";
         sha512 = "yHd3oKGMgm7zxo3EA7H2n7vxSoiGmHk5t6Ou4bXsfcgWyhfDKMpyKfhHR6Bjnn63c+YXBLBPUql9H4wPJM6sXw==";
       };
     }
@@ -965,7 +971,7 @@
       name = "react_refresh___react_refresh_0.13.0.tgz";
       path = fetchurl {
         name = "react_refresh___react_refresh_0.13.0.tgz";
-        url  = "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.13.0.tgz";
+        url = "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.13.0.tgz";
         sha512 = "XP8A9BT0CpRBD+NYLLeIhld/RqG9+gktUjW1FkE+Vm7OCinbG1SshcK5tb9ls4kzvjZr9mOQc7HYgBngEyPAXg==";
       };
     }
@@ -973,7 +979,7 @@
       name = "react___react_17.0.2.tgz";
       path = fetchurl {
         name = "react___react_17.0.2.tgz";
-        url  = "https://registry.yarnpkg.com/react/-/react-17.0.2.tgz";
+        url = "https://registry.yarnpkg.com/react/-/react-17.0.2.tgz";
         sha512 = "gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==";
       };
     }
@@ -981,7 +987,7 @@
       name = "resolve___resolve_1.22.1.tgz";
       path = fetchurl {
         name = "resolve___resolve_1.22.1.tgz";
-        url  = "https://registry.yarnpkg.com/resolve/-/resolve-1.22.1.tgz";
+        url = "https://registry.yarnpkg.com/resolve/-/resolve-1.22.1.tgz";
         sha512 = "nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==";
       };
     }
@@ -989,7 +995,7 @@
       name = "rollup___rollup_2.77.3.tgz";
       path = fetchurl {
         name = "rollup___rollup_2.77.3.tgz";
-        url  = "https://registry.yarnpkg.com/rollup/-/rollup-2.77.3.tgz";
+        url = "https://registry.yarnpkg.com/rollup/-/rollup-2.77.3.tgz";
         sha512 = "/qxNTG7FbmefJWoeeYJFbHehJ2HNWnjkAFRKzWN/45eNBBF/r8lo992CwcJXEzyVxs5FmfId+vTSTQDb+bxA+g==";
       };
     }
@@ -997,7 +1003,7 @@
       name = "scheduler___scheduler_0.20.2.tgz";
       path = fetchurl {
         name = "scheduler___scheduler_0.20.2.tgz";
-        url  = "https://registry.yarnpkg.com/scheduler/-/scheduler-0.20.2.tgz";
+        url = "https://registry.yarnpkg.com/scheduler/-/scheduler-0.20.2.tgz";
         sha512 = "2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==";
       };
     }
@@ -1005,7 +1011,7 @@
       name = "semver___semver_6.3.1.tgz";
       path = fetchurl {
         name = "semver___semver_6.3.1.tgz";
-        url  = "https://registry.yarnpkg.com/semver/-/semver-6.3.1.tgz";
+        url = "https://registry.yarnpkg.com/semver/-/semver-6.3.1.tgz";
         sha512 = "BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==";
       };
     }
@@ -1013,7 +1019,7 @@
       name = "source_map_js___source_map_js_1.0.2.tgz";
       path = fetchurl {
         name = "source_map_js___source_map_js_1.0.2.tgz";
-        url  = "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.0.2.tgz";
+        url = "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.0.2.tgz";
         sha512 = "R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==";
       };
     }
@@ -1021,7 +1027,7 @@
       name = "supports_color___supports_color_5.5.0.tgz";
       path = fetchurl {
         name = "supports_color___supports_color_5.5.0.tgz";
-        url  = "https://registry.yarnpkg.com/supports-color/-/supports-color-5.5.0.tgz";
+        url = "https://registry.yarnpkg.com/supports-color/-/supports-color-5.5.0.tgz";
         sha512 = "QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==";
       };
     }
@@ -1029,7 +1035,7 @@
       name = "supports_preserve_symlinks_flag___supports_preserve_symlinks_flag_1.0.0.tgz";
       path = fetchurl {
         name = "supports_preserve_symlinks_flag___supports_preserve_symlinks_flag_1.0.0.tgz";
-        url  = "https://registry.yarnpkg.com/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz";
+        url = "https://registry.yarnpkg.com/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz";
         sha512 = "ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==";
       };
     }
@@ -1037,7 +1043,7 @@
       name = "tabbable___tabbable_5.3.3.tgz";
       path = fetchurl {
         name = "tabbable___tabbable_5.3.3.tgz";
-        url  = "https://registry.yarnpkg.com/tabbable/-/tabbable-5.3.3.tgz";
+        url = "https://registry.yarnpkg.com/tabbable/-/tabbable-5.3.3.tgz";
         sha512 = "QD9qKY3StfbZqWOPLp0++pOrAVb/HbUi5xCc8cUo4XjP19808oaMiDzn0leBY5mCespIBM0CIZePzZjgzR83kA==";
       };
     }
@@ -1045,7 +1051,7 @@
       name = "to_fast_properties___to_fast_properties_2.0.0.tgz";
       path = fetchurl {
         name = "to_fast_properties___to_fast_properties_2.0.0.tgz";
-        url  = "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-2.0.0.tgz";
+        url = "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-2.0.0.tgz";
         sha512 = "/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==";
       };
     }
@@ -1053,7 +1059,7 @@
       name = "tslib___tslib_1.14.1.tgz";
       path = fetchurl {
         name = "tslib___tslib_1.14.1.tgz";
-        url  = "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz";
+        url = "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz";
         sha512 = "Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==";
       };
     }
@@ -1061,7 +1067,7 @@
       name = "typescript___typescript_4.9.4.tgz";
       path = fetchurl {
         name = "typescript___typescript_4.9.4.tgz";
-        url  = "https://registry.yarnpkg.com/typescript/-/typescript-4.9.4.tgz";
+        url = "https://registry.yarnpkg.com/typescript/-/typescript-4.9.4.tgz";
         sha512 = "Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==";
       };
     }
@@ -1069,7 +1075,7 @@
       name = "update_browserslist_db___update_browserslist_db_1.0.10.tgz";
       path = fetchurl {
         name = "update_browserslist_db___update_browserslist_db_1.0.10.tgz";
-        url  = "https://registry.yarnpkg.com/update-browserslist-db/-/update-browserslist-db-1.0.10.tgz";
+        url = "https://registry.yarnpkg.com/update-browserslist-db/-/update-browserslist-db-1.0.10.tgz";
         sha512 = "OztqDenkfFkbSG+tRxBeAnCVPckDBcvibKd35yDONx6OU8N7sqgwc7rCbkJ/WcYtVRZ4ba68d6byhC21GFh7sQ==";
       };
     }
@@ -1077,7 +1083,7 @@
       name = "uuid___uuid_8.3.2.tgz";
       path = fetchurl {
         name = "uuid___uuid_8.3.2.tgz";
-        url  = "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz";
+        url = "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz";
         sha512 = "+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==";
       };
     }
@@ -1085,7 +1091,7 @@
       name = "uuidv4___uuidv4_6.2.13.tgz";
       path = fetchurl {
         name = "uuidv4___uuidv4_6.2.13.tgz";
-        url  = "https://registry.yarnpkg.com/uuidv4/-/uuidv4-6.2.13.tgz";
+        url = "https://registry.yarnpkg.com/uuidv4/-/uuidv4-6.2.13.tgz";
         sha512 = "AXyzMjazYB3ovL3q051VLH06Ixj//Knx7QnUSi1T//Ie3io6CpsPu9nVMOx5MoLWh6xV0B9J0hIaxungxXUbPQ==";
       };
     }
@@ -1093,7 +1099,7 @@
       name = "vite___vite_2.9.17.tgz";
       path = fetchurl {
         name = "vite___vite_2.9.17.tgz";
-        url  = "https://registry.yarnpkg.com/vite/-/vite-2.9.17.tgz";
+        url = "https://registry.yarnpkg.com/vite/-/vite-2.9.17.tgz";
         sha512 = "XxcRzra6d7xrKXH66jZUgb+srThoPu+TLJc06GifUyKq9JmjHkc1Numc8ra0h56rju2jfVWw3B3fs5l3OFMvUw==";
       };
     }
@@ -1101,7 +1107,7 @@
       name = "yallist___yallist_3.1.1.tgz";
       path = fetchurl {
         name = "yallist___yallist_3.1.1.tgz";
-        url  = "https://registry.yarnpkg.com/yallist/-/yallist-3.1.1.tgz";
+        url = "https://registry.yarnpkg.com/yallist/-/yallist-3.1.1.tgz";
         sha512 = "a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==";
       };
     }

--- a/client/yarn.nix
+++ b/client/yarn.nix
@@ -1,11 +1,17 @@
-{ fetchurl, fetchgit, linkFarm, runCommand, gnutar }: rec {
+{
+  fetchurl,
+  fetchgit,
+  linkFarm,
+  runCommand,
+  gnutar,
+}: rec {
   offline_cache = linkFarm "offline" packages;
   packages = [
     {
       name = "_aashutoshrathi_word_wrap___word_wrap_1.2.6.tgz";
       path = fetchurl {
         name = "_aashutoshrathi_word_wrap___word_wrap_1.2.6.tgz";
-        url  = "https://registry.yarnpkg.com/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz";
+        url = "https://registry.yarnpkg.com/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz";
         sha512 = "1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==";
       };
     }
@@ -13,7 +19,7 @@
       name = "_babel_code_frame___code_frame_7.23.5.tgz";
       path = fetchurl {
         name = "_babel_code_frame___code_frame_7.23.5.tgz";
-        url  = "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.23.5.tgz";
+        url = "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.23.5.tgz";
         sha512 = "CgH3s1a96LipHCmSUmYFPwY7MNx8C3avkq7i4Wl3cfa662ldtUe4VM1TPXX70pfmrlWTb6jLqTYrZyT2ZTJBgA==";
       };
     }
@@ -21,7 +27,7 @@
       name = "_babel_helper_validator_identifier___helper_validator_identifier_7.22.20.tgz";
       path = fetchurl {
         name = "_babel_helper_validator_identifier___helper_validator_identifier_7.22.20.tgz";
-        url  = "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz";
+        url = "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz";
         sha512 = "Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==";
       };
     }
@@ -29,7 +35,7 @@
       name = "_babel_highlight___highlight_7.23.4.tgz";
       path = fetchurl {
         name = "_babel_highlight___highlight_7.23.4.tgz";
-        url  = "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.23.4.tgz";
+        url = "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.23.4.tgz";
         sha512 = "acGdbYSfp2WheJoJm/EBBBLh/ID8KDc64ISZ9DYtBmC8/Q204PZJLHyzeB5qMzJ5trcOkybd78M4x2KWsUq++A==";
       };
     }
@@ -37,7 +43,7 @@
       name = "_discoveryjs_json_ext___json_ext_0.5.7.tgz";
       path = fetchurl {
         name = "_discoveryjs_json_ext___json_ext_0.5.7.tgz";
-        url  = "https://registry.yarnpkg.com/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz";
+        url = "https://registry.yarnpkg.com/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz";
         sha512 = "dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==";
       };
     }
@@ -45,7 +51,7 @@
       name = "_eslint_community_eslint_utils___eslint_utils_4.4.0.tgz";
       path = fetchurl {
         name = "_eslint_community_eslint_utils___eslint_utils_4.4.0.tgz";
-        url  = "https://registry.yarnpkg.com/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz";
+        url = "https://registry.yarnpkg.com/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz";
         sha512 = "1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==";
       };
     }
@@ -53,7 +59,7 @@
       name = "_eslint_community_regexpp___regexpp_4.10.0.tgz";
       path = fetchurl {
         name = "_eslint_community_regexpp___regexpp_4.10.0.tgz";
-        url  = "https://registry.yarnpkg.com/@eslint-community/regexpp/-/regexpp-4.10.0.tgz";
+        url = "https://registry.yarnpkg.com/@eslint-community/regexpp/-/regexpp-4.10.0.tgz";
         sha512 = "Cu96Sd2By9mCNTx2iyKOmq10v22jUVQv0lQnlGNy16oE9589yE+QADPbrMGCkA51cKZSg3Pu/aTJVTGfL/qjUA==";
       };
     }
@@ -61,7 +67,7 @@
       name = "_eslint_eslintrc___eslintrc_2.1.4.tgz";
       path = fetchurl {
         name = "_eslint_eslintrc___eslintrc_2.1.4.tgz";
-        url  = "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-2.1.4.tgz";
+        url = "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-2.1.4.tgz";
         sha512 = "269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==";
       };
     }
@@ -69,7 +75,7 @@
       name = "_eslint_js___js_8.56.0.tgz";
       path = fetchurl {
         name = "_eslint_js___js_8.56.0.tgz";
-        url  = "https://registry.yarnpkg.com/@eslint/js/-/js-8.56.0.tgz";
+        url = "https://registry.yarnpkg.com/@eslint/js/-/js-8.56.0.tgz";
         sha512 = "gMsVel9D7f2HLkBma9VbtzZRehRogVRfbr++f06nL2vnCGCNlzOD+/MUov/F4p8myyAHspEhVobgjpX64q5m6A==";
       };
     }
@@ -77,7 +83,7 @@
       name = "_humanwhocodes_config_array___config_array_0.11.14.tgz";
       path = fetchurl {
         name = "_humanwhocodes_config_array___config_array_0.11.14.tgz";
-        url  = "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.11.14.tgz";
+        url = "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.11.14.tgz";
         sha512 = "3T8LkOmg45BV5FICb15QQMsyUSWrQ8AygVfC7ZG32zOalnqrilm018ZVCw0eapXux8FtA33q8PSRSstjee3jSg==";
       };
     }
@@ -85,7 +91,7 @@
       name = "_humanwhocodes_module_importer___module_importer_1.0.1.tgz";
       path = fetchurl {
         name = "_humanwhocodes_module_importer___module_importer_1.0.1.tgz";
-        url  = "https://registry.yarnpkg.com/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz";
+        url = "https://registry.yarnpkg.com/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz";
         sha512 = "bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==";
       };
     }
@@ -93,7 +99,7 @@
       name = "_humanwhocodes_object_schema___object_schema_2.0.2.tgz";
       path = fetchurl {
         name = "_humanwhocodes_object_schema___object_schema_2.0.2.tgz";
-        url  = "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-2.0.2.tgz";
+        url = "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-2.0.2.tgz";
         sha512 = "6EwiSjwWYP7pTckG6I5eyFANjPhmPjUX9JRLUSfNPC7FX7zK9gyZAfUEaECL6ALTpGX5AjnBq3C9XmVWPitNpw==";
       };
     }
@@ -101,7 +107,7 @@
       name = "_jest_expect_utils___expect_utils_29.7.0.tgz";
       path = fetchurl {
         name = "_jest_expect_utils___expect_utils_29.7.0.tgz";
-        url  = "https://registry.yarnpkg.com/@jest/expect-utils/-/expect-utils-29.7.0.tgz";
+        url = "https://registry.yarnpkg.com/@jest/expect-utils/-/expect-utils-29.7.0.tgz";
         sha512 = "GlsNBWiFQFCVi9QVSx7f5AgMeLxe9YCCs5PuP2O2LdjDAA8Jh9eX7lA1Jq/xdXw3Wb3hyvlFNfZIfcRetSzYcA==";
       };
     }
@@ -109,7 +115,7 @@
       name = "_jest_schemas___schemas_29.6.3.tgz";
       path = fetchurl {
         name = "_jest_schemas___schemas_29.6.3.tgz";
-        url  = "https://registry.yarnpkg.com/@jest/schemas/-/schemas-29.6.3.tgz";
+        url = "https://registry.yarnpkg.com/@jest/schemas/-/schemas-29.6.3.tgz";
         sha512 = "mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==";
       };
     }
@@ -117,7 +123,7 @@
       name = "_jest_types___types_29.6.3.tgz";
       path = fetchurl {
         name = "_jest_types___types_29.6.3.tgz";
-        url  = "https://registry.yarnpkg.com/@jest/types/-/types-29.6.3.tgz";
+        url = "https://registry.yarnpkg.com/@jest/types/-/types-29.6.3.tgz";
         sha512 = "u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==";
       };
     }
@@ -125,7 +131,7 @@
       name = "_jridgewell_gen_mapping___gen_mapping_0.3.3.tgz";
       path = fetchurl {
         name = "_jridgewell_gen_mapping___gen_mapping_0.3.3.tgz";
-        url  = "https://registry.yarnpkg.com/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz";
+        url = "https://registry.yarnpkg.com/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz";
         sha512 = "HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==";
       };
     }
@@ -133,7 +139,7 @@
       name = "_jridgewell_resolve_uri___resolve_uri_3.1.1.tgz";
       path = fetchurl {
         name = "_jridgewell_resolve_uri___resolve_uri_3.1.1.tgz";
-        url  = "https://registry.yarnpkg.com/@jridgewell/resolve-uri/-/resolve-uri-3.1.1.tgz";
+        url = "https://registry.yarnpkg.com/@jridgewell/resolve-uri/-/resolve-uri-3.1.1.tgz";
         sha512 = "dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA==";
       };
     }
@@ -141,7 +147,7 @@
       name = "_jridgewell_set_array___set_array_1.1.2.tgz";
       path = fetchurl {
         name = "_jridgewell_set_array___set_array_1.1.2.tgz";
-        url  = "https://registry.yarnpkg.com/@jridgewell/set-array/-/set-array-1.1.2.tgz";
+        url = "https://registry.yarnpkg.com/@jridgewell/set-array/-/set-array-1.1.2.tgz";
         sha512 = "xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==";
       };
     }
@@ -149,7 +155,7 @@
       name = "_jridgewell_source_map___source_map_0.3.5.tgz";
       path = fetchurl {
         name = "_jridgewell_source_map___source_map_0.3.5.tgz";
-        url  = "https://registry.yarnpkg.com/@jridgewell/source-map/-/source-map-0.3.5.tgz";
+        url = "https://registry.yarnpkg.com/@jridgewell/source-map/-/source-map-0.3.5.tgz";
         sha512 = "UTYAUj/wviwdsMfzoSJspJxbkH5o1snzwX0//0ENX1u/55kkZZkcTZP6u9bwKGkv+dkk9at4m1Cpt0uY80kcpQ==";
       };
     }
@@ -157,7 +163,7 @@
       name = "_jridgewell_sourcemap_codec___sourcemap_codec_1.4.15.tgz";
       path = fetchurl {
         name = "_jridgewell_sourcemap_codec___sourcemap_codec_1.4.15.tgz";
-        url  = "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz";
+        url = "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz";
         sha512 = "eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==";
       };
     }
@@ -165,7 +171,7 @@
       name = "_jridgewell_trace_mapping___trace_mapping_0.3.22.tgz";
       path = fetchurl {
         name = "_jridgewell_trace_mapping___trace_mapping_0.3.22.tgz";
-        url  = "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.22.tgz";
+        url = "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.22.tgz";
         sha512 = "Wf963MzWtA2sjrNt+g18IAln9lKnlRp+K2eH4jjIoF1wYeq3aMREpG09xhlhdzS0EjwU7qmUJYangWa+151vZw==";
       };
     }
@@ -173,7 +179,7 @@
       name = "_nodelib_fs.scandir___fs.scandir_2.1.5.tgz";
       path = fetchurl {
         name = "_nodelib_fs.scandir___fs.scandir_2.1.5.tgz";
-        url  = "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz";
+        url = "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz";
         sha512 = "vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==";
       };
     }
@@ -181,7 +187,7 @@
       name = "_nodelib_fs.stat___fs.stat_2.0.5.tgz";
       path = fetchurl {
         name = "_nodelib_fs.stat___fs.stat_2.0.5.tgz";
-        url  = "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz";
+        url = "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz";
         sha512 = "RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==";
       };
     }
@@ -189,7 +195,7 @@
       name = "_nodelib_fs.walk___fs.walk_1.2.8.tgz";
       path = fetchurl {
         name = "_nodelib_fs.walk___fs.walk_1.2.8.tgz";
-        url  = "https://registry.yarnpkg.com/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz";
+        url = "https://registry.yarnpkg.com/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz";
         sha512 = "oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==";
       };
     }
@@ -197,7 +203,7 @@
       name = "_sinclair_typebox___typebox_0.27.8.tgz";
       path = fetchurl {
         name = "_sinclair_typebox___typebox_0.27.8.tgz";
-        url  = "https://registry.yarnpkg.com/@sinclair/typebox/-/typebox-0.27.8.tgz";
+        url = "https://registry.yarnpkg.com/@sinclair/typebox/-/typebox-0.27.8.tgz";
         sha512 = "+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==";
       };
     }
@@ -205,7 +211,7 @@
       name = "_tootallnate_once___once_1.1.2.tgz";
       path = fetchurl {
         name = "_tootallnate_once___once_1.1.2.tgz";
-        url  = "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.1.2.tgz";
+        url = "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.1.2.tgz";
         sha512 = "RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==";
       };
     }
@@ -213,7 +219,7 @@
       name = "_types_eslint_scope___eslint_scope_3.7.7.tgz";
       path = fetchurl {
         name = "_types_eslint_scope___eslint_scope_3.7.7.tgz";
-        url  = "https://registry.yarnpkg.com/@types/eslint-scope/-/eslint-scope-3.7.7.tgz";
+        url = "https://registry.yarnpkg.com/@types/eslint-scope/-/eslint-scope-3.7.7.tgz";
         sha512 = "MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==";
       };
     }
@@ -221,7 +227,7 @@
       name = "_types_eslint___eslint_8.56.2.tgz";
       path = fetchurl {
         name = "_types_eslint___eslint_8.56.2.tgz";
-        url  = "https://registry.yarnpkg.com/@types/eslint/-/eslint-8.56.2.tgz";
+        url = "https://registry.yarnpkg.com/@types/eslint/-/eslint-8.56.2.tgz";
         sha512 = "uQDwm1wFHmbBbCZCqAlq6Do9LYwByNZHWzXppSnay9SuwJ+VRbjkbLABer54kcPnMSlG6Fdiy2yaFXm/z9Z5gw==";
       };
     }
@@ -229,7 +235,7 @@
       name = "_types_estree___estree_1.0.5.tgz";
       path = fetchurl {
         name = "_types_estree___estree_1.0.5.tgz";
-        url  = "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.5.tgz";
+        url = "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.5.tgz";
         sha512 = "/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==";
       };
     }
@@ -237,7 +243,7 @@
       name = "_types_glob___glob_8.1.0.tgz";
       path = fetchurl {
         name = "_types_glob___glob_8.1.0.tgz";
-        url  = "https://registry.yarnpkg.com/@types/glob/-/glob-8.1.0.tgz";
+        url = "https://registry.yarnpkg.com/@types/glob/-/glob-8.1.0.tgz";
         sha512 = "IO+MJPVhoqz+28h1qLAcBEH2+xHMK6MTyHJc7MTnnYb6wsoLR29POVGJ7LycmVXIqyy/4/2ShP5sUwTXuOwb/w==";
       };
     }
@@ -245,7 +251,7 @@
       name = "_types_istanbul_lib_coverage___istanbul_lib_coverage_2.0.6.tgz";
       path = fetchurl {
         name = "_types_istanbul_lib_coverage___istanbul_lib_coverage_2.0.6.tgz";
-        url  = "https://registry.yarnpkg.com/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz";
+        url = "https://registry.yarnpkg.com/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz";
         sha512 = "2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==";
       };
     }
@@ -253,7 +259,7 @@
       name = "_types_istanbul_lib_report___istanbul_lib_report_3.0.3.tgz";
       path = fetchurl {
         name = "_types_istanbul_lib_report___istanbul_lib_report_3.0.3.tgz";
-        url  = "https://registry.yarnpkg.com/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.3.tgz";
+        url = "https://registry.yarnpkg.com/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.3.tgz";
         sha512 = "NQn7AHQnk/RSLOxrBbGyJM/aVQ+pjj5HCgasFxc0K/KhoATfQ/47AyUl15I2yBUpihjmas+a+VJBOqecrFH+uA==";
       };
     }
@@ -261,7 +267,7 @@
       name = "_types_istanbul_reports___istanbul_reports_3.0.4.tgz";
       path = fetchurl {
         name = "_types_istanbul_reports___istanbul_reports_3.0.4.tgz";
-        url  = "https://registry.yarnpkg.com/@types/istanbul-reports/-/istanbul-reports-3.0.4.tgz";
+        url = "https://registry.yarnpkg.com/@types/istanbul-reports/-/istanbul-reports-3.0.4.tgz";
         sha512 = "pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==";
       };
     }
@@ -269,7 +275,7 @@
       name = "_types_json_schema___json_schema_7.0.15.tgz";
       path = fetchurl {
         name = "_types_json_schema___json_schema_7.0.15.tgz";
-        url  = "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.15.tgz";
+        url = "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.15.tgz";
         sha512 = "5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==";
       };
     }
@@ -277,7 +283,7 @@
       name = "_types_minimatch___minimatch_5.1.2.tgz";
       path = fetchurl {
         name = "_types_minimatch___minimatch_5.1.2.tgz";
-        url  = "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-5.1.2.tgz";
+        url = "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-5.1.2.tgz";
         sha512 = "K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==";
       };
     }
@@ -285,7 +291,7 @@
       name = "_types_mocha___mocha_10.0.6.tgz";
       path = fetchurl {
         name = "_types_mocha___mocha_10.0.6.tgz";
-        url  = "https://registry.yarnpkg.com/@types/mocha/-/mocha-10.0.6.tgz";
+        url = "https://registry.yarnpkg.com/@types/mocha/-/mocha-10.0.6.tgz";
         sha512 = "dJvrYWxP/UcXm36Qn36fxhUKu8A/xMRXVT2cliFF1Z7UA9liG5Psj3ezNSZw+5puH2czDXRLcXQxf8JbJt0ejg==";
       };
     }
@@ -293,7 +299,7 @@
       name = "_types_node___node_20.11.6.tgz";
       path = fetchurl {
         name = "_types_node___node_20.11.6.tgz";
-        url  = "https://registry.yarnpkg.com/@types/node/-/node-20.11.6.tgz";
+        url = "https://registry.yarnpkg.com/@types/node/-/node-20.11.6.tgz";
         sha512 = "+EOokTnksGVgip2PbYbr3xnR7kZigh4LbybAfBAw5BpnQ+FqBYUsvCEjYd70IXKlbohQ64mzEYmMtlWUY8q//Q==";
       };
     }
@@ -301,7 +307,7 @@
       name = "_types_node___node_16.18.75.tgz";
       path = fetchurl {
         name = "_types_node___node_16.18.75.tgz";
-        url  = "https://registry.yarnpkg.com/@types/node/-/node-16.18.75.tgz";
+        url = "https://registry.yarnpkg.com/@types/node/-/node-16.18.75.tgz";
         sha512 = "+FSfZd5mpMDTcIK7bp2GueIcAespzR4FROOXnEst248c85vwthIEwtXYOLgVc/sI4ihE1K/7yO1lEiSgvwAOxA==";
       };
     }
@@ -309,7 +315,7 @@
       name = "_types_semver___semver_7.5.6.tgz";
       path = fetchurl {
         name = "_types_semver___semver_7.5.6.tgz";
-        url  = "https://registry.yarnpkg.com/@types/semver/-/semver-7.5.6.tgz";
+        url = "https://registry.yarnpkg.com/@types/semver/-/semver-7.5.6.tgz";
         sha512 = "dn1l8LaMea/IjDoHNd9J52uBbInB796CDffS6VdIxvqYCPSG0V0DzHp76GpaWnlhg88uYyPbXCDIowa86ybd5A==";
       };
     }
@@ -317,7 +323,7 @@
       name = "_types_stack_utils___stack_utils_2.0.3.tgz";
       path = fetchurl {
         name = "_types_stack_utils___stack_utils_2.0.3.tgz";
-        url  = "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-2.0.3.tgz";
+        url = "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-2.0.3.tgz";
         sha512 = "9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==";
       };
     }
@@ -325,7 +331,7 @@
       name = "_types_tmp___tmp_0.2.6.tgz";
       path = fetchurl {
         name = "_types_tmp___tmp_0.2.6.tgz";
-        url  = "https://registry.yarnpkg.com/@types/tmp/-/tmp-0.2.6.tgz";
+        url = "https://registry.yarnpkg.com/@types/tmp/-/tmp-0.2.6.tgz";
         sha512 = "chhaNf2oKHlRkDGt+tiKE2Z5aJ6qalm7Z9rlLdBwmOiAAf09YQvvoLXjWK4HWPF1xU/fqvMgfNfpVoBscA/tKA==";
       };
     }
@@ -333,7 +339,7 @@
       name = "_types_vscode___vscode_1.85.0.tgz";
       path = fetchurl {
         name = "_types_vscode___vscode_1.85.0.tgz";
-        url  = "https://registry.yarnpkg.com/@types/vscode/-/vscode-1.85.0.tgz";
+        url = "https://registry.yarnpkg.com/@types/vscode/-/vscode-1.85.0.tgz";
         sha512 = "CF/RBon/GXwdfmnjZj0WTUMZN5H6YITOfBCP4iEZlOtVQXuzw6t7Le7+cR+7JzdMrnlm7Mfp49Oj2TuSXIWo3g==";
       };
     }
@@ -341,7 +347,7 @@
       name = "_types_yargs_parser___yargs_parser_21.0.3.tgz";
       path = fetchurl {
         name = "_types_yargs_parser___yargs_parser_21.0.3.tgz";
-        url  = "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-21.0.3.tgz";
+        url = "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-21.0.3.tgz";
         sha512 = "I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==";
       };
     }
@@ -349,7 +355,7 @@
       name = "_types_yargs___yargs_17.0.32.tgz";
       path = fetchurl {
         name = "_types_yargs___yargs_17.0.32.tgz";
-        url  = "https://registry.yarnpkg.com/@types/yargs/-/yargs-17.0.32.tgz";
+        url = "https://registry.yarnpkg.com/@types/yargs/-/yargs-17.0.32.tgz";
         sha512 = "xQ67Yc/laOG5uMfX/093MRlGGCIBzZMarVa+gfNKJxWAIgykYpVGkBdbqEzGDDfCrVUj6Hiff4mTZ5BA6TmAog==";
       };
     }
@@ -357,7 +363,7 @@
       name = "_typescript_eslint_eslint_plugin___eslint_plugin_5.62.0.tgz";
       path = fetchurl {
         name = "_typescript_eslint_eslint_plugin___eslint_plugin_5.62.0.tgz";
-        url  = "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.62.0.tgz";
+        url = "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.62.0.tgz";
         sha512 = "TiZzBSJja/LbhNPvk6yc0JrX9XqhQ0hdh6M2svYfsHGejaKFIAGd9MQ+ERIMzLGlN/kZoYIgdxFV0PuljTKXag==";
       };
     }
@@ -365,7 +371,7 @@
       name = "_typescript_eslint_parser___parser_5.62.0.tgz";
       path = fetchurl {
         name = "_typescript_eslint_parser___parser_5.62.0.tgz";
-        url  = "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-5.62.0.tgz";
+        url = "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-5.62.0.tgz";
         sha512 = "VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==";
       };
     }
@@ -373,7 +379,7 @@
       name = "_typescript_eslint_scope_manager___scope_manager_5.62.0.tgz";
       path = fetchurl {
         name = "_typescript_eslint_scope_manager___scope_manager_5.62.0.tgz";
-        url  = "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-5.62.0.tgz";
+        url = "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-5.62.0.tgz";
         sha512 = "VXuvVvZeQCQb5Zgf4HAxc04q5j+WrNAtNh9OwCsCgpKqESMTu3tF/jhZ3xG6T4NZwWl65Bg8KuS2uEvhSfLl0w==";
       };
     }
@@ -381,7 +387,7 @@
       name = "_typescript_eslint_type_utils___type_utils_5.62.0.tgz";
       path = fetchurl {
         name = "_typescript_eslint_type_utils___type_utils_5.62.0.tgz";
-        url  = "https://registry.yarnpkg.com/@typescript-eslint/type-utils/-/type-utils-5.62.0.tgz";
+        url = "https://registry.yarnpkg.com/@typescript-eslint/type-utils/-/type-utils-5.62.0.tgz";
         sha512 = "xsSQreu+VnfbqQpW5vnCJdq1Z3Q0U31qiWmRhr98ONQmcp/yhiPJFPq8MXiJVLiksmOKSjIldZzkebzHuCGzew==";
       };
     }
@@ -389,7 +395,7 @@
       name = "_typescript_eslint_types___types_5.62.0.tgz";
       path = fetchurl {
         name = "_typescript_eslint_types___types_5.62.0.tgz";
-        url  = "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.62.0.tgz";
+        url = "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.62.0.tgz";
         sha512 = "87NVngcbVXUahrRTqIK27gD2t5Cu1yuCXxbLcFtCzZGlfyVWWh8mLHkoxzjsB6DDNnvdL+fW8MiwPEJyGJQDgQ==";
       };
     }
@@ -397,7 +403,7 @@
       name = "_typescript_eslint_typescript_estree___typescript_estree_5.62.0.tgz";
       path = fetchurl {
         name = "_typescript_eslint_typescript_estree___typescript_estree_5.62.0.tgz";
-        url  = "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-5.62.0.tgz";
+        url = "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-5.62.0.tgz";
         sha512 = "CmcQ6uY7b9y694lKdRB8FEel7JbU/40iSAPomu++SjLMntB+2Leay2LO6i8VnJk58MtE9/nQSFIH6jpyRWyYzA==";
       };
     }
@@ -405,7 +411,7 @@
       name = "_typescript_eslint_utils___utils_5.62.0.tgz";
       path = fetchurl {
         name = "_typescript_eslint_utils___utils_5.62.0.tgz";
-        url  = "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-5.62.0.tgz";
+        url = "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-5.62.0.tgz";
         sha512 = "n8oxjeb5aIbPFEtmQxQYOLI0i9n5ySBEY/ZEHHZqKQSFnxio1rv6dthascc9dLuwrL0RC5mPCxB7vnAVGAYWAQ==";
       };
     }
@@ -413,7 +419,7 @@
       name = "_typescript_eslint_visitor_keys___visitor_keys_5.62.0.tgz";
       path = fetchurl {
         name = "_typescript_eslint_visitor_keys___visitor_keys_5.62.0.tgz";
-        url  = "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.62.0.tgz";
+        url = "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.62.0.tgz";
         sha512 = "07ny+LHRzQXepkGg6w0mFY41fVUNBrL2Roj/++7V1txKugfjm/Ci/qSND03r2RhlJhJYMcTn9AhhSSqQp0Ysyw==";
       };
     }
@@ -421,7 +427,7 @@
       name = "_ungap_structured_clone___structured_clone_1.2.0.tgz";
       path = fetchurl {
         name = "_ungap_structured_clone___structured_clone_1.2.0.tgz";
-        url  = "https://registry.yarnpkg.com/@ungap/structured-clone/-/structured-clone-1.2.0.tgz";
+        url = "https://registry.yarnpkg.com/@ungap/structured-clone/-/structured-clone-1.2.0.tgz";
         sha512 = "zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==";
       };
     }
@@ -429,7 +435,7 @@
       name = "_vscode_test_electron___test_electron_2.3.8.tgz";
       path = fetchurl {
         name = "_vscode_test_electron___test_electron_2.3.8.tgz";
-        url  = "https://registry.yarnpkg.com/@vscode/test-electron/-/test-electron-2.3.8.tgz";
+        url = "https://registry.yarnpkg.com/@vscode/test-electron/-/test-electron-2.3.8.tgz";
         sha512 = "b4aZZsBKtMGdDljAsOPObnAi7+VWIaYl3ylCz1jTs+oV6BZ4TNHcVNC3xUn0azPeszBmwSBDQYfFESIaUQnrOg==";
       };
     }
@@ -437,7 +443,7 @@
       name = "_vscode_vsce___vsce_2.22.0.tgz";
       path = fetchurl {
         name = "_vscode_vsce___vsce_2.22.0.tgz";
-        url  = "https://registry.yarnpkg.com/@vscode/vsce/-/vsce-2.22.0.tgz";
+        url = "https://registry.yarnpkg.com/@vscode/vsce/-/vsce-2.22.0.tgz";
         sha512 = "8df4uJiM3C6GZ2Sx/KilSKVxsetrTBBIUb3c0W4B1EWHcddioVs5mkyDKtMNP0khP/xBILVSzlXxhV+nm2rC9A==";
       };
     }
@@ -445,7 +451,7 @@
       name = "_webassemblyjs_ast___ast_1.11.6.tgz";
       path = fetchurl {
         name = "_webassemblyjs_ast___ast_1.11.6.tgz";
-        url  = "https://registry.yarnpkg.com/@webassemblyjs/ast/-/ast-1.11.6.tgz";
+        url = "https://registry.yarnpkg.com/@webassemblyjs/ast/-/ast-1.11.6.tgz";
         sha512 = "IN1xI7PwOvLPgjcf180gC1bqn3q/QaOCwYUahIOhbYUu8KA/3tw2RT/T0Gidi1l7Hhj5D/INhJxiICObqpMu4Q==";
       };
     }
@@ -453,7 +459,7 @@
       name = "_webassemblyjs_floating_point_hex_parser___floating_point_hex_parser_1.11.6.tgz";
       path = fetchurl {
         name = "_webassemblyjs_floating_point_hex_parser___floating_point_hex_parser_1.11.6.tgz";
-        url  = "https://registry.yarnpkg.com/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.11.6.tgz";
+        url = "https://registry.yarnpkg.com/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.11.6.tgz";
         sha512 = "ejAj9hfRJ2XMsNHk/v6Fu2dGS+i4UaXBXGemOfQ/JfQ6mdQg/WXtwleQRLLS4OvfDhv8rYnVwH27YJLMyYsxhw==";
       };
     }
@@ -461,7 +467,7 @@
       name = "_webassemblyjs_helper_api_error___helper_api_error_1.11.6.tgz";
       path = fetchurl {
         name = "_webassemblyjs_helper_api_error___helper_api_error_1.11.6.tgz";
-        url  = "https://registry.yarnpkg.com/@webassemblyjs/helper-api-error/-/helper-api-error-1.11.6.tgz";
+        url = "https://registry.yarnpkg.com/@webassemblyjs/helper-api-error/-/helper-api-error-1.11.6.tgz";
         sha512 = "o0YkoP4pVu4rN8aTJgAyj9hC2Sv5UlkzCHhxqWj8butaLvnpdc2jOwh4ewE6CX0txSfLn/UYaV/pheS2Txg//Q==";
       };
     }
@@ -469,7 +475,7 @@
       name = "_webassemblyjs_helper_buffer___helper_buffer_1.11.6.tgz";
       path = fetchurl {
         name = "_webassemblyjs_helper_buffer___helper_buffer_1.11.6.tgz";
-        url  = "https://registry.yarnpkg.com/@webassemblyjs/helper-buffer/-/helper-buffer-1.11.6.tgz";
+        url = "https://registry.yarnpkg.com/@webassemblyjs/helper-buffer/-/helper-buffer-1.11.6.tgz";
         sha512 = "z3nFzdcp1mb8nEOFFk8DrYLpHvhKC3grJD2ardfKOzmbmJvEf/tPIqCY+sNcwZIY8ZD7IkB2l7/pqhUhqm7hLA==";
       };
     }
@@ -477,7 +483,7 @@
       name = "_webassemblyjs_helper_numbers___helper_numbers_1.11.6.tgz";
       path = fetchurl {
         name = "_webassemblyjs_helper_numbers___helper_numbers_1.11.6.tgz";
-        url  = "https://registry.yarnpkg.com/@webassemblyjs/helper-numbers/-/helper-numbers-1.11.6.tgz";
+        url = "https://registry.yarnpkg.com/@webassemblyjs/helper-numbers/-/helper-numbers-1.11.6.tgz";
         sha512 = "vUIhZ8LZoIWHBohiEObxVm6hwP034jwmc9kuq5GdHZH0wiLVLIPcMCdpJzG4C11cHoQ25TFIQj9kaVADVX7N3g==";
       };
     }
@@ -485,7 +491,7 @@
       name = "_webassemblyjs_helper_wasm_bytecode___helper_wasm_bytecode_1.11.6.tgz";
       path = fetchurl {
         name = "_webassemblyjs_helper_wasm_bytecode___helper_wasm_bytecode_1.11.6.tgz";
-        url  = "https://registry.yarnpkg.com/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.11.6.tgz";
+        url = "https://registry.yarnpkg.com/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.11.6.tgz";
         sha512 = "sFFHKwcmBprO9e7Icf0+gddyWYDViL8bpPjJJl0WHxCdETktXdmtWLGVzoHbqUcY4Be1LkNfwTmXOJUFZYSJdA==";
       };
     }
@@ -493,7 +499,7 @@
       name = "_webassemblyjs_helper_wasm_section___helper_wasm_section_1.11.6.tgz";
       path = fetchurl {
         name = "_webassemblyjs_helper_wasm_section___helper_wasm_section_1.11.6.tgz";
-        url  = "https://registry.yarnpkg.com/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.11.6.tgz";
+        url = "https://registry.yarnpkg.com/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.11.6.tgz";
         sha512 = "LPpZbSOwTpEC2cgn4hTydySy1Ke+XEu+ETXuoyvuyezHO3Kjdu90KK95Sh9xTbmjrCsUwvWwCOQQNta37VrS9g==";
       };
     }
@@ -501,7 +507,7 @@
       name = "_webassemblyjs_ieee754___ieee754_1.11.6.tgz";
       path = fetchurl {
         name = "_webassemblyjs_ieee754___ieee754_1.11.6.tgz";
-        url  = "https://registry.yarnpkg.com/@webassemblyjs/ieee754/-/ieee754-1.11.6.tgz";
+        url = "https://registry.yarnpkg.com/@webassemblyjs/ieee754/-/ieee754-1.11.6.tgz";
         sha512 = "LM4p2csPNvbij6U1f19v6WR56QZ8JcHg3QIJTlSwzFcmx6WSORicYj6I63f9yU1kEUtrpG+kjkiIAkevHpDXrg==";
       };
     }
@@ -509,7 +515,7 @@
       name = "_webassemblyjs_leb128___leb128_1.11.6.tgz";
       path = fetchurl {
         name = "_webassemblyjs_leb128___leb128_1.11.6.tgz";
-        url  = "https://registry.yarnpkg.com/@webassemblyjs/leb128/-/leb128-1.11.6.tgz";
+        url = "https://registry.yarnpkg.com/@webassemblyjs/leb128/-/leb128-1.11.6.tgz";
         sha512 = "m7a0FhE67DQXgouf1tbN5XQcdWoNgaAuoULHIfGFIEVKA6tu/edls6XnIlkmS6FrXAquJRPni3ZZKjw6FSPjPQ==";
       };
     }
@@ -517,7 +523,7 @@
       name = "_webassemblyjs_utf8___utf8_1.11.6.tgz";
       path = fetchurl {
         name = "_webassemblyjs_utf8___utf8_1.11.6.tgz";
-        url  = "https://registry.yarnpkg.com/@webassemblyjs/utf8/-/utf8-1.11.6.tgz";
+        url = "https://registry.yarnpkg.com/@webassemblyjs/utf8/-/utf8-1.11.6.tgz";
         sha512 = "vtXf2wTQ3+up9Zsg8sa2yWiQpzSsMyXj0qViVP6xKGCUT8p8YJ6HqI7l5eCnWx1T/FYdsv07HQs2wTFbbof/RA==";
       };
     }
@@ -525,7 +531,7 @@
       name = "_webassemblyjs_wasm_edit___wasm_edit_1.11.6.tgz";
       path = fetchurl {
         name = "_webassemblyjs_wasm_edit___wasm_edit_1.11.6.tgz";
-        url  = "https://registry.yarnpkg.com/@webassemblyjs/wasm-edit/-/wasm-edit-1.11.6.tgz";
+        url = "https://registry.yarnpkg.com/@webassemblyjs/wasm-edit/-/wasm-edit-1.11.6.tgz";
         sha512 = "Ybn2I6fnfIGuCR+Faaz7YcvtBKxvoLV3Lebn1tM4o/IAJzmi9AWYIPWpyBfU8cC+JxAO57bk4+zdsTjJR+VTOw==";
       };
     }
@@ -533,7 +539,7 @@
       name = "_webassemblyjs_wasm_gen___wasm_gen_1.11.6.tgz";
       path = fetchurl {
         name = "_webassemblyjs_wasm_gen___wasm_gen_1.11.6.tgz";
-        url  = "https://registry.yarnpkg.com/@webassemblyjs/wasm-gen/-/wasm-gen-1.11.6.tgz";
+        url = "https://registry.yarnpkg.com/@webassemblyjs/wasm-gen/-/wasm-gen-1.11.6.tgz";
         sha512 = "3XOqkZP/y6B4F0PBAXvI1/bky7GryoogUtfwExeP/v7Nzwo1QLcq5oQmpKlftZLbT+ERUOAZVQjuNVak6UXjPA==";
       };
     }
@@ -541,7 +547,7 @@
       name = "_webassemblyjs_wasm_opt___wasm_opt_1.11.6.tgz";
       path = fetchurl {
         name = "_webassemblyjs_wasm_opt___wasm_opt_1.11.6.tgz";
-        url  = "https://registry.yarnpkg.com/@webassemblyjs/wasm-opt/-/wasm-opt-1.11.6.tgz";
+        url = "https://registry.yarnpkg.com/@webassemblyjs/wasm-opt/-/wasm-opt-1.11.6.tgz";
         sha512 = "cOrKuLRE7PCe6AsOVl7WasYf3wbSo4CeOk6PkrjS7g57MFfVUF9u6ysQBBODX0LdgSvQqRiGz3CXvIDKcPNy4g==";
       };
     }
@@ -549,7 +555,7 @@
       name = "_webassemblyjs_wasm_parser___wasm_parser_1.11.6.tgz";
       path = fetchurl {
         name = "_webassemblyjs_wasm_parser___wasm_parser_1.11.6.tgz";
-        url  = "https://registry.yarnpkg.com/@webassemblyjs/wasm-parser/-/wasm-parser-1.11.6.tgz";
+        url = "https://registry.yarnpkg.com/@webassemblyjs/wasm-parser/-/wasm-parser-1.11.6.tgz";
         sha512 = "6ZwPeGzMJM3Dqp3hCsLgESxBGtT/OeCvCZ4TA1JUPYgmhAx38tTPR9JaKy0S5H3evQpO/h2uWs2j6Yc/fjkpTQ==";
       };
     }
@@ -557,7 +563,7 @@
       name = "_webassemblyjs_wast_printer___wast_printer_1.11.6.tgz";
       path = fetchurl {
         name = "_webassemblyjs_wast_printer___wast_printer_1.11.6.tgz";
-        url  = "https://registry.yarnpkg.com/@webassemblyjs/wast-printer/-/wast-printer-1.11.6.tgz";
+        url = "https://registry.yarnpkg.com/@webassemblyjs/wast-printer/-/wast-printer-1.11.6.tgz";
         sha512 = "JM7AhRcE+yW2GWYaKeHL5vt4xqee5N2WcezptmgyhNS+ScggqcT1OtXykhAb13Sn5Yas0j2uv9tHgrjwvzAP4A==";
       };
     }
@@ -565,7 +571,7 @@
       name = "_webpack_cli_configtest___configtest_2.1.1.tgz";
       path = fetchurl {
         name = "_webpack_cli_configtest___configtest_2.1.1.tgz";
-        url  = "https://registry.yarnpkg.com/@webpack-cli/configtest/-/configtest-2.1.1.tgz";
+        url = "https://registry.yarnpkg.com/@webpack-cli/configtest/-/configtest-2.1.1.tgz";
         sha512 = "wy0mglZpDSiSS0XHrVR+BAdId2+yxPSoJW8fsna3ZpYSlufjvxnP4YbKTCBZnNIcGN4r6ZPXV55X4mYExOfLmw==";
       };
     }
@@ -573,7 +579,7 @@
       name = "_webpack_cli_info___info_2.0.2.tgz";
       path = fetchurl {
         name = "_webpack_cli_info___info_2.0.2.tgz";
-        url  = "https://registry.yarnpkg.com/@webpack-cli/info/-/info-2.0.2.tgz";
+        url = "https://registry.yarnpkg.com/@webpack-cli/info/-/info-2.0.2.tgz";
         sha512 = "zLHQdI/Qs1UyT5UBdWNqsARasIA+AaF8t+4u2aS2nEpBQh2mWIVb8qAklq0eUENnC5mOItrIB4LiS9xMtph18A==";
       };
     }
@@ -581,7 +587,7 @@
       name = "_webpack_cli_serve___serve_2.0.5.tgz";
       path = fetchurl {
         name = "_webpack_cli_serve___serve_2.0.5.tgz";
-        url  = "https://registry.yarnpkg.com/@webpack-cli/serve/-/serve-2.0.5.tgz";
+        url = "https://registry.yarnpkg.com/@webpack-cli/serve/-/serve-2.0.5.tgz";
         sha512 = "lqaoKnRYBdo1UgDX8uF24AfGMifWK19TxPmM5FHc2vAGxrJ/qtyUyFBWoY1tISZdelsQ5fBcOusifo5o5wSJxQ==";
       };
     }
@@ -589,7 +595,7 @@
       name = "_xtuc_ieee754___ieee754_1.2.0.tgz";
       path = fetchurl {
         name = "_xtuc_ieee754___ieee754_1.2.0.tgz";
-        url  = "https://registry.yarnpkg.com/@xtuc/ieee754/-/ieee754-1.2.0.tgz";
+        url = "https://registry.yarnpkg.com/@xtuc/ieee754/-/ieee754-1.2.0.tgz";
         sha512 = "DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==";
       };
     }
@@ -597,7 +603,7 @@
       name = "_xtuc_long___long_4.2.2.tgz";
       path = fetchurl {
         name = "_xtuc_long___long_4.2.2.tgz";
-        url  = "https://registry.yarnpkg.com/@xtuc/long/-/long-4.2.2.tgz";
+        url = "https://registry.yarnpkg.com/@xtuc/long/-/long-4.2.2.tgz";
         sha512 = "NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==";
       };
     }
@@ -605,7 +611,7 @@
       name = "acorn_import_assertions___acorn_import_assertions_1.9.0.tgz";
       path = fetchurl {
         name = "acorn_import_assertions___acorn_import_assertions_1.9.0.tgz";
-        url  = "https://registry.yarnpkg.com/acorn-import-assertions/-/acorn-import-assertions-1.9.0.tgz";
+        url = "https://registry.yarnpkg.com/acorn-import-assertions/-/acorn-import-assertions-1.9.0.tgz";
         sha512 = "cmMwop9x+8KFhxvKrKfPYmN6/pKTYYHBqLa0DfvVZcKMJWNyWLnaqND7dx/qn66R7ewM1UX5XMaDVP5wlVTaVA==";
       };
     }
@@ -613,7 +619,7 @@
       name = "acorn_jsx___acorn_jsx_5.3.2.tgz";
       path = fetchurl {
         name = "acorn_jsx___acorn_jsx_5.3.2.tgz";
-        url  = "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.3.2.tgz";
+        url = "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.3.2.tgz";
         sha512 = "rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==";
       };
     }
@@ -621,7 +627,7 @@
       name = "acorn___acorn_8.11.3.tgz";
       path = fetchurl {
         name = "acorn___acorn_8.11.3.tgz";
-        url  = "https://registry.yarnpkg.com/acorn/-/acorn-8.11.3.tgz";
+        url = "https://registry.yarnpkg.com/acorn/-/acorn-8.11.3.tgz";
         sha512 = "Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==";
       };
     }
@@ -629,7 +635,7 @@
       name = "agent_base___agent_base_6.0.2.tgz";
       path = fetchurl {
         name = "agent_base___agent_base_6.0.2.tgz";
-        url  = "https://registry.yarnpkg.com/agent-base/-/agent-base-6.0.2.tgz";
+        url = "https://registry.yarnpkg.com/agent-base/-/agent-base-6.0.2.tgz";
         sha512 = "RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==";
       };
     }
@@ -637,7 +643,7 @@
       name = "ajv_keywords___ajv_keywords_3.5.2.tgz";
       path = fetchurl {
         name = "ajv_keywords___ajv_keywords_3.5.2.tgz";
-        url  = "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-3.5.2.tgz";
+        url = "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-3.5.2.tgz";
         sha512 = "5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==";
       };
     }
@@ -645,7 +651,7 @@
       name = "ajv___ajv_6.12.6.tgz";
       path = fetchurl {
         name = "ajv___ajv_6.12.6.tgz";
-        url  = "https://registry.yarnpkg.com/ajv/-/ajv-6.12.6.tgz";
+        url = "https://registry.yarnpkg.com/ajv/-/ajv-6.12.6.tgz";
         sha512 = "j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==";
       };
     }
@@ -653,7 +659,7 @@
       name = "ansi_colors___ansi_colors_4.1.1.tgz";
       path = fetchurl {
         name = "ansi_colors___ansi_colors_4.1.1.tgz";
-        url  = "https://registry.yarnpkg.com/ansi-colors/-/ansi-colors-4.1.1.tgz";
+        url = "https://registry.yarnpkg.com/ansi-colors/-/ansi-colors-4.1.1.tgz";
         sha512 = "JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==";
       };
     }
@@ -661,7 +667,7 @@
       name = "ansi_regex___ansi_regex_5.0.1.tgz";
       path = fetchurl {
         name = "ansi_regex___ansi_regex_5.0.1.tgz";
-        url  = "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz";
+        url = "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz";
         sha512 = "quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==";
       };
     }
@@ -669,7 +675,7 @@
       name = "ansi_styles___ansi_styles_3.2.1.tgz";
       path = fetchurl {
         name = "ansi_styles___ansi_styles_3.2.1.tgz";
-        url  = "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.1.tgz";
+        url = "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.1.tgz";
         sha512 = "VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==";
       };
     }
@@ -677,7 +683,7 @@
       name = "ansi_styles___ansi_styles_4.3.0.tgz";
       path = fetchurl {
         name = "ansi_styles___ansi_styles_4.3.0.tgz";
-        url  = "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-4.3.0.tgz";
+        url = "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-4.3.0.tgz";
         sha512 = "zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==";
       };
     }
@@ -685,7 +691,7 @@
       name = "ansi_styles___ansi_styles_5.2.0.tgz";
       path = fetchurl {
         name = "ansi_styles___ansi_styles_5.2.0.tgz";
-        url  = "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-5.2.0.tgz";
+        url = "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-5.2.0.tgz";
         sha512 = "Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==";
       };
     }
@@ -693,7 +699,7 @@
       name = "anymatch___anymatch_3.1.3.tgz";
       path = fetchurl {
         name = "anymatch___anymatch_3.1.3.tgz";
-        url  = "https://registry.yarnpkg.com/anymatch/-/anymatch-3.1.3.tgz";
+        url = "https://registry.yarnpkg.com/anymatch/-/anymatch-3.1.3.tgz";
         sha512 = "KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==";
       };
     }
@@ -701,7 +707,7 @@
       name = "argparse___argparse_2.0.1.tgz";
       path = fetchurl {
         name = "argparse___argparse_2.0.1.tgz";
-        url  = "https://registry.yarnpkg.com/argparse/-/argparse-2.0.1.tgz";
+        url = "https://registry.yarnpkg.com/argparse/-/argparse-2.0.1.tgz";
         sha512 = "8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==";
       };
     }
@@ -709,7 +715,7 @@
       name = "array_union___array_union_2.1.0.tgz";
       path = fetchurl {
         name = "array_union___array_union_2.1.0.tgz";
-        url  = "https://registry.yarnpkg.com/array-union/-/array-union-2.1.0.tgz";
+        url = "https://registry.yarnpkg.com/array-union/-/array-union-2.1.0.tgz";
         sha512 = "HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==";
       };
     }
@@ -717,7 +723,7 @@
       name = "azure_devops_node_api___azure_devops_node_api_11.2.0.tgz";
       path = fetchurl {
         name = "azure_devops_node_api___azure_devops_node_api_11.2.0.tgz";
-        url  = "https://registry.yarnpkg.com/azure-devops-node-api/-/azure-devops-node-api-11.2.0.tgz";
+        url = "https://registry.yarnpkg.com/azure-devops-node-api/-/azure-devops-node-api-11.2.0.tgz";
         sha512 = "XdiGPhrpaT5J8wdERRKs5g8E0Zy1pvOYTli7z9E8nmOn3YGp4FhtjhrOyFmX/8veWCwdI69mCHKJw6l+4J/bHA==";
       };
     }
@@ -725,7 +731,7 @@
       name = "balanced_match___balanced_match_1.0.2.tgz";
       path = fetchurl {
         name = "balanced_match___balanced_match_1.0.2.tgz";
-        url  = "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz";
+        url = "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz";
         sha512 = "3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==";
       };
     }
@@ -733,7 +739,7 @@
       name = "base64_js___base64_js_1.5.1.tgz";
       path = fetchurl {
         name = "base64_js___base64_js_1.5.1.tgz";
-        url  = "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz";
+        url = "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz";
         sha512 = "AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==";
       };
     }
@@ -741,7 +747,7 @@
       name = "binary_extensions___binary_extensions_2.2.0.tgz";
       path = fetchurl {
         name = "binary_extensions___binary_extensions_2.2.0.tgz";
-        url  = "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.2.0.tgz";
+        url = "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.2.0.tgz";
         sha512 = "jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==";
       };
     }
@@ -749,7 +755,7 @@
       name = "bl___bl_4.1.0.tgz";
       path = fetchurl {
         name = "bl___bl_4.1.0.tgz";
-        url  = "https://registry.yarnpkg.com/bl/-/bl-4.1.0.tgz";
+        url = "https://registry.yarnpkg.com/bl/-/bl-4.1.0.tgz";
         sha512 = "1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==";
       };
     }
@@ -757,7 +763,7 @@
       name = "boolbase___boolbase_1.0.0.tgz";
       path = fetchurl {
         name = "boolbase___boolbase_1.0.0.tgz";
-        url  = "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz";
+        url = "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz";
         sha512 = "JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==";
       };
     }
@@ -765,7 +771,7 @@
       name = "brace_expansion___brace_expansion_1.1.11.tgz";
       path = fetchurl {
         name = "brace_expansion___brace_expansion_1.1.11.tgz";
-        url  = "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz";
+        url = "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz";
         sha512 = "iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==";
       };
     }
@@ -773,7 +779,7 @@
       name = "brace_expansion___brace_expansion_2.0.1.tgz";
       path = fetchurl {
         name = "brace_expansion___brace_expansion_2.0.1.tgz";
-        url  = "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-2.0.1.tgz";
+        url = "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-2.0.1.tgz";
         sha512 = "XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==";
       };
     }
@@ -781,7 +787,7 @@
       name = "braces___braces_3.0.2.tgz";
       path = fetchurl {
         name = "braces___braces_3.0.2.tgz";
-        url  = "https://registry.yarnpkg.com/braces/-/braces-3.0.2.tgz";
+        url = "https://registry.yarnpkg.com/braces/-/braces-3.0.2.tgz";
         sha512 = "b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==";
       };
     }
@@ -789,7 +795,7 @@
       name = "browser_stdout___browser_stdout_1.3.1.tgz";
       path = fetchurl {
         name = "browser_stdout___browser_stdout_1.3.1.tgz";
-        url  = "https://registry.yarnpkg.com/browser-stdout/-/browser-stdout-1.3.1.tgz";
+        url = "https://registry.yarnpkg.com/browser-stdout/-/browser-stdout-1.3.1.tgz";
         sha512 = "qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==";
       };
     }
@@ -797,7 +803,7 @@
       name = "browserslist___browserslist_4.22.2.tgz";
       path = fetchurl {
         name = "browserslist___browserslist_4.22.2.tgz";
-        url  = "https://registry.yarnpkg.com/browserslist/-/browserslist-4.22.2.tgz";
+        url = "https://registry.yarnpkg.com/browserslist/-/browserslist-4.22.2.tgz";
         sha512 = "0UgcrvQmBDvZHFGdYUehrCNIazki7/lUP3kkoi/r3YB2amZbFM9J43ZRkJTXBUZK4gmx56+Sqk9+Vs9mwZx9+A==";
       };
     }
@@ -805,7 +811,7 @@
       name = "buffer_crc32___buffer_crc32_0.2.13.tgz";
       path = fetchurl {
         name = "buffer_crc32___buffer_crc32_0.2.13.tgz";
-        url  = "https://registry.yarnpkg.com/buffer-crc32/-/buffer-crc32-0.2.13.tgz";
+        url = "https://registry.yarnpkg.com/buffer-crc32/-/buffer-crc32-0.2.13.tgz";
         sha512 = "VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==";
       };
     }
@@ -813,7 +819,7 @@
       name = "buffer_from___buffer_from_1.1.2.tgz";
       path = fetchurl {
         name = "buffer_from___buffer_from_1.1.2.tgz";
-        url  = "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.2.tgz";
+        url = "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.2.tgz";
         sha512 = "E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==";
       };
     }
@@ -821,7 +827,7 @@
       name = "buffer___buffer_5.7.1.tgz";
       path = fetchurl {
         name = "buffer___buffer_5.7.1.tgz";
-        url  = "https://registry.yarnpkg.com/buffer/-/buffer-5.7.1.tgz";
+        url = "https://registry.yarnpkg.com/buffer/-/buffer-5.7.1.tgz";
         sha512 = "EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==";
       };
     }
@@ -829,7 +835,7 @@
       name = "call_bind___call_bind_1.0.5.tgz";
       path = fetchurl {
         name = "call_bind___call_bind_1.0.5.tgz";
-        url  = "https://registry.yarnpkg.com/call-bind/-/call-bind-1.0.5.tgz";
+        url = "https://registry.yarnpkg.com/call-bind/-/call-bind-1.0.5.tgz";
         sha512 = "C3nQxfFZxFRVoJoGKKI8y3MOEo129NQ+FgQ08iye+Mk4zNZZGdjfs06bVTr+DBSlA66Q2VEcMki/cUCP4SercQ==";
       };
     }
@@ -837,7 +843,7 @@
       name = "callsites___callsites_3.1.0.tgz";
       path = fetchurl {
         name = "callsites___callsites_3.1.0.tgz";
-        url  = "https://registry.yarnpkg.com/callsites/-/callsites-3.1.0.tgz";
+        url = "https://registry.yarnpkg.com/callsites/-/callsites-3.1.0.tgz";
         sha512 = "P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==";
       };
     }
@@ -845,7 +851,7 @@
       name = "camelcase___camelcase_6.3.0.tgz";
       path = fetchurl {
         name = "camelcase___camelcase_6.3.0.tgz";
-        url  = "https://registry.yarnpkg.com/camelcase/-/camelcase-6.3.0.tgz";
+        url = "https://registry.yarnpkg.com/camelcase/-/camelcase-6.3.0.tgz";
         sha512 = "Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==";
       };
     }
@@ -853,7 +859,7 @@
       name = "caniuse_lite___caniuse_lite_1.0.30001579.tgz";
       path = fetchurl {
         name = "caniuse_lite___caniuse_lite_1.0.30001579.tgz";
-        url  = "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001579.tgz";
+        url = "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001579.tgz";
         sha512 = "u5AUVkixruKHJjw/pj9wISlcMpgFWzSrczLZbrqBSxukQixmg0SJ5sZTpvaFvxU0HoQKd4yoyAogyrAz9pzJnA==";
       };
     }
@@ -861,7 +867,7 @@
       name = "chalk___chalk_2.4.2.tgz";
       path = fetchurl {
         name = "chalk___chalk_2.4.2.tgz";
-        url  = "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz";
+        url = "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz";
         sha512 = "Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==";
       };
     }
@@ -869,7 +875,7 @@
       name = "chalk___chalk_4.1.2.tgz";
       path = fetchurl {
         name = "chalk___chalk_4.1.2.tgz";
-        url  = "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz";
+        url = "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz";
         sha512 = "oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==";
       };
     }
@@ -877,7 +883,7 @@
       name = "cheerio_select___cheerio_select_2.1.0.tgz";
       path = fetchurl {
         name = "cheerio_select___cheerio_select_2.1.0.tgz";
-        url  = "https://registry.yarnpkg.com/cheerio-select/-/cheerio-select-2.1.0.tgz";
+        url = "https://registry.yarnpkg.com/cheerio-select/-/cheerio-select-2.1.0.tgz";
         sha512 = "9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==";
       };
     }
@@ -885,7 +891,7 @@
       name = "cheerio___cheerio_1.0.0_rc.12.tgz";
       path = fetchurl {
         name = "cheerio___cheerio_1.0.0_rc.12.tgz";
-        url  = "https://registry.yarnpkg.com/cheerio/-/cheerio-1.0.0-rc.12.tgz";
+        url = "https://registry.yarnpkg.com/cheerio/-/cheerio-1.0.0-rc.12.tgz";
         sha512 = "VqR8m68vM46BNnuZ5NtnGBKIE/DfN0cRIzg9n40EIq9NOv90ayxLBXA8fXC5gquFRGJSTRqBq25Jt2ECLR431Q==";
       };
     }
@@ -893,7 +899,7 @@
       name = "chokidar___chokidar_3.5.3.tgz";
       path = fetchurl {
         name = "chokidar___chokidar_3.5.3.tgz";
-        url  = "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.3.tgz";
+        url = "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.3.tgz";
         sha512 = "Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==";
       };
     }
@@ -901,7 +907,7 @@
       name = "chownr___chownr_1.1.4.tgz";
       path = fetchurl {
         name = "chownr___chownr_1.1.4.tgz";
-        url  = "https://registry.yarnpkg.com/chownr/-/chownr-1.1.4.tgz";
+        url = "https://registry.yarnpkg.com/chownr/-/chownr-1.1.4.tgz";
         sha512 = "jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==";
       };
     }
@@ -909,7 +915,7 @@
       name = "chrome_trace_event___chrome_trace_event_1.0.3.tgz";
       path = fetchurl {
         name = "chrome_trace_event___chrome_trace_event_1.0.3.tgz";
-        url  = "https://registry.yarnpkg.com/chrome-trace-event/-/chrome-trace-event-1.0.3.tgz";
+        url = "https://registry.yarnpkg.com/chrome-trace-event/-/chrome-trace-event-1.0.3.tgz";
         sha512 = "p3KULyQg4S7NIHixdwbGX+nFHkoBiA4YQmyWtjb8XngSKV124nJmRysgAeujbUVb15vh+RvFUfCPqU7rXk+hZg==";
       };
     }
@@ -917,7 +923,7 @@
       name = "ci_info___ci_info_3.9.0.tgz";
       path = fetchurl {
         name = "ci_info___ci_info_3.9.0.tgz";
-        url  = "https://registry.yarnpkg.com/ci-info/-/ci-info-3.9.0.tgz";
+        url = "https://registry.yarnpkg.com/ci-info/-/ci-info-3.9.0.tgz";
         sha512 = "NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==";
       };
     }
@@ -925,7 +931,7 @@
       name = "cliui___cliui_7.0.4.tgz";
       path = fetchurl {
         name = "cliui___cliui_7.0.4.tgz";
-        url  = "https://registry.yarnpkg.com/cliui/-/cliui-7.0.4.tgz";
+        url = "https://registry.yarnpkg.com/cliui/-/cliui-7.0.4.tgz";
         sha512 = "OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==";
       };
     }
@@ -933,7 +939,7 @@
       name = "clone_deep___clone_deep_4.0.1.tgz";
       path = fetchurl {
         name = "clone_deep___clone_deep_4.0.1.tgz";
-        url  = "https://registry.yarnpkg.com/clone-deep/-/clone-deep-4.0.1.tgz";
+        url = "https://registry.yarnpkg.com/clone-deep/-/clone-deep-4.0.1.tgz";
         sha512 = "neHB9xuzh/wk0dIHweyAXv2aPGZIVk3pLMe+/RNzINf17fe0OG96QroktYAUm7SM1PBnzTabaLboqqxDyMU+SQ==";
       };
     }
@@ -941,7 +947,7 @@
       name = "color_convert___color_convert_1.9.3.tgz";
       path = fetchurl {
         name = "color_convert___color_convert_1.9.3.tgz";
-        url  = "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.3.tgz";
+        url = "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.3.tgz";
         sha512 = "QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==";
       };
     }
@@ -949,7 +955,7 @@
       name = "color_convert___color_convert_2.0.1.tgz";
       path = fetchurl {
         name = "color_convert___color_convert_2.0.1.tgz";
-        url  = "https://registry.yarnpkg.com/color-convert/-/color-convert-2.0.1.tgz";
+        url = "https://registry.yarnpkg.com/color-convert/-/color-convert-2.0.1.tgz";
         sha512 = "RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==";
       };
     }
@@ -957,7 +963,7 @@
       name = "color_name___color_name_1.1.3.tgz";
       path = fetchurl {
         name = "color_name___color_name_1.1.3.tgz";
-        url  = "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz";
+        url = "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz";
         sha512 = "72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==";
       };
     }
@@ -965,7 +971,7 @@
       name = "color_name___color_name_1.1.4.tgz";
       path = fetchurl {
         name = "color_name___color_name_1.1.4.tgz";
-        url  = "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz";
+        url = "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz";
         sha512 = "dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==";
       };
     }
@@ -973,7 +979,7 @@
       name = "colorette___colorette_2.0.20.tgz";
       path = fetchurl {
         name = "colorette___colorette_2.0.20.tgz";
-        url  = "https://registry.yarnpkg.com/colorette/-/colorette-2.0.20.tgz";
+        url = "https://registry.yarnpkg.com/colorette/-/colorette-2.0.20.tgz";
         sha512 = "IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==";
       };
     }
@@ -981,7 +987,7 @@
       name = "commander___commander_10.0.1.tgz";
       path = fetchurl {
         name = "commander___commander_10.0.1.tgz";
-        url  = "https://registry.yarnpkg.com/commander/-/commander-10.0.1.tgz";
+        url = "https://registry.yarnpkg.com/commander/-/commander-10.0.1.tgz";
         sha512 = "y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==";
       };
     }
@@ -989,7 +995,7 @@
       name = "commander___commander_2.20.3.tgz";
       path = fetchurl {
         name = "commander___commander_2.20.3.tgz";
-        url  = "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz";
+        url = "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz";
         sha512 = "GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==";
       };
     }
@@ -997,7 +1003,7 @@
       name = "commander___commander_6.2.1.tgz";
       path = fetchurl {
         name = "commander___commander_6.2.1.tgz";
-        url  = "https://registry.yarnpkg.com/commander/-/commander-6.2.1.tgz";
+        url = "https://registry.yarnpkg.com/commander/-/commander-6.2.1.tgz";
         sha512 = "U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==";
       };
     }
@@ -1005,7 +1011,7 @@
       name = "compare_versions___compare_versions_6.1.0.tgz";
       path = fetchurl {
         name = "compare_versions___compare_versions_6.1.0.tgz";
-        url  = "https://registry.yarnpkg.com/compare-versions/-/compare-versions-6.1.0.tgz";
+        url = "https://registry.yarnpkg.com/compare-versions/-/compare-versions-6.1.0.tgz";
         sha512 = "LNZQXhqUvqUTotpZ00qLSaify3b4VFD588aRr8MKFw4CMUr98ytzCW5wDH5qx/DEY5kCDXcbcRuCqL0szEf2tg==";
       };
     }
@@ -1013,7 +1019,7 @@
       name = "concat_map___concat_map_0.0.1.tgz";
       path = fetchurl {
         name = "concat_map___concat_map_0.0.1.tgz";
-        url  = "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz";
+        url = "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz";
         sha512 = "/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==";
       };
     }
@@ -1021,7 +1027,7 @@
       name = "core_util_is___core_util_is_1.0.3.tgz";
       path = fetchurl {
         name = "core_util_is___core_util_is_1.0.3.tgz";
-        url  = "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.3.tgz";
+        url = "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.3.tgz";
         sha512 = "ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==";
       };
     }
@@ -1029,7 +1035,7 @@
       name = "cross_spawn___cross_spawn_7.0.3.tgz";
       path = fetchurl {
         name = "cross_spawn___cross_spawn_7.0.3.tgz";
-        url  = "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz";
+        url = "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz";
         sha512 = "iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==";
       };
     }
@@ -1037,7 +1043,7 @@
       name = "css_select___css_select_5.1.0.tgz";
       path = fetchurl {
         name = "css_select___css_select_5.1.0.tgz";
-        url  = "https://registry.yarnpkg.com/css-select/-/css-select-5.1.0.tgz";
+        url = "https://registry.yarnpkg.com/css-select/-/css-select-5.1.0.tgz";
         sha512 = "nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==";
       };
     }
@@ -1045,7 +1051,7 @@
       name = "css_what___css_what_6.1.0.tgz";
       path = fetchurl {
         name = "css_what___css_what_6.1.0.tgz";
-        url  = "https://registry.yarnpkg.com/css-what/-/css-what-6.1.0.tgz";
+        url = "https://registry.yarnpkg.com/css-what/-/css-what-6.1.0.tgz";
         sha512 = "HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==";
       };
     }
@@ -1053,7 +1059,7 @@
       name = "debug___debug_4.3.4.tgz";
       path = fetchurl {
         name = "debug___debug_4.3.4.tgz";
-        url  = "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz";
+        url = "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz";
         sha512 = "PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==";
       };
     }
@@ -1061,7 +1067,7 @@
       name = "decamelize___decamelize_4.0.0.tgz";
       path = fetchurl {
         name = "decamelize___decamelize_4.0.0.tgz";
-        url  = "https://registry.yarnpkg.com/decamelize/-/decamelize-4.0.0.tgz";
+        url = "https://registry.yarnpkg.com/decamelize/-/decamelize-4.0.0.tgz";
         sha512 = "9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==";
       };
     }
@@ -1069,7 +1075,7 @@
       name = "decompress_response___decompress_response_6.0.0.tgz";
       path = fetchurl {
         name = "decompress_response___decompress_response_6.0.0.tgz";
-        url  = "https://registry.yarnpkg.com/decompress-response/-/decompress-response-6.0.0.tgz";
+        url = "https://registry.yarnpkg.com/decompress-response/-/decompress-response-6.0.0.tgz";
         sha512 = "aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==";
       };
     }
@@ -1077,7 +1083,7 @@
       name = "deep_extend___deep_extend_0.6.0.tgz";
       path = fetchurl {
         name = "deep_extend___deep_extend_0.6.0.tgz";
-        url  = "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.6.0.tgz";
+        url = "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.6.0.tgz";
         sha512 = "LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==";
       };
     }
@@ -1085,7 +1091,7 @@
       name = "deep_is___deep_is_0.1.4.tgz";
       path = fetchurl {
         name = "deep_is___deep_is_0.1.4.tgz";
-        url  = "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.4.tgz";
+        url = "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.4.tgz";
         sha512 = "oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==";
       };
     }
@@ -1093,7 +1099,7 @@
       name = "define_data_property___define_data_property_1.1.1.tgz";
       path = fetchurl {
         name = "define_data_property___define_data_property_1.1.1.tgz";
-        url  = "https://registry.yarnpkg.com/define-data-property/-/define-data-property-1.1.1.tgz";
+        url = "https://registry.yarnpkg.com/define-data-property/-/define-data-property-1.1.1.tgz";
         sha512 = "E7uGkTzkk1d0ByLeSc6ZsFS79Axg+m1P/VsgYsxHgiuc3tFSj+MjMIwe90FC4lOAZzNBdY7kkO2P2wKdsQ1vgQ==";
       };
     }
@@ -1101,7 +1107,7 @@
       name = "detect_libc___detect_libc_2.0.2.tgz";
       path = fetchurl {
         name = "detect_libc___detect_libc_2.0.2.tgz";
-        url  = "https://registry.yarnpkg.com/detect-libc/-/detect-libc-2.0.2.tgz";
+        url = "https://registry.yarnpkg.com/detect-libc/-/detect-libc-2.0.2.tgz";
         sha512 = "UX6sGumvvqSaXgdKGUsgZWqcUyIXZ/vZTrlRT/iobiKhGL0zL4d3osHj3uqllWJK+i+sixDS/3COVEOFbupFyw==";
       };
     }
@@ -1109,7 +1115,7 @@
       name = "diff_sequences___diff_sequences_29.6.3.tgz";
       path = fetchurl {
         name = "diff_sequences___diff_sequences_29.6.3.tgz";
-        url  = "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-29.6.3.tgz";
+        url = "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-29.6.3.tgz";
         sha512 = "EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==";
       };
     }
@@ -1117,7 +1123,7 @@
       name = "diff___diff_5.0.0.tgz";
       path = fetchurl {
         name = "diff___diff_5.0.0.tgz";
-        url  = "https://registry.yarnpkg.com/diff/-/diff-5.0.0.tgz";
+        url = "https://registry.yarnpkg.com/diff/-/diff-5.0.0.tgz";
         sha512 = "/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==";
       };
     }
@@ -1125,7 +1131,7 @@
       name = "dir_glob___dir_glob_3.0.1.tgz";
       path = fetchurl {
         name = "dir_glob___dir_glob_3.0.1.tgz";
-        url  = "https://registry.yarnpkg.com/dir-glob/-/dir-glob-3.0.1.tgz";
+        url = "https://registry.yarnpkg.com/dir-glob/-/dir-glob-3.0.1.tgz";
         sha512 = "WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==";
       };
     }
@@ -1133,7 +1139,7 @@
       name = "doctrine___doctrine_3.0.0.tgz";
       path = fetchurl {
         name = "doctrine___doctrine_3.0.0.tgz";
-        url  = "https://registry.yarnpkg.com/doctrine/-/doctrine-3.0.0.tgz";
+        url = "https://registry.yarnpkg.com/doctrine/-/doctrine-3.0.0.tgz";
         sha512 = "yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==";
       };
     }
@@ -1141,7 +1147,7 @@
       name = "dom_serializer___dom_serializer_2.0.0.tgz";
       path = fetchurl {
         name = "dom_serializer___dom_serializer_2.0.0.tgz";
-        url  = "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-2.0.0.tgz";
+        url = "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-2.0.0.tgz";
         sha512 = "wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==";
       };
     }
@@ -1149,7 +1155,7 @@
       name = "domelementtype___domelementtype_2.3.0.tgz";
       path = fetchurl {
         name = "domelementtype___domelementtype_2.3.0.tgz";
-        url  = "https://registry.yarnpkg.com/domelementtype/-/domelementtype-2.3.0.tgz";
+        url = "https://registry.yarnpkg.com/domelementtype/-/domelementtype-2.3.0.tgz";
         sha512 = "OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==";
       };
     }
@@ -1157,7 +1163,7 @@
       name = "domhandler___domhandler_5.0.3.tgz";
       path = fetchurl {
         name = "domhandler___domhandler_5.0.3.tgz";
-        url  = "https://registry.yarnpkg.com/domhandler/-/domhandler-5.0.3.tgz";
+        url = "https://registry.yarnpkg.com/domhandler/-/domhandler-5.0.3.tgz";
         sha512 = "cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==";
       };
     }
@@ -1165,7 +1171,7 @@
       name = "domutils___domutils_3.1.0.tgz";
       path = fetchurl {
         name = "domutils___domutils_3.1.0.tgz";
-        url  = "https://registry.yarnpkg.com/domutils/-/domutils-3.1.0.tgz";
+        url = "https://registry.yarnpkg.com/domutils/-/domutils-3.1.0.tgz";
         sha512 = "H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==";
       };
     }
@@ -1173,7 +1179,7 @@
       name = "electron_to_chromium___electron_to_chromium_1.4.643.tgz";
       path = fetchurl {
         name = "electron_to_chromium___electron_to_chromium_1.4.643.tgz";
-        url  = "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.643.tgz";
+        url = "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.643.tgz";
         sha512 = "QHscvvS7gt155PtoRC0dR2ilhL8E9LHhfTQEq1uD5AL0524rBLAwpAREFH06f87/e45B9XkR6Ki5dbhbCsVEIg==";
       };
     }
@@ -1181,7 +1187,7 @@
       name = "emoji_regex___emoji_regex_8.0.0.tgz";
       path = fetchurl {
         name = "emoji_regex___emoji_regex_8.0.0.tgz";
-        url  = "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz";
+        url = "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz";
         sha512 = "MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==";
       };
     }
@@ -1189,7 +1195,7 @@
       name = "end_of_stream___end_of_stream_1.4.4.tgz";
       path = fetchurl {
         name = "end_of_stream___end_of_stream_1.4.4.tgz";
-        url  = "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.4.4.tgz";
+        url = "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.4.4.tgz";
         sha512 = "+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==";
       };
     }
@@ -1197,7 +1203,7 @@
       name = "enhanced_resolve___enhanced_resolve_5.15.0.tgz";
       path = fetchurl {
         name = "enhanced_resolve___enhanced_resolve_5.15.0.tgz";
-        url  = "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-5.15.0.tgz";
+        url = "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-5.15.0.tgz";
         sha512 = "LXYT42KJ7lpIKECr2mAXIaMldcNCh/7E0KBKOu4KSfkHmP+mZmSs+8V5gBAqisWBy0OO4W5Oyys0GO1Y8KtdKg==";
       };
     }
@@ -1205,7 +1211,7 @@
       name = "entities___entities_4.5.0.tgz";
       path = fetchurl {
         name = "entities___entities_4.5.0.tgz";
-        url  = "https://registry.yarnpkg.com/entities/-/entities-4.5.0.tgz";
+        url = "https://registry.yarnpkg.com/entities/-/entities-4.5.0.tgz";
         sha512 = "V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==";
       };
     }
@@ -1213,7 +1219,7 @@
       name = "entities___entities_2.1.0.tgz";
       path = fetchurl {
         name = "entities___entities_2.1.0.tgz";
-        url  = "https://registry.yarnpkg.com/entities/-/entities-2.1.0.tgz";
+        url = "https://registry.yarnpkg.com/entities/-/entities-2.1.0.tgz";
         sha512 = "hCx1oky9PFrJ611mf0ifBLBRW8lUUVRlFolb5gWRfIELabBlbp9xZvrqZLZAs+NxFnbfQoeGd8wDkygjg7U85w==";
       };
     }
@@ -1221,7 +1227,7 @@
       name = "envinfo___envinfo_7.11.0.tgz";
       path = fetchurl {
         name = "envinfo___envinfo_7.11.0.tgz";
-        url  = "https://registry.yarnpkg.com/envinfo/-/envinfo-7.11.0.tgz";
+        url = "https://registry.yarnpkg.com/envinfo/-/envinfo-7.11.0.tgz";
         sha512 = "G9/6xF1FPbIw0TtalAMaVPpiq2aDEuKLXM314jPVAO9r2fo2a4BLqMNkmRS7O/xPPZ+COAhGIz3ETvHEV3eUcg==";
       };
     }
@@ -1229,7 +1235,7 @@
       name = "es_module_lexer___es_module_lexer_1.4.1.tgz";
       path = fetchurl {
         name = "es_module_lexer___es_module_lexer_1.4.1.tgz";
-        url  = "https://registry.yarnpkg.com/es-module-lexer/-/es-module-lexer-1.4.1.tgz";
+        url = "https://registry.yarnpkg.com/es-module-lexer/-/es-module-lexer-1.4.1.tgz";
         sha512 = "cXLGjP0c4T3flZJKQSuziYoq7MlT+rnvfZjfp7h+I7K9BNX54kP9nyWvdbwjQ4u1iWbOL4u96fgeZLToQlZC7w==";
       };
     }
@@ -1237,7 +1243,7 @@
       name = "escalade___escalade_3.1.1.tgz";
       path = fetchurl {
         name = "escalade___escalade_3.1.1.tgz";
-        url  = "https://registry.yarnpkg.com/escalade/-/escalade-3.1.1.tgz";
+        url = "https://registry.yarnpkg.com/escalade/-/escalade-3.1.1.tgz";
         sha512 = "k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==";
       };
     }
@@ -1245,7 +1251,7 @@
       name = "escape_string_regexp___escape_string_regexp_4.0.0.tgz";
       path = fetchurl {
         name = "escape_string_regexp___escape_string_regexp_4.0.0.tgz";
-        url  = "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz";
+        url = "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz";
         sha512 = "TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==";
       };
     }
@@ -1253,7 +1259,7 @@
       name = "escape_string_regexp___escape_string_regexp_1.0.5.tgz";
       path = fetchurl {
         name = "escape_string_regexp___escape_string_regexp_1.0.5.tgz";
-        url  = "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz";
+        url = "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz";
         sha512 = "vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==";
       };
     }
@@ -1261,7 +1267,7 @@
       name = "escape_string_regexp___escape_string_regexp_2.0.0.tgz";
       path = fetchurl {
         name = "escape_string_regexp___escape_string_regexp_2.0.0.tgz";
-        url  = "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz";
+        url = "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz";
         sha512 = "UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==";
       };
     }
@@ -1269,7 +1275,7 @@
       name = "eslint_scope___eslint_scope_5.1.1.tgz";
       path = fetchurl {
         name = "eslint_scope___eslint_scope_5.1.1.tgz";
-        url  = "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-5.1.1.tgz";
+        url = "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-5.1.1.tgz";
         sha512 = "2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==";
       };
     }
@@ -1277,7 +1283,7 @@
       name = "eslint_scope___eslint_scope_7.2.2.tgz";
       path = fetchurl {
         name = "eslint_scope___eslint_scope_7.2.2.tgz";
-        url  = "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-7.2.2.tgz";
+        url = "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-7.2.2.tgz";
         sha512 = "dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==";
       };
     }
@@ -1285,7 +1291,7 @@
       name = "eslint_visitor_keys___eslint_visitor_keys_3.4.3.tgz";
       path = fetchurl {
         name = "eslint_visitor_keys___eslint_visitor_keys_3.4.3.tgz";
-        url  = "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz";
+        url = "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz";
         sha512 = "wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==";
       };
     }
@@ -1293,7 +1299,7 @@
       name = "eslint___eslint_8.56.0.tgz";
       path = fetchurl {
         name = "eslint___eslint_8.56.0.tgz";
-        url  = "https://registry.yarnpkg.com/eslint/-/eslint-8.56.0.tgz";
+        url = "https://registry.yarnpkg.com/eslint/-/eslint-8.56.0.tgz";
         sha512 = "Go19xM6T9puCOWntie1/P997aXxFsOi37JIHRWI514Hc6ZnaHGKY9xFhrU65RT6CcBEzZoGG1e6Nq+DT04ZtZQ==";
       };
     }
@@ -1301,7 +1307,7 @@
       name = "espree___espree_9.6.1.tgz";
       path = fetchurl {
         name = "espree___espree_9.6.1.tgz";
-        url  = "https://registry.yarnpkg.com/espree/-/espree-9.6.1.tgz";
+        url = "https://registry.yarnpkg.com/espree/-/espree-9.6.1.tgz";
         sha512 = "oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==";
       };
     }
@@ -1309,7 +1315,7 @@
       name = "esquery___esquery_1.5.0.tgz";
       path = fetchurl {
         name = "esquery___esquery_1.5.0.tgz";
-        url  = "https://registry.yarnpkg.com/esquery/-/esquery-1.5.0.tgz";
+        url = "https://registry.yarnpkg.com/esquery/-/esquery-1.5.0.tgz";
         sha512 = "YQLXUplAwJgCydQ78IMJywZCceoqk1oH01OERdSAJc/7U2AylwjhSCLDEtqwg811idIS/9fIU5GjG73IgjKMVg==";
       };
     }
@@ -1317,7 +1323,7 @@
       name = "esrecurse___esrecurse_4.3.0.tgz";
       path = fetchurl {
         name = "esrecurse___esrecurse_4.3.0.tgz";
-        url  = "https://registry.yarnpkg.com/esrecurse/-/esrecurse-4.3.0.tgz";
+        url = "https://registry.yarnpkg.com/esrecurse/-/esrecurse-4.3.0.tgz";
         sha512 = "KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==";
       };
     }
@@ -1325,7 +1331,7 @@
       name = "estraverse___estraverse_4.3.0.tgz";
       path = fetchurl {
         name = "estraverse___estraverse_4.3.0.tgz";
-        url  = "https://registry.yarnpkg.com/estraverse/-/estraverse-4.3.0.tgz";
+        url = "https://registry.yarnpkg.com/estraverse/-/estraverse-4.3.0.tgz";
         sha512 = "39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==";
       };
     }
@@ -1333,7 +1339,7 @@
       name = "estraverse___estraverse_5.3.0.tgz";
       path = fetchurl {
         name = "estraverse___estraverse_5.3.0.tgz";
-        url  = "https://registry.yarnpkg.com/estraverse/-/estraverse-5.3.0.tgz";
+        url = "https://registry.yarnpkg.com/estraverse/-/estraverse-5.3.0.tgz";
         sha512 = "MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==";
       };
     }
@@ -1341,7 +1347,7 @@
       name = "esutils___esutils_2.0.3.tgz";
       path = fetchurl {
         name = "esutils___esutils_2.0.3.tgz";
-        url  = "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz";
+        url = "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz";
         sha512 = "kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==";
       };
     }
@@ -1349,7 +1355,7 @@
       name = "events___events_3.3.0.tgz";
       path = fetchurl {
         name = "events___events_3.3.0.tgz";
-        url  = "https://registry.yarnpkg.com/events/-/events-3.3.0.tgz";
+        url = "https://registry.yarnpkg.com/events/-/events-3.3.0.tgz";
         sha512 = "mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==";
       };
     }
@@ -1357,7 +1363,7 @@
       name = "expand_template___expand_template_2.0.3.tgz";
       path = fetchurl {
         name = "expand_template___expand_template_2.0.3.tgz";
-        url  = "https://registry.yarnpkg.com/expand-template/-/expand-template-2.0.3.tgz";
+        url = "https://registry.yarnpkg.com/expand-template/-/expand-template-2.0.3.tgz";
         sha512 = "XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==";
       };
     }
@@ -1365,7 +1371,7 @@
       name = "expect___expect_29.7.0.tgz";
       path = fetchurl {
         name = "expect___expect_29.7.0.tgz";
-        url  = "https://registry.yarnpkg.com/expect/-/expect-29.7.0.tgz";
+        url = "https://registry.yarnpkg.com/expect/-/expect-29.7.0.tgz";
         sha512 = "2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==";
       };
     }
@@ -1373,7 +1379,7 @@
       name = "fast_deep_equal___fast_deep_equal_3.1.3.tgz";
       path = fetchurl {
         name = "fast_deep_equal___fast_deep_equal_3.1.3.tgz";
-        url  = "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz";
+        url = "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz";
         sha512 = "f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==";
       };
     }
@@ -1381,7 +1387,7 @@
       name = "fast_glob___fast_glob_3.3.2.tgz";
       path = fetchurl {
         name = "fast_glob___fast_glob_3.3.2.tgz";
-        url  = "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.3.2.tgz";
+        url = "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.3.2.tgz";
         sha512 = "oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==";
       };
     }
@@ -1389,7 +1395,7 @@
       name = "fast_json_stable_stringify___fast_json_stable_stringify_2.1.0.tgz";
       path = fetchurl {
         name = "fast_json_stable_stringify___fast_json_stable_stringify_2.1.0.tgz";
-        url  = "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz";
+        url = "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz";
         sha512 = "lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==";
       };
     }
@@ -1397,7 +1403,7 @@
       name = "fast_levenshtein___fast_levenshtein_2.0.6.tgz";
       path = fetchurl {
         name = "fast_levenshtein___fast_levenshtein_2.0.6.tgz";
-        url  = "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz";
+        url = "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz";
         sha512 = "DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==";
       };
     }
@@ -1405,7 +1411,7 @@
       name = "fastest_levenshtein___fastest_levenshtein_1.0.16.tgz";
       path = fetchurl {
         name = "fastest_levenshtein___fastest_levenshtein_1.0.16.tgz";
-        url  = "https://registry.yarnpkg.com/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz";
+        url = "https://registry.yarnpkg.com/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz";
         sha512 = "eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==";
       };
     }
@@ -1413,7 +1419,7 @@
       name = "fastq___fastq_1.16.0.tgz";
       path = fetchurl {
         name = "fastq___fastq_1.16.0.tgz";
-        url  = "https://registry.yarnpkg.com/fastq/-/fastq-1.16.0.tgz";
+        url = "https://registry.yarnpkg.com/fastq/-/fastq-1.16.0.tgz";
         sha512 = "ifCoaXsDrsdkWTtiNJX5uzHDsrck5TzfKKDcuFFTIrrc/BS076qgEIfoIy1VeZqViznfKiysPYTh/QeHtnIsYA==";
       };
     }
@@ -1421,7 +1427,7 @@
       name = "fd_slicer___fd_slicer_1.1.0.tgz";
       path = fetchurl {
         name = "fd_slicer___fd_slicer_1.1.0.tgz";
-        url  = "https://registry.yarnpkg.com/fd-slicer/-/fd-slicer-1.1.0.tgz";
+        url = "https://registry.yarnpkg.com/fd-slicer/-/fd-slicer-1.1.0.tgz";
         sha512 = "cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==";
       };
     }
@@ -1429,7 +1435,7 @@
       name = "file_entry_cache___file_entry_cache_6.0.1.tgz";
       path = fetchurl {
         name = "file_entry_cache___file_entry_cache_6.0.1.tgz";
-        url  = "https://registry.yarnpkg.com/file-entry-cache/-/file-entry-cache-6.0.1.tgz";
+        url = "https://registry.yarnpkg.com/file-entry-cache/-/file-entry-cache-6.0.1.tgz";
         sha512 = "7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==";
       };
     }
@@ -1437,7 +1443,7 @@
       name = "fill_range___fill_range_7.0.1.tgz";
       path = fetchurl {
         name = "fill_range___fill_range_7.0.1.tgz";
-        url  = "https://registry.yarnpkg.com/fill-range/-/fill-range-7.0.1.tgz";
+        url = "https://registry.yarnpkg.com/fill-range/-/fill-range-7.0.1.tgz";
         sha512 = "qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==";
       };
     }
@@ -1445,7 +1451,7 @@
       name = "find_up___find_up_5.0.0.tgz";
       path = fetchurl {
         name = "find_up___find_up_5.0.0.tgz";
-        url  = "https://registry.yarnpkg.com/find-up/-/find-up-5.0.0.tgz";
+        url = "https://registry.yarnpkg.com/find-up/-/find-up-5.0.0.tgz";
         sha512 = "78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==";
       };
     }
@@ -1453,7 +1459,7 @@
       name = "find_up___find_up_4.1.0.tgz";
       path = fetchurl {
         name = "find_up___find_up_4.1.0.tgz";
-        url  = "https://registry.yarnpkg.com/find-up/-/find-up-4.1.0.tgz";
+        url = "https://registry.yarnpkg.com/find-up/-/find-up-4.1.0.tgz";
         sha512 = "PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==";
       };
     }
@@ -1461,7 +1467,7 @@
       name = "flat_cache___flat_cache_3.2.0.tgz";
       path = fetchurl {
         name = "flat_cache___flat_cache_3.2.0.tgz";
-        url  = "https://registry.yarnpkg.com/flat-cache/-/flat-cache-3.2.0.tgz";
+        url = "https://registry.yarnpkg.com/flat-cache/-/flat-cache-3.2.0.tgz";
         sha512 = "CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==";
       };
     }
@@ -1469,7 +1475,7 @@
       name = "flat___flat_5.0.2.tgz";
       path = fetchurl {
         name = "flat___flat_5.0.2.tgz";
-        url  = "https://registry.yarnpkg.com/flat/-/flat-5.0.2.tgz";
+        url = "https://registry.yarnpkg.com/flat/-/flat-5.0.2.tgz";
         sha512 = "b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==";
       };
     }
@@ -1477,7 +1483,7 @@
       name = "flatted___flatted_3.2.9.tgz";
       path = fetchurl {
         name = "flatted___flatted_3.2.9.tgz";
-        url  = "https://registry.yarnpkg.com/flatted/-/flatted-3.2.9.tgz";
+        url = "https://registry.yarnpkg.com/flatted/-/flatted-3.2.9.tgz";
         sha512 = "36yxDn5H7OFZQla0/jFJmbIKTdZAQHngCedGxiMmpNfEZM0sdEeT+WczLQrjK6D7o2aiyLYDnkw0R3JK0Qv1RQ==";
       };
     }
@@ -1485,7 +1491,7 @@
       name = "fs_constants___fs_constants_1.0.0.tgz";
       path = fetchurl {
         name = "fs_constants___fs_constants_1.0.0.tgz";
-        url  = "https://registry.yarnpkg.com/fs-constants/-/fs-constants-1.0.0.tgz";
+        url = "https://registry.yarnpkg.com/fs-constants/-/fs-constants-1.0.0.tgz";
         sha512 = "y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==";
       };
     }
@@ -1493,7 +1499,7 @@
       name = "fs.realpath___fs.realpath_1.0.0.tgz";
       path = fetchurl {
         name = "fs.realpath___fs.realpath_1.0.0.tgz";
-        url  = "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz";
+        url = "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz";
         sha512 = "OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==";
       };
     }
@@ -1501,7 +1507,7 @@
       name = "fsevents___fsevents_2.3.3.tgz";
       path = fetchurl {
         name = "fsevents___fsevents_2.3.3.tgz";
-        url  = "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.3.tgz";
+        url = "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.3.tgz";
         sha512 = "5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==";
       };
     }
@@ -1509,7 +1515,7 @@
       name = "function_bind___function_bind_1.1.2.tgz";
       path = fetchurl {
         name = "function_bind___function_bind_1.1.2.tgz";
-        url  = "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.2.tgz";
+        url = "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.2.tgz";
         sha512 = "7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==";
       };
     }
@@ -1517,7 +1523,7 @@
       name = "get_caller_file___get_caller_file_2.0.5.tgz";
       path = fetchurl {
         name = "get_caller_file___get_caller_file_2.0.5.tgz";
-        url  = "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz";
+        url = "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz";
         sha512 = "DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==";
       };
     }
@@ -1525,7 +1531,7 @@
       name = "get_intrinsic___get_intrinsic_1.2.2.tgz";
       path = fetchurl {
         name = "get_intrinsic___get_intrinsic_1.2.2.tgz";
-        url  = "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.2.2.tgz";
+        url = "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.2.2.tgz";
         sha512 = "0gSo4ml/0j98Y3lngkFEot/zhiCeWsbYIlZ+uZOVgzLyLaUw7wxUL+nCTP0XJvJg1AXulJRI3UJi8GsbDuxdGA==";
       };
     }
@@ -1533,7 +1539,7 @@
       name = "github_from_package___github_from_package_0.0.0.tgz";
       path = fetchurl {
         name = "github_from_package___github_from_package_0.0.0.tgz";
-        url  = "https://registry.yarnpkg.com/github-from-package/-/github-from-package-0.0.0.tgz";
+        url = "https://registry.yarnpkg.com/github-from-package/-/github-from-package-0.0.0.tgz";
         sha512 = "SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==";
       };
     }
@@ -1541,7 +1547,7 @@
       name = "glob_parent___glob_parent_5.1.2.tgz";
       path = fetchurl {
         name = "glob_parent___glob_parent_5.1.2.tgz";
-        url  = "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.2.tgz";
+        url = "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.2.tgz";
         sha512 = "AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==";
       };
     }
@@ -1549,7 +1555,7 @@
       name = "glob_parent___glob_parent_6.0.2.tgz";
       path = fetchurl {
         name = "glob_parent___glob_parent_6.0.2.tgz";
-        url  = "https://registry.yarnpkg.com/glob-parent/-/glob-parent-6.0.2.tgz";
+        url = "https://registry.yarnpkg.com/glob-parent/-/glob-parent-6.0.2.tgz";
         sha512 = "XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==";
       };
     }
@@ -1557,7 +1563,7 @@
       name = "glob_to_regexp___glob_to_regexp_0.4.1.tgz";
       path = fetchurl {
         name = "glob_to_regexp___glob_to_regexp_0.4.1.tgz";
-        url  = "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz";
+        url = "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz";
         sha512 = "lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==";
       };
     }
@@ -1565,7 +1571,7 @@
       name = "glob___glob_7.2.0.tgz";
       path = fetchurl {
         name = "glob___glob_7.2.0.tgz";
-        url  = "https://registry.yarnpkg.com/glob/-/glob-7.2.0.tgz";
+        url = "https://registry.yarnpkg.com/glob/-/glob-7.2.0.tgz";
         sha512 = "lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==";
       };
     }
@@ -1573,7 +1579,7 @@
       name = "glob___glob_7.2.3.tgz";
       path = fetchurl {
         name = "glob___glob_7.2.3.tgz";
-        url  = "https://registry.yarnpkg.com/glob/-/glob-7.2.3.tgz";
+        url = "https://registry.yarnpkg.com/glob/-/glob-7.2.3.tgz";
         sha512 = "nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==";
       };
     }
@@ -1581,7 +1587,7 @@
       name = "glob___glob_8.1.0.tgz";
       path = fetchurl {
         name = "glob___glob_8.1.0.tgz";
-        url  = "https://registry.yarnpkg.com/glob/-/glob-8.1.0.tgz";
+        url = "https://registry.yarnpkg.com/glob/-/glob-8.1.0.tgz";
         sha512 = "r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==";
       };
     }
@@ -1589,7 +1595,7 @@
       name = "globals___globals_13.24.0.tgz";
       path = fetchurl {
         name = "globals___globals_13.24.0.tgz";
-        url  = "https://registry.yarnpkg.com/globals/-/globals-13.24.0.tgz";
+        url = "https://registry.yarnpkg.com/globals/-/globals-13.24.0.tgz";
         sha512 = "AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==";
       };
     }
@@ -1597,7 +1603,7 @@
       name = "globby___globby_11.1.0.tgz";
       path = fetchurl {
         name = "globby___globby_11.1.0.tgz";
-        url  = "https://registry.yarnpkg.com/globby/-/globby-11.1.0.tgz";
+        url = "https://registry.yarnpkg.com/globby/-/globby-11.1.0.tgz";
         sha512 = "jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==";
       };
     }
@@ -1605,7 +1611,7 @@
       name = "gopd___gopd_1.0.1.tgz";
       path = fetchurl {
         name = "gopd___gopd_1.0.1.tgz";
-        url  = "https://registry.yarnpkg.com/gopd/-/gopd-1.0.1.tgz";
+        url = "https://registry.yarnpkg.com/gopd/-/gopd-1.0.1.tgz";
         sha512 = "d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==";
       };
     }
@@ -1613,7 +1619,7 @@
       name = "graceful_fs___graceful_fs_4.2.11.tgz";
       path = fetchurl {
         name = "graceful_fs___graceful_fs_4.2.11.tgz";
-        url  = "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.11.tgz";
+        url = "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.11.tgz";
         sha512 = "RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==";
       };
     }
@@ -1621,7 +1627,7 @@
       name = "graphemer___graphemer_1.4.0.tgz";
       path = fetchurl {
         name = "graphemer___graphemer_1.4.0.tgz";
-        url  = "https://registry.yarnpkg.com/graphemer/-/graphemer-1.4.0.tgz";
+        url = "https://registry.yarnpkg.com/graphemer/-/graphemer-1.4.0.tgz";
         sha512 = "EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==";
       };
     }
@@ -1629,7 +1635,7 @@
       name = "has_flag___has_flag_3.0.0.tgz";
       path = fetchurl {
         name = "has_flag___has_flag_3.0.0.tgz";
-        url  = "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz";
+        url = "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz";
         sha512 = "sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==";
       };
     }
@@ -1637,7 +1643,7 @@
       name = "has_flag___has_flag_4.0.0.tgz";
       path = fetchurl {
         name = "has_flag___has_flag_4.0.0.tgz";
-        url  = "https://registry.yarnpkg.com/has-flag/-/has-flag-4.0.0.tgz";
+        url = "https://registry.yarnpkg.com/has-flag/-/has-flag-4.0.0.tgz";
         sha512 = "EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==";
       };
     }
@@ -1645,7 +1651,7 @@
       name = "has_property_descriptors___has_property_descriptors_1.0.1.tgz";
       path = fetchurl {
         name = "has_property_descriptors___has_property_descriptors_1.0.1.tgz";
-        url  = "https://registry.yarnpkg.com/has-property-descriptors/-/has-property-descriptors-1.0.1.tgz";
+        url = "https://registry.yarnpkg.com/has-property-descriptors/-/has-property-descriptors-1.0.1.tgz";
         sha512 = "VsX8eaIewvas0xnvinAe9bw4WfIeODpGYikiWYLH+dma0Jw6KHYqWiWfhQlgOVK8D6PvjubK5Uc4P0iIhIcNVg==";
       };
     }
@@ -1653,7 +1659,7 @@
       name = "has_proto___has_proto_1.0.1.tgz";
       path = fetchurl {
         name = "has_proto___has_proto_1.0.1.tgz";
-        url  = "https://registry.yarnpkg.com/has-proto/-/has-proto-1.0.1.tgz";
+        url = "https://registry.yarnpkg.com/has-proto/-/has-proto-1.0.1.tgz";
         sha512 = "7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg==";
       };
     }
@@ -1661,7 +1667,7 @@
       name = "has_symbols___has_symbols_1.0.3.tgz";
       path = fetchurl {
         name = "has_symbols___has_symbols_1.0.3.tgz";
-        url  = "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.3.tgz";
+        url = "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.3.tgz";
         sha512 = "l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==";
       };
     }
@@ -1669,7 +1675,7 @@
       name = "hasown___hasown_2.0.0.tgz";
       path = fetchurl {
         name = "hasown___hasown_2.0.0.tgz";
-        url  = "https://registry.yarnpkg.com/hasown/-/hasown-2.0.0.tgz";
+        url = "https://registry.yarnpkg.com/hasown/-/hasown-2.0.0.tgz";
         sha512 = "vUptKVTpIJhcczKBbgnS+RtcuYMB8+oNzPK2/Hp3hanz8JmpATdmmgLgSaadVREkDm+e2giHwY3ZRkyjSIDDFA==";
       };
     }
@@ -1677,7 +1683,7 @@
       name = "he___he_1.2.0.tgz";
       path = fetchurl {
         name = "he___he_1.2.0.tgz";
-        url  = "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz";
+        url = "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz";
         sha512 = "F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==";
       };
     }
@@ -1685,7 +1691,7 @@
       name = "hosted_git_info___hosted_git_info_4.1.0.tgz";
       path = fetchurl {
         name = "hosted_git_info___hosted_git_info_4.1.0.tgz";
-        url  = "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-4.1.0.tgz";
+        url = "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-4.1.0.tgz";
         sha512 = "kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==";
       };
     }
@@ -1693,7 +1699,7 @@
       name = "htmlparser2___htmlparser2_8.0.2.tgz";
       path = fetchurl {
         name = "htmlparser2___htmlparser2_8.0.2.tgz";
-        url  = "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-8.0.2.tgz";
+        url = "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-8.0.2.tgz";
         sha512 = "GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==";
       };
     }
@@ -1701,7 +1707,7 @@
       name = "http_proxy_agent___http_proxy_agent_4.0.1.tgz";
       path = fetchurl {
         name = "http_proxy_agent___http_proxy_agent_4.0.1.tgz";
-        url  = "https://registry.yarnpkg.com/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz";
+        url = "https://registry.yarnpkg.com/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz";
         sha512 = "k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==";
       };
     }
@@ -1709,7 +1715,7 @@
       name = "https_proxy_agent___https_proxy_agent_5.0.1.tgz";
       path = fetchurl {
         name = "https_proxy_agent___https_proxy_agent_5.0.1.tgz";
-        url  = "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz";
+        url = "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz";
         sha512 = "dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==";
       };
     }
@@ -1717,7 +1723,7 @@
       name = "ieee754___ieee754_1.2.1.tgz";
       path = fetchurl {
         name = "ieee754___ieee754_1.2.1.tgz";
-        url  = "https://registry.yarnpkg.com/ieee754/-/ieee754-1.2.1.tgz";
+        url = "https://registry.yarnpkg.com/ieee754/-/ieee754-1.2.1.tgz";
         sha512 = "dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==";
       };
     }
@@ -1725,7 +1731,7 @@
       name = "ignore___ignore_5.3.0.tgz";
       path = fetchurl {
         name = "ignore___ignore_5.3.0.tgz";
-        url  = "https://registry.yarnpkg.com/ignore/-/ignore-5.3.0.tgz";
+        url = "https://registry.yarnpkg.com/ignore/-/ignore-5.3.0.tgz";
         sha512 = "g7dmpshy+gD7mh88OC9NwSGTKoc3kyLAZQRU1mt53Aw/vnvfXnbC+F/7F7QoYVKbV+KNvJx8wArewKy1vXMtlg==";
       };
     }
@@ -1733,7 +1739,7 @@
       name = "immediate___immediate_3.0.6.tgz";
       path = fetchurl {
         name = "immediate___immediate_3.0.6.tgz";
-        url  = "https://registry.yarnpkg.com/immediate/-/immediate-3.0.6.tgz";
+        url = "https://registry.yarnpkg.com/immediate/-/immediate-3.0.6.tgz";
         sha512 = "XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==";
       };
     }
@@ -1741,7 +1747,7 @@
       name = "import_fresh___import_fresh_3.3.0.tgz";
       path = fetchurl {
         name = "import_fresh___import_fresh_3.3.0.tgz";
-        url  = "https://registry.yarnpkg.com/import-fresh/-/import-fresh-3.3.0.tgz";
+        url = "https://registry.yarnpkg.com/import-fresh/-/import-fresh-3.3.0.tgz";
         sha512 = "veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==";
       };
     }
@@ -1749,7 +1755,7 @@
       name = "import_local___import_local_3.1.0.tgz";
       path = fetchurl {
         name = "import_local___import_local_3.1.0.tgz";
-        url  = "https://registry.yarnpkg.com/import-local/-/import-local-3.1.0.tgz";
+        url = "https://registry.yarnpkg.com/import-local/-/import-local-3.1.0.tgz";
         sha512 = "ASB07uLtnDs1o6EHjKpX34BKYDSqnFerfTOJL2HvMqF70LnxpjkzDB8J44oT9pu4AMPkQwf8jl6szgvNd2tRIg==";
       };
     }
@@ -1757,7 +1763,7 @@
       name = "imurmurhash___imurmurhash_0.1.4.tgz";
       path = fetchurl {
         name = "imurmurhash___imurmurhash_0.1.4.tgz";
-        url  = "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz";
+        url = "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz";
         sha512 = "JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==";
       };
     }
@@ -1765,7 +1771,7 @@
       name = "inflight___inflight_1.0.6.tgz";
       path = fetchurl {
         name = "inflight___inflight_1.0.6.tgz";
-        url  = "https://registry.yarnpkg.com/inflight/-/inflight-1.0.6.tgz";
+        url = "https://registry.yarnpkg.com/inflight/-/inflight-1.0.6.tgz";
         sha512 = "k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==";
       };
     }
@@ -1773,7 +1779,7 @@
       name = "inherits___inherits_2.0.4.tgz";
       path = fetchurl {
         name = "inherits___inherits_2.0.4.tgz";
-        url  = "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz";
+        url = "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz";
         sha512 = "k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==";
       };
     }
@@ -1781,7 +1787,7 @@
       name = "ini___ini_1.3.8.tgz";
       path = fetchurl {
         name = "ini___ini_1.3.8.tgz";
-        url  = "https://registry.yarnpkg.com/ini/-/ini-1.3.8.tgz";
+        url = "https://registry.yarnpkg.com/ini/-/ini-1.3.8.tgz";
         sha512 = "JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==";
       };
     }
@@ -1789,7 +1795,7 @@
       name = "interpret___interpret_3.1.1.tgz";
       path = fetchurl {
         name = "interpret___interpret_3.1.1.tgz";
-        url  = "https://registry.yarnpkg.com/interpret/-/interpret-3.1.1.tgz";
+        url = "https://registry.yarnpkg.com/interpret/-/interpret-3.1.1.tgz";
         sha512 = "6xwYfHbajpoF0xLW+iwLkhwgvLoZDfjYfoFNu8ftMoXINzwuymNLd9u/KmwtdT2GbR+/Cz66otEGEVVUHX9QLQ==";
       };
     }
@@ -1797,7 +1803,7 @@
       name = "is_binary_path___is_binary_path_2.1.0.tgz";
       path = fetchurl {
         name = "is_binary_path___is_binary_path_2.1.0.tgz";
-        url  = "https://registry.yarnpkg.com/is-binary-path/-/is-binary-path-2.1.0.tgz";
+        url = "https://registry.yarnpkg.com/is-binary-path/-/is-binary-path-2.1.0.tgz";
         sha512 = "ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==";
       };
     }
@@ -1805,7 +1811,7 @@
       name = "is_core_module___is_core_module_2.13.1.tgz";
       path = fetchurl {
         name = "is_core_module___is_core_module_2.13.1.tgz";
-        url  = "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.13.1.tgz";
+        url = "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.13.1.tgz";
         sha512 = "hHrIjvZsftOsvKSn2TRYl63zvxsgE0K+0mYMoH6gD4omR5IWB2KynivBQczo3+wF1cCkjzvptnI9Q0sPU66ilw==";
       };
     }
@@ -1813,7 +1819,7 @@
       name = "is_extglob___is_extglob_2.1.1.tgz";
       path = fetchurl {
         name = "is_extglob___is_extglob_2.1.1.tgz";
-        url  = "https://registry.yarnpkg.com/is-extglob/-/is-extglob-2.1.1.tgz";
+        url = "https://registry.yarnpkg.com/is-extglob/-/is-extglob-2.1.1.tgz";
         sha512 = "SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==";
       };
     }
@@ -1821,7 +1827,7 @@
       name = "is_fullwidth_code_point___is_fullwidth_code_point_3.0.0.tgz";
       path = fetchurl {
         name = "is_fullwidth_code_point___is_fullwidth_code_point_3.0.0.tgz";
-        url  = "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz";
+        url = "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz";
         sha512 = "zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==";
       };
     }
@@ -1829,7 +1835,7 @@
       name = "is_glob___is_glob_4.0.3.tgz";
       path = fetchurl {
         name = "is_glob___is_glob_4.0.3.tgz";
-        url  = "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.3.tgz";
+        url = "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.3.tgz";
         sha512 = "xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==";
       };
     }
@@ -1837,7 +1843,7 @@
       name = "is_number___is_number_7.0.0.tgz";
       path = fetchurl {
         name = "is_number___is_number_7.0.0.tgz";
-        url  = "https://registry.yarnpkg.com/is-number/-/is-number-7.0.0.tgz";
+        url = "https://registry.yarnpkg.com/is-number/-/is-number-7.0.0.tgz";
         sha512 = "41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==";
       };
     }
@@ -1845,7 +1851,7 @@
       name = "is_path_inside___is_path_inside_3.0.3.tgz";
       path = fetchurl {
         name = "is_path_inside___is_path_inside_3.0.3.tgz";
-        url  = "https://registry.yarnpkg.com/is-path-inside/-/is-path-inside-3.0.3.tgz";
+        url = "https://registry.yarnpkg.com/is-path-inside/-/is-path-inside-3.0.3.tgz";
         sha512 = "Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==";
       };
     }
@@ -1853,7 +1859,7 @@
       name = "is_plain_obj___is_plain_obj_2.1.0.tgz";
       path = fetchurl {
         name = "is_plain_obj___is_plain_obj_2.1.0.tgz";
-        url  = "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-2.1.0.tgz";
+        url = "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-2.1.0.tgz";
         sha512 = "YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==";
       };
     }
@@ -1861,7 +1867,7 @@
       name = "is_plain_object___is_plain_object_2.0.4.tgz";
       path = fetchurl {
         name = "is_plain_object___is_plain_object_2.0.4.tgz";
-        url  = "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-2.0.4.tgz";
+        url = "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-2.0.4.tgz";
         sha512 = "h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==";
       };
     }
@@ -1869,7 +1875,7 @@
       name = "is_unicode_supported___is_unicode_supported_0.1.0.tgz";
       path = fetchurl {
         name = "is_unicode_supported___is_unicode_supported_0.1.0.tgz";
-        url  = "https://registry.yarnpkg.com/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz";
+        url = "https://registry.yarnpkg.com/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz";
         sha512 = "knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==";
       };
     }
@@ -1877,7 +1883,7 @@
       name = "isarray___isarray_1.0.0.tgz";
       path = fetchurl {
         name = "isarray___isarray_1.0.0.tgz";
-        url  = "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz";
+        url = "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz";
         sha512 = "VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==";
       };
     }
@@ -1885,7 +1891,7 @@
       name = "isexe___isexe_2.0.0.tgz";
       path = fetchurl {
         name = "isexe___isexe_2.0.0.tgz";
-        url  = "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz";
+        url = "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz";
         sha512 = "RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==";
       };
     }
@@ -1893,7 +1899,7 @@
       name = "isobject___isobject_3.0.1.tgz";
       path = fetchurl {
         name = "isobject___isobject_3.0.1.tgz";
-        url  = "https://registry.yarnpkg.com/isobject/-/isobject-3.0.1.tgz";
+        url = "https://registry.yarnpkg.com/isobject/-/isobject-3.0.1.tgz";
         sha512 = "WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==";
       };
     }
@@ -1901,7 +1907,7 @@
       name = "jest_diff___jest_diff_29.7.0.tgz";
       path = fetchurl {
         name = "jest_diff___jest_diff_29.7.0.tgz";
-        url  = "https://registry.yarnpkg.com/jest-diff/-/jest-diff-29.7.0.tgz";
+        url = "https://registry.yarnpkg.com/jest-diff/-/jest-diff-29.7.0.tgz";
         sha512 = "LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==";
       };
     }
@@ -1909,7 +1915,7 @@
       name = "jest_get_type___jest_get_type_29.6.3.tgz";
       path = fetchurl {
         name = "jest_get_type___jest_get_type_29.6.3.tgz";
-        url  = "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-29.6.3.tgz";
+        url = "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-29.6.3.tgz";
         sha512 = "zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==";
       };
     }
@@ -1917,7 +1923,7 @@
       name = "jest_matcher_utils___jest_matcher_utils_29.7.0.tgz";
       path = fetchurl {
         name = "jest_matcher_utils___jest_matcher_utils_29.7.0.tgz";
-        url  = "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-29.7.0.tgz";
+        url = "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-29.7.0.tgz";
         sha512 = "sBkD+Xi9DtcChsI3L3u0+N0opgPYnCRPtGcQYrgXmR+hmt/fYfWAL0xRXYU8eWOdfuLgBe0YCW3AFtnRLagq/g==";
       };
     }
@@ -1925,7 +1931,7 @@
       name = "jest_message_util___jest_message_util_29.7.0.tgz";
       path = fetchurl {
         name = "jest_message_util___jest_message_util_29.7.0.tgz";
-        url  = "https://registry.yarnpkg.com/jest-message-util/-/jest-message-util-29.7.0.tgz";
+        url = "https://registry.yarnpkg.com/jest-message-util/-/jest-message-util-29.7.0.tgz";
         sha512 = "GBEV4GRADeP+qtB2+6u61stea8mGcOT4mCtrYISZwfu9/ISHFJ/5zOMXYbpBE9RsS5+Gb63DW4FgmnKJ79Kf6w==";
       };
     }
@@ -1933,7 +1939,7 @@
       name = "jest_util___jest_util_29.7.0.tgz";
       path = fetchurl {
         name = "jest_util___jest_util_29.7.0.tgz";
-        url  = "https://registry.yarnpkg.com/jest-util/-/jest-util-29.7.0.tgz";
+        url = "https://registry.yarnpkg.com/jest-util/-/jest-util-29.7.0.tgz";
         sha512 = "z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==";
       };
     }
@@ -1941,7 +1947,7 @@
       name = "jest_worker___jest_worker_27.5.1.tgz";
       path = fetchurl {
         name = "jest_worker___jest_worker_27.5.1.tgz";
-        url  = "https://registry.yarnpkg.com/jest-worker/-/jest-worker-27.5.1.tgz";
+        url = "https://registry.yarnpkg.com/jest-worker/-/jest-worker-27.5.1.tgz";
         sha512 = "7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==";
       };
     }
@@ -1949,7 +1955,7 @@
       name = "js_tokens___js_tokens_4.0.0.tgz";
       path = fetchurl {
         name = "js_tokens___js_tokens_4.0.0.tgz";
-        url  = "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz";
+        url = "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz";
         sha512 = "RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==";
       };
     }
@@ -1957,7 +1963,7 @@
       name = "js_yaml___js_yaml_4.1.0.tgz";
       path = fetchurl {
         name = "js_yaml___js_yaml_4.1.0.tgz";
-        url  = "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.1.0.tgz";
+        url = "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.1.0.tgz";
         sha512 = "wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==";
       };
     }
@@ -1965,7 +1971,7 @@
       name = "json_buffer___json_buffer_3.0.1.tgz";
       path = fetchurl {
         name = "json_buffer___json_buffer_3.0.1.tgz";
-        url  = "https://registry.yarnpkg.com/json-buffer/-/json-buffer-3.0.1.tgz";
+        url = "https://registry.yarnpkg.com/json-buffer/-/json-buffer-3.0.1.tgz";
         sha512 = "4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==";
       };
     }
@@ -1973,7 +1979,7 @@
       name = "json_parse_even_better_errors___json_parse_even_better_errors_2.3.1.tgz";
       path = fetchurl {
         name = "json_parse_even_better_errors___json_parse_even_better_errors_2.3.1.tgz";
-        url  = "https://registry.yarnpkg.com/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz";
+        url = "https://registry.yarnpkg.com/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz";
         sha512 = "xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==";
       };
     }
@@ -1981,7 +1987,7 @@
       name = "json_schema_traverse___json_schema_traverse_0.4.1.tgz";
       path = fetchurl {
         name = "json_schema_traverse___json_schema_traverse_0.4.1.tgz";
-        url  = "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz";
+        url = "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz";
         sha512 = "xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==";
       };
     }
@@ -1989,7 +1995,7 @@
       name = "json_stable_stringify_without_jsonify___json_stable_stringify_without_jsonify_1.0.1.tgz";
       path = fetchurl {
         name = "json_stable_stringify_without_jsonify___json_stable_stringify_without_jsonify_1.0.1.tgz";
-        url  = "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz";
+        url = "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz";
         sha512 = "Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==";
       };
     }
@@ -1997,7 +2003,7 @@
       name = "jsonc_parser___jsonc_parser_3.2.1.tgz";
       path = fetchurl {
         name = "jsonc_parser___jsonc_parser_3.2.1.tgz";
-        url  = "https://registry.yarnpkg.com/jsonc-parser/-/jsonc-parser-3.2.1.tgz";
+        url = "https://registry.yarnpkg.com/jsonc-parser/-/jsonc-parser-3.2.1.tgz";
         sha512 = "AilxAyFOAcK5wA1+LeaySVBrHsGQvUFCDWXKpZjzaL0PqW+xfBOttn8GNtWKFWqneyMZj41MWF9Kl6iPWLwgOA==";
       };
     }
@@ -2005,7 +2011,7 @@
       name = "jszip___jszip_3.10.1.tgz";
       path = fetchurl {
         name = "jszip___jszip_3.10.1.tgz";
-        url  = "https://registry.yarnpkg.com/jszip/-/jszip-3.10.1.tgz";
+        url = "https://registry.yarnpkg.com/jszip/-/jszip-3.10.1.tgz";
         sha512 = "xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==";
       };
     }
@@ -2013,7 +2019,7 @@
       name = "keytar___keytar_7.9.0.tgz";
       path = fetchurl {
         name = "keytar___keytar_7.9.0.tgz";
-        url  = "https://registry.yarnpkg.com/keytar/-/keytar-7.9.0.tgz";
+        url = "https://registry.yarnpkg.com/keytar/-/keytar-7.9.0.tgz";
         sha512 = "VPD8mtVtm5JNtA2AErl6Chp06JBfy7diFQ7TQQhdpWOl6MrCRB+eRbvAZUsbGQS9kiMq0coJsy0W0vHpDCkWsQ==";
       };
     }
@@ -2021,7 +2027,7 @@
       name = "keyv___keyv_4.5.4.tgz";
       path = fetchurl {
         name = "keyv___keyv_4.5.4.tgz";
-        url  = "https://registry.yarnpkg.com/keyv/-/keyv-4.5.4.tgz";
+        url = "https://registry.yarnpkg.com/keyv/-/keyv-4.5.4.tgz";
         sha512 = "oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==";
       };
     }
@@ -2029,7 +2035,7 @@
       name = "kind_of___kind_of_6.0.3.tgz";
       path = fetchurl {
         name = "kind_of___kind_of_6.0.3.tgz";
-        url  = "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.3.tgz";
+        url = "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.3.tgz";
         sha512 = "dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==";
       };
     }
@@ -2037,7 +2043,7 @@
       name = "leven___leven_3.1.0.tgz";
       path = fetchurl {
         name = "leven___leven_3.1.0.tgz";
-        url  = "https://registry.yarnpkg.com/leven/-/leven-3.1.0.tgz";
+        url = "https://registry.yarnpkg.com/leven/-/leven-3.1.0.tgz";
         sha512 = "qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==";
       };
     }
@@ -2045,7 +2051,7 @@
       name = "levn___levn_0.4.1.tgz";
       path = fetchurl {
         name = "levn___levn_0.4.1.tgz";
-        url  = "https://registry.yarnpkg.com/levn/-/levn-0.4.1.tgz";
+        url = "https://registry.yarnpkg.com/levn/-/levn-0.4.1.tgz";
         sha512 = "+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==";
       };
     }
@@ -2053,7 +2059,7 @@
       name = "lie___lie_3.3.0.tgz";
       path = fetchurl {
         name = "lie___lie_3.3.0.tgz";
-        url  = "https://registry.yarnpkg.com/lie/-/lie-3.3.0.tgz";
+        url = "https://registry.yarnpkg.com/lie/-/lie-3.3.0.tgz";
         sha512 = "UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==";
       };
     }
@@ -2061,7 +2067,7 @@
       name = "linkify_it___linkify_it_3.0.3.tgz";
       path = fetchurl {
         name = "linkify_it___linkify_it_3.0.3.tgz";
-        url  = "https://registry.yarnpkg.com/linkify-it/-/linkify-it-3.0.3.tgz";
+        url = "https://registry.yarnpkg.com/linkify-it/-/linkify-it-3.0.3.tgz";
         sha512 = "ynTsyrFSdE5oZ/O9GEf00kPngmOfVwazR5GKDq6EYfhlpFug3J2zybX56a2PRRpc9P+FuSoGNAwjlbDs9jJBPQ==";
       };
     }
@@ -2069,7 +2075,7 @@
       name = "loader_runner___loader_runner_4.3.0.tgz";
       path = fetchurl {
         name = "loader_runner___loader_runner_4.3.0.tgz";
-        url  = "https://registry.yarnpkg.com/loader-runner/-/loader-runner-4.3.0.tgz";
+        url = "https://registry.yarnpkg.com/loader-runner/-/loader-runner-4.3.0.tgz";
         sha512 = "3R/1M+yS3j5ou80Me59j7F9IMs4PXs3VqRrm0TU3AbKPxlmpoY1TNscJV/oGJXo8qCatFGTfDbY6W6ipGOYXfg==";
       };
     }
@@ -2077,7 +2083,7 @@
       name = "locate_path___locate_path_5.0.0.tgz";
       path = fetchurl {
         name = "locate_path___locate_path_5.0.0.tgz";
-        url  = "https://registry.yarnpkg.com/locate-path/-/locate-path-5.0.0.tgz";
+        url = "https://registry.yarnpkg.com/locate-path/-/locate-path-5.0.0.tgz";
         sha512 = "t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==";
       };
     }
@@ -2085,7 +2091,7 @@
       name = "locate_path___locate_path_6.0.0.tgz";
       path = fetchurl {
         name = "locate_path___locate_path_6.0.0.tgz";
-        url  = "https://registry.yarnpkg.com/locate-path/-/locate-path-6.0.0.tgz";
+        url = "https://registry.yarnpkg.com/locate-path/-/locate-path-6.0.0.tgz";
         sha512 = "iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==";
       };
     }
@@ -2093,7 +2099,7 @@
       name = "lodash.merge___lodash.merge_4.6.2.tgz";
       path = fetchurl {
         name = "lodash.merge___lodash.merge_4.6.2.tgz";
-        url  = "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz";
+        url = "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz";
         sha512 = "0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==";
       };
     }
@@ -2101,7 +2107,7 @@
       name = "log_symbols___log_symbols_4.1.0.tgz";
       path = fetchurl {
         name = "log_symbols___log_symbols_4.1.0.tgz";
-        url  = "https://registry.yarnpkg.com/log-symbols/-/log-symbols-4.1.0.tgz";
+        url = "https://registry.yarnpkg.com/log-symbols/-/log-symbols-4.1.0.tgz";
         sha512 = "8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==";
       };
     }
@@ -2109,7 +2115,7 @@
       name = "lru_cache___lru_cache_6.0.0.tgz";
       path = fetchurl {
         name = "lru_cache___lru_cache_6.0.0.tgz";
-        url  = "https://registry.yarnpkg.com/lru-cache/-/lru-cache-6.0.0.tgz";
+        url = "https://registry.yarnpkg.com/lru-cache/-/lru-cache-6.0.0.tgz";
         sha512 = "Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==";
       };
     }
@@ -2117,7 +2123,7 @@
       name = "markdown_it___markdown_it_12.3.2.tgz";
       path = fetchurl {
         name = "markdown_it___markdown_it_12.3.2.tgz";
-        url  = "https://registry.yarnpkg.com/markdown-it/-/markdown-it-12.3.2.tgz";
+        url = "https://registry.yarnpkg.com/markdown-it/-/markdown-it-12.3.2.tgz";
         sha512 = "TchMembfxfNVpHkbtriWltGWc+m3xszaRD0CZup7GFFhzIgQqxIfn3eGj1yZpfuflzPvfkt611B2Q/Bsk1YnGg==";
       };
     }
@@ -2125,7 +2131,7 @@
       name = "mdurl___mdurl_1.0.1.tgz";
       path = fetchurl {
         name = "mdurl___mdurl_1.0.1.tgz";
-        url  = "https://registry.yarnpkg.com/mdurl/-/mdurl-1.0.1.tgz";
+        url = "https://registry.yarnpkg.com/mdurl/-/mdurl-1.0.1.tgz";
         sha512 = "/sKlQJCBYVY9Ers9hqzKou4H6V5UWc/M59TH2dvkt+84itfnq7uFOMLpOiOS4ujvHP4etln18fmIxA5R5fll0g==";
       };
     }
@@ -2133,7 +2139,7 @@
       name = "merge_stream___merge_stream_2.0.0.tgz";
       path = fetchurl {
         name = "merge_stream___merge_stream_2.0.0.tgz";
-        url  = "https://registry.yarnpkg.com/merge-stream/-/merge-stream-2.0.0.tgz";
+        url = "https://registry.yarnpkg.com/merge-stream/-/merge-stream-2.0.0.tgz";
         sha512 = "abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==";
       };
     }
@@ -2141,7 +2147,7 @@
       name = "merge2___merge2_1.4.1.tgz";
       path = fetchurl {
         name = "merge2___merge2_1.4.1.tgz";
-        url  = "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz";
+        url = "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz";
         sha512 = "8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==";
       };
     }
@@ -2149,7 +2155,7 @@
       name = "micromatch___micromatch_4.0.5.tgz";
       path = fetchurl {
         name = "micromatch___micromatch_4.0.5.tgz";
-        url  = "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.5.tgz";
+        url = "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.5.tgz";
         sha512 = "DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==";
       };
     }
@@ -2157,7 +2163,7 @@
       name = "mime_db___mime_db_1.52.0.tgz";
       path = fetchurl {
         name = "mime_db___mime_db_1.52.0.tgz";
-        url  = "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz";
+        url = "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz";
         sha512 = "sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==";
       };
     }
@@ -2165,7 +2171,7 @@
       name = "mime_types___mime_types_2.1.35.tgz";
       path = fetchurl {
         name = "mime_types___mime_types_2.1.35.tgz";
-        url  = "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.35.tgz";
+        url = "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.35.tgz";
         sha512 = "ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==";
       };
     }
@@ -2173,7 +2179,7 @@
       name = "mime___mime_1.6.0.tgz";
       path = fetchurl {
         name = "mime___mime_1.6.0.tgz";
-        url  = "https://registry.yarnpkg.com/mime/-/mime-1.6.0.tgz";
+        url = "https://registry.yarnpkg.com/mime/-/mime-1.6.0.tgz";
         sha512 = "x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==";
       };
     }
@@ -2181,7 +2187,7 @@
       name = "mimic_response___mimic_response_3.1.0.tgz";
       path = fetchurl {
         name = "mimic_response___mimic_response_3.1.0.tgz";
-        url  = "https://registry.yarnpkg.com/mimic-response/-/mimic-response-3.1.0.tgz";
+        url = "https://registry.yarnpkg.com/mimic-response/-/mimic-response-3.1.0.tgz";
         sha512 = "z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==";
       };
     }
@@ -2189,7 +2195,7 @@
       name = "minimatch___minimatch_5.0.1.tgz";
       path = fetchurl {
         name = "minimatch___minimatch_5.0.1.tgz";
-        url  = "https://registry.yarnpkg.com/minimatch/-/minimatch-5.0.1.tgz";
+        url = "https://registry.yarnpkg.com/minimatch/-/minimatch-5.0.1.tgz";
         sha512 = "nLDxIFRyhDblz3qMuq+SoRZED4+miJ/G+tdDrjkkkRnjAsBexeGpgjLEQ0blJy7rHhR2b93rhQY4SvyWu9v03g==";
       };
     }
@@ -2197,7 +2203,7 @@
       name = "minimatch___minimatch_3.1.2.tgz";
       path = fetchurl {
         name = "minimatch___minimatch_3.1.2.tgz";
-        url  = "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.2.tgz";
+        url = "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.2.tgz";
         sha512 = "J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==";
       };
     }
@@ -2205,7 +2211,7 @@
       name = "minimatch___minimatch_5.1.6.tgz";
       path = fetchurl {
         name = "minimatch___minimatch_5.1.6.tgz";
-        url  = "https://registry.yarnpkg.com/minimatch/-/minimatch-5.1.6.tgz";
+        url = "https://registry.yarnpkg.com/minimatch/-/minimatch-5.1.6.tgz";
         sha512 = "lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==";
       };
     }
@@ -2213,7 +2219,7 @@
       name = "minimist___minimist_1.2.8.tgz";
       path = fetchurl {
         name = "minimist___minimist_1.2.8.tgz";
-        url  = "https://registry.yarnpkg.com/minimist/-/minimist-1.2.8.tgz";
+        url = "https://registry.yarnpkg.com/minimist/-/minimist-1.2.8.tgz";
         sha512 = "2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==";
       };
     }
@@ -2221,7 +2227,7 @@
       name = "mkdirp_classic___mkdirp_classic_0.5.3.tgz";
       path = fetchurl {
         name = "mkdirp_classic___mkdirp_classic_0.5.3.tgz";
-        url  = "https://registry.yarnpkg.com/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz";
+        url = "https://registry.yarnpkg.com/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz";
         sha512 = "gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==";
       };
     }
@@ -2229,7 +2235,7 @@
       name = "mocha___mocha_10.2.0.tgz";
       path = fetchurl {
         name = "mocha___mocha_10.2.0.tgz";
-        url  = "https://registry.yarnpkg.com/mocha/-/mocha-10.2.0.tgz";
+        url = "https://registry.yarnpkg.com/mocha/-/mocha-10.2.0.tgz";
         sha512 = "IDY7fl/BecMwFHzoqF2sg/SHHANeBoMMXFlS9r0OXKDssYE1M5O43wUY/9BVPeIvfH2zmEbBfseqN9gBQZzXkg==";
       };
     }
@@ -2237,7 +2243,7 @@
       name = "ms___ms_2.1.2.tgz";
       path = fetchurl {
         name = "ms___ms_2.1.2.tgz";
-        url  = "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz";
+        url = "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz";
         sha512 = "sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==";
       };
     }
@@ -2245,7 +2251,7 @@
       name = "ms___ms_2.1.3.tgz";
       path = fetchurl {
         name = "ms___ms_2.1.3.tgz";
-        url  = "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz";
+        url = "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz";
         sha512 = "6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==";
       };
     }
@@ -2253,7 +2259,7 @@
       name = "mute_stream___mute_stream_0.0.8.tgz";
       path = fetchurl {
         name = "mute_stream___mute_stream_0.0.8.tgz";
-        url  = "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.8.tgz";
+        url = "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.8.tgz";
         sha512 = "nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==";
       };
     }
@@ -2261,7 +2267,7 @@
       name = "nanoid___nanoid_3.3.3.tgz";
       path = fetchurl {
         name = "nanoid___nanoid_3.3.3.tgz";
-        url  = "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.3.tgz";
+        url = "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.3.tgz";
         sha512 = "p1sjXuopFs0xg+fPASzQ28agW1oHD7xDsd9Xkf3T15H3c/cifrFHVwrh74PdoklAPi+i7MdRsE47vm2r6JoB+w==";
       };
     }
@@ -2269,7 +2275,7 @@
       name = "napi_build_utils___napi_build_utils_1.0.2.tgz";
       path = fetchurl {
         name = "napi_build_utils___napi_build_utils_1.0.2.tgz";
-        url  = "https://registry.yarnpkg.com/napi-build-utils/-/napi-build-utils-1.0.2.tgz";
+        url = "https://registry.yarnpkg.com/napi-build-utils/-/napi-build-utils-1.0.2.tgz";
         sha512 = "ONmRUqK7zj7DWX0D9ADe03wbwOBZxNAfF20PlGfCWQcD3+/MakShIHrMqx9YwPTfxDdF1zLeL+RGZiR9kGMLdg==";
       };
     }
@@ -2277,7 +2283,7 @@
       name = "natural_compare_lite___natural_compare_lite_1.4.0.tgz";
       path = fetchurl {
         name = "natural_compare_lite___natural_compare_lite_1.4.0.tgz";
-        url  = "https://registry.yarnpkg.com/natural-compare-lite/-/natural-compare-lite-1.4.0.tgz";
+        url = "https://registry.yarnpkg.com/natural-compare-lite/-/natural-compare-lite-1.4.0.tgz";
         sha512 = "Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==";
       };
     }
@@ -2285,7 +2291,7 @@
       name = "natural_compare___natural_compare_1.4.0.tgz";
       path = fetchurl {
         name = "natural_compare___natural_compare_1.4.0.tgz";
-        url  = "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz";
+        url = "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz";
         sha512 = "OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==";
       };
     }
@@ -2293,7 +2299,7 @@
       name = "neo_async___neo_async_2.6.2.tgz";
       path = fetchurl {
         name = "neo_async___neo_async_2.6.2.tgz";
-        url  = "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.2.tgz";
+        url = "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.2.tgz";
         sha512 = "Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==";
       };
     }
@@ -2301,7 +2307,7 @@
       name = "node_abi___node_abi_3.54.0.tgz";
       path = fetchurl {
         name = "node_abi___node_abi_3.54.0.tgz";
-        url  = "https://registry.yarnpkg.com/node-abi/-/node-abi-3.54.0.tgz";
+        url = "https://registry.yarnpkg.com/node-abi/-/node-abi-3.54.0.tgz";
         sha512 = "p7eGEiQil0YUV3ItH4/tBb781L5impVmmx2E9FRKF7d18XXzp4PGT2tdYMFY6wQqgxD0IwNZOiSJ0/K0fSi/OA==";
       };
     }
@@ -2309,7 +2315,7 @@
       name = "node_addon_api___node_addon_api_4.3.0.tgz";
       path = fetchurl {
         name = "node_addon_api___node_addon_api_4.3.0.tgz";
-        url  = "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-4.3.0.tgz";
+        url = "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-4.3.0.tgz";
         sha512 = "73sE9+3UaLYYFmDsFZnqCInzPyh3MqIwZO9cw58yIqAZhONrrabrYyYe3TuIqtIiOuTXVhsGau8hcrhhwSsDIQ==";
       };
     }
@@ -2317,7 +2323,7 @@
       name = "node_releases___node_releases_2.0.14.tgz";
       path = fetchurl {
         name = "node_releases___node_releases_2.0.14.tgz";
-        url  = "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.14.tgz";
+        url = "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.14.tgz";
         sha512 = "y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw==";
       };
     }
@@ -2325,7 +2331,7 @@
       name = "normalize_path___normalize_path_3.0.0.tgz";
       path = fetchurl {
         name = "normalize_path___normalize_path_3.0.0.tgz";
-        url  = "https://registry.yarnpkg.com/normalize-path/-/normalize-path-3.0.0.tgz";
+        url = "https://registry.yarnpkg.com/normalize-path/-/normalize-path-3.0.0.tgz";
         sha512 = "6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==";
       };
     }
@@ -2333,7 +2339,7 @@
       name = "nth_check___nth_check_2.1.1.tgz";
       path = fetchurl {
         name = "nth_check___nth_check_2.1.1.tgz";
-        url  = "https://registry.yarnpkg.com/nth-check/-/nth-check-2.1.1.tgz";
+        url = "https://registry.yarnpkg.com/nth-check/-/nth-check-2.1.1.tgz";
         sha512 = "lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==";
       };
     }
@@ -2341,7 +2347,7 @@
       name = "object_inspect___object_inspect_1.13.1.tgz";
       path = fetchurl {
         name = "object_inspect___object_inspect_1.13.1.tgz";
-        url  = "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.13.1.tgz";
+        url = "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.13.1.tgz";
         sha512 = "5qoj1RUiKOMsCCNLV1CBiPYE10sziTsnmNxkAI/rZhiD63CF7IqdFGC/XzjWjpSgLf0LxXX3bDFIh0E18f6UhQ==";
       };
     }
@@ -2349,7 +2355,7 @@
       name = "once___once_1.4.0.tgz";
       path = fetchurl {
         name = "once___once_1.4.0.tgz";
-        url  = "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz";
+        url = "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz";
         sha512 = "lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==";
       };
     }
@@ -2357,7 +2363,7 @@
       name = "optionator___optionator_0.9.3.tgz";
       path = fetchurl {
         name = "optionator___optionator_0.9.3.tgz";
-        url  = "https://registry.yarnpkg.com/optionator/-/optionator-0.9.3.tgz";
+        url = "https://registry.yarnpkg.com/optionator/-/optionator-0.9.3.tgz";
         sha512 = "JjCoypp+jKn1ttEFExxhetCKeJt9zhAgAve5FXHixTvFDW/5aEktX9bufBKLRRMdU7bNtpLfcGu94B3cdEJgjg==";
       };
     }
@@ -2365,7 +2371,7 @@
       name = "p_limit___p_limit_2.3.0.tgz";
       path = fetchurl {
         name = "p_limit___p_limit_2.3.0.tgz";
-        url  = "https://registry.yarnpkg.com/p-limit/-/p-limit-2.3.0.tgz";
+        url = "https://registry.yarnpkg.com/p-limit/-/p-limit-2.3.0.tgz";
         sha512 = "//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==";
       };
     }
@@ -2373,7 +2379,7 @@
       name = "p_limit___p_limit_3.1.0.tgz";
       path = fetchurl {
         name = "p_limit___p_limit_3.1.0.tgz";
-        url  = "https://registry.yarnpkg.com/p-limit/-/p-limit-3.1.0.tgz";
+        url = "https://registry.yarnpkg.com/p-limit/-/p-limit-3.1.0.tgz";
         sha512 = "TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==";
       };
     }
@@ -2381,7 +2387,7 @@
       name = "p_locate___p_locate_4.1.0.tgz";
       path = fetchurl {
         name = "p_locate___p_locate_4.1.0.tgz";
-        url  = "https://registry.yarnpkg.com/p-locate/-/p-locate-4.1.0.tgz";
+        url = "https://registry.yarnpkg.com/p-locate/-/p-locate-4.1.0.tgz";
         sha512 = "R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==";
       };
     }
@@ -2389,7 +2395,7 @@
       name = "p_locate___p_locate_5.0.0.tgz";
       path = fetchurl {
         name = "p_locate___p_locate_5.0.0.tgz";
-        url  = "https://registry.yarnpkg.com/p-locate/-/p-locate-5.0.0.tgz";
+        url = "https://registry.yarnpkg.com/p-locate/-/p-locate-5.0.0.tgz";
         sha512 = "LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==";
       };
     }
@@ -2397,7 +2403,7 @@
       name = "p_try___p_try_2.2.0.tgz";
       path = fetchurl {
         name = "p_try___p_try_2.2.0.tgz";
-        url  = "https://registry.yarnpkg.com/p-try/-/p-try-2.2.0.tgz";
+        url = "https://registry.yarnpkg.com/p-try/-/p-try-2.2.0.tgz";
         sha512 = "R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==";
       };
     }
@@ -2405,7 +2411,7 @@
       name = "pako___pako_1.0.11.tgz";
       path = fetchurl {
         name = "pako___pako_1.0.11.tgz";
-        url  = "https://registry.yarnpkg.com/pako/-/pako-1.0.11.tgz";
+        url = "https://registry.yarnpkg.com/pako/-/pako-1.0.11.tgz";
         sha512 = "4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==";
       };
     }
@@ -2413,7 +2419,7 @@
       name = "parent_module___parent_module_1.0.1.tgz";
       path = fetchurl {
         name = "parent_module___parent_module_1.0.1.tgz";
-        url  = "https://registry.yarnpkg.com/parent-module/-/parent-module-1.0.1.tgz";
+        url = "https://registry.yarnpkg.com/parent-module/-/parent-module-1.0.1.tgz";
         sha512 = "GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==";
       };
     }
@@ -2421,7 +2427,7 @@
       name = "parse_semver___parse_semver_1.1.1.tgz";
       path = fetchurl {
         name = "parse_semver___parse_semver_1.1.1.tgz";
-        url  = "https://registry.yarnpkg.com/parse-semver/-/parse-semver-1.1.1.tgz";
+        url = "https://registry.yarnpkg.com/parse-semver/-/parse-semver-1.1.1.tgz";
         sha512 = "Eg1OuNntBMH0ojvEKSrvDSnwLmvVuUOSdylH/pSCPNMIspLlweJyIWXCE+k/5hm3cj/EBUYwmWkjhBALNP4LXQ==";
       };
     }
@@ -2429,7 +2435,7 @@
       name = "parse5_htmlparser2_tree_adapter___parse5_htmlparser2_tree_adapter_7.0.0.tgz";
       path = fetchurl {
         name = "parse5_htmlparser2_tree_adapter___parse5_htmlparser2_tree_adapter_7.0.0.tgz";
-        url  = "https://registry.yarnpkg.com/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.0.0.tgz";
+        url = "https://registry.yarnpkg.com/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.0.0.tgz";
         sha512 = "B77tOZrqqfUfnVcOrUvfdLbz4pu4RopLD/4vmu3HUPswwTA8OH0EMW9BlWR2B0RCoiZRAHEUu7IxeP1Pd1UU+g==";
       };
     }
@@ -2437,7 +2443,7 @@
       name = "parse5___parse5_7.1.2.tgz";
       path = fetchurl {
         name = "parse5___parse5_7.1.2.tgz";
-        url  = "https://registry.yarnpkg.com/parse5/-/parse5-7.1.2.tgz";
+        url = "https://registry.yarnpkg.com/parse5/-/parse5-7.1.2.tgz";
         sha512 = "Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==";
       };
     }
@@ -2445,7 +2451,7 @@
       name = "path_exists___path_exists_4.0.0.tgz";
       path = fetchurl {
         name = "path_exists___path_exists_4.0.0.tgz";
-        url  = "https://registry.yarnpkg.com/path-exists/-/path-exists-4.0.0.tgz";
+        url = "https://registry.yarnpkg.com/path-exists/-/path-exists-4.0.0.tgz";
         sha512 = "ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==";
       };
     }
@@ -2453,7 +2459,7 @@
       name = "path_is_absolute___path_is_absolute_1.0.1.tgz";
       path = fetchurl {
         name = "path_is_absolute___path_is_absolute_1.0.1.tgz";
-        url  = "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz";
+        url = "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz";
         sha512 = "AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==";
       };
     }
@@ -2461,7 +2467,7 @@
       name = "path_key___path_key_3.1.1.tgz";
       path = fetchurl {
         name = "path_key___path_key_3.1.1.tgz";
-        url  = "https://registry.yarnpkg.com/path-key/-/path-key-3.1.1.tgz";
+        url = "https://registry.yarnpkg.com/path-key/-/path-key-3.1.1.tgz";
         sha512 = "ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==";
       };
     }
@@ -2469,7 +2475,7 @@
       name = "path_parse___path_parse_1.0.7.tgz";
       path = fetchurl {
         name = "path_parse___path_parse_1.0.7.tgz";
-        url  = "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.7.tgz";
+        url = "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.7.tgz";
         sha512 = "LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==";
       };
     }
@@ -2477,7 +2483,7 @@
       name = "path_type___path_type_4.0.0.tgz";
       path = fetchurl {
         name = "path_type___path_type_4.0.0.tgz";
-        url  = "https://registry.yarnpkg.com/path-type/-/path-type-4.0.0.tgz";
+        url = "https://registry.yarnpkg.com/path-type/-/path-type-4.0.0.tgz";
         sha512 = "gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==";
       };
     }
@@ -2485,7 +2491,7 @@
       name = "pend___pend_1.2.0.tgz";
       path = fetchurl {
         name = "pend___pend_1.2.0.tgz";
-        url  = "https://registry.yarnpkg.com/pend/-/pend-1.2.0.tgz";
+        url = "https://registry.yarnpkg.com/pend/-/pend-1.2.0.tgz";
         sha512 = "F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==";
       };
     }
@@ -2493,7 +2499,7 @@
       name = "picocolors___picocolors_1.0.0.tgz";
       path = fetchurl {
         name = "picocolors___picocolors_1.0.0.tgz";
-        url  = "https://registry.yarnpkg.com/picocolors/-/picocolors-1.0.0.tgz";
+        url = "https://registry.yarnpkg.com/picocolors/-/picocolors-1.0.0.tgz";
         sha512 = "1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==";
       };
     }
@@ -2501,7 +2507,7 @@
       name = "picomatch___picomatch_2.3.1.tgz";
       path = fetchurl {
         name = "picomatch___picomatch_2.3.1.tgz";
-        url  = "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz";
+        url = "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz";
         sha512 = "JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==";
       };
     }
@@ -2509,7 +2515,7 @@
       name = "pkg_dir___pkg_dir_4.2.0.tgz";
       path = fetchurl {
         name = "pkg_dir___pkg_dir_4.2.0.tgz";
-        url  = "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-4.2.0.tgz";
+        url = "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-4.2.0.tgz";
         sha512 = "HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==";
       };
     }
@@ -2517,7 +2523,7 @@
       name = "prebuild_install___prebuild_install_7.1.1.tgz";
       path = fetchurl {
         name = "prebuild_install___prebuild_install_7.1.1.tgz";
-        url  = "https://registry.yarnpkg.com/prebuild-install/-/prebuild-install-7.1.1.tgz";
+        url = "https://registry.yarnpkg.com/prebuild-install/-/prebuild-install-7.1.1.tgz";
         sha512 = "jAXscXWMcCK8GgCoHOfIr0ODh5ai8mj63L2nWrjuAgXE6tDyYGnx4/8o/rCgU+B4JSyZBKbeZqzhtwtC3ovxjw==";
       };
     }
@@ -2525,7 +2531,7 @@
       name = "prelude_ls___prelude_ls_1.2.1.tgz";
       path = fetchurl {
         name = "prelude_ls___prelude_ls_1.2.1.tgz";
-        url  = "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.2.1.tgz";
+        url = "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.2.1.tgz";
         sha512 = "vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==";
       };
     }
@@ -2533,7 +2539,7 @@
       name = "pretty_format___pretty_format_29.7.0.tgz";
       path = fetchurl {
         name = "pretty_format___pretty_format_29.7.0.tgz";
-        url  = "https://registry.yarnpkg.com/pretty-format/-/pretty-format-29.7.0.tgz";
+        url = "https://registry.yarnpkg.com/pretty-format/-/pretty-format-29.7.0.tgz";
         sha512 = "Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==";
       };
     }
@@ -2541,7 +2547,7 @@
       name = "process_nextick_args___process_nextick_args_2.0.1.tgz";
       path = fetchurl {
         name = "process_nextick_args___process_nextick_args_2.0.1.tgz";
-        url  = "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.1.tgz";
+        url = "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.1.tgz";
         sha512 = "3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==";
       };
     }
@@ -2549,7 +2555,7 @@
       name = "pump___pump_3.0.0.tgz";
       path = fetchurl {
         name = "pump___pump_3.0.0.tgz";
-        url  = "https://registry.yarnpkg.com/pump/-/pump-3.0.0.tgz";
+        url = "https://registry.yarnpkg.com/pump/-/pump-3.0.0.tgz";
         sha512 = "LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==";
       };
     }
@@ -2557,7 +2563,7 @@
       name = "punycode___punycode_2.3.1.tgz";
       path = fetchurl {
         name = "punycode___punycode_2.3.1.tgz";
-        url  = "https://registry.yarnpkg.com/punycode/-/punycode-2.3.1.tgz";
+        url = "https://registry.yarnpkg.com/punycode/-/punycode-2.3.1.tgz";
         sha512 = "vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==";
       };
     }
@@ -2565,7 +2571,7 @@
       name = "qs___qs_6.11.2.tgz";
       path = fetchurl {
         name = "qs___qs_6.11.2.tgz";
-        url  = "https://registry.yarnpkg.com/qs/-/qs-6.11.2.tgz";
+        url = "https://registry.yarnpkg.com/qs/-/qs-6.11.2.tgz";
         sha512 = "tDNIz22aBzCDxLtVH++VnTfzxlfeK5CbqohpSqpJgj1Wg/cQbStNAz3NuqCs5vV+pjBsK4x4pN9HlVh7rcYRiA==";
       };
     }
@@ -2573,7 +2579,7 @@
       name = "queue_microtask___queue_microtask_1.2.3.tgz";
       path = fetchurl {
         name = "queue_microtask___queue_microtask_1.2.3.tgz";
-        url  = "https://registry.yarnpkg.com/queue-microtask/-/queue-microtask-1.2.3.tgz";
+        url = "https://registry.yarnpkg.com/queue-microtask/-/queue-microtask-1.2.3.tgz";
         sha512 = "NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==";
       };
     }
@@ -2581,7 +2587,7 @@
       name = "randombytes___randombytes_2.1.0.tgz";
       path = fetchurl {
         name = "randombytes___randombytes_2.1.0.tgz";
-        url  = "https://registry.yarnpkg.com/randombytes/-/randombytes-2.1.0.tgz";
+        url = "https://registry.yarnpkg.com/randombytes/-/randombytes-2.1.0.tgz";
         sha512 = "vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==";
       };
     }
@@ -2589,7 +2595,7 @@
       name = "rc___rc_1.2.8.tgz";
       path = fetchurl {
         name = "rc___rc_1.2.8.tgz";
-        url  = "https://registry.yarnpkg.com/rc/-/rc-1.2.8.tgz";
+        url = "https://registry.yarnpkg.com/rc/-/rc-1.2.8.tgz";
         sha512 = "y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==";
       };
     }
@@ -2597,7 +2603,7 @@
       name = "react_is___react_is_18.2.0.tgz";
       path = fetchurl {
         name = "react_is___react_is_18.2.0.tgz";
-        url  = "https://registry.yarnpkg.com/react-is/-/react-is-18.2.0.tgz";
+        url = "https://registry.yarnpkg.com/react-is/-/react-is-18.2.0.tgz";
         sha512 = "xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==";
       };
     }
@@ -2605,7 +2611,7 @@
       name = "read___read_1.0.7.tgz";
       path = fetchurl {
         name = "read___read_1.0.7.tgz";
-        url  = "https://registry.yarnpkg.com/read/-/read-1.0.7.tgz";
+        url = "https://registry.yarnpkg.com/read/-/read-1.0.7.tgz";
         sha512 = "rSOKNYUmaxy0om1BNjMN4ezNT6VKK+2xF4GBhc81mkH7L60i6dp8qPYrkndNLT3QPphoII3maL9PVC9XmhHwVQ==";
       };
     }
@@ -2613,7 +2619,7 @@
       name = "readable_stream___readable_stream_3.6.2.tgz";
       path = fetchurl {
         name = "readable_stream___readable_stream_3.6.2.tgz";
-        url  = "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.2.tgz";
+        url = "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.2.tgz";
         sha512 = "9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==";
       };
     }
@@ -2621,7 +2627,7 @@
       name = "readable_stream___readable_stream_2.3.8.tgz";
       path = fetchurl {
         name = "readable_stream___readable_stream_2.3.8.tgz";
-        url  = "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.8.tgz";
+        url = "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.8.tgz";
         sha512 = "8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==";
       };
     }
@@ -2629,7 +2635,7 @@
       name = "readdirp___readdirp_3.6.0.tgz";
       path = fetchurl {
         name = "readdirp___readdirp_3.6.0.tgz";
-        url  = "https://registry.yarnpkg.com/readdirp/-/readdirp-3.6.0.tgz";
+        url = "https://registry.yarnpkg.com/readdirp/-/readdirp-3.6.0.tgz";
         sha512 = "hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==";
       };
     }
@@ -2637,7 +2643,7 @@
       name = "rechoir___rechoir_0.8.0.tgz";
       path = fetchurl {
         name = "rechoir___rechoir_0.8.0.tgz";
-        url  = "https://registry.yarnpkg.com/rechoir/-/rechoir-0.8.0.tgz";
+        url = "https://registry.yarnpkg.com/rechoir/-/rechoir-0.8.0.tgz";
         sha512 = "/vxpCXddiX8NGfGO/mTafwjq4aFa/71pvamip0++IQk3zG8cbCj0fifNPrjjF1XMXUne91jL9OoxmdykoEtifQ==";
       };
     }
@@ -2645,7 +2651,7 @@
       name = "require_directory___require_directory_2.1.1.tgz";
       path = fetchurl {
         name = "require_directory___require_directory_2.1.1.tgz";
-        url  = "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz";
+        url = "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz";
         sha512 = "fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==";
       };
     }
@@ -2653,7 +2659,7 @@
       name = "resolve_cwd___resolve_cwd_3.0.0.tgz";
       path = fetchurl {
         name = "resolve_cwd___resolve_cwd_3.0.0.tgz";
-        url  = "https://registry.yarnpkg.com/resolve-cwd/-/resolve-cwd-3.0.0.tgz";
+        url = "https://registry.yarnpkg.com/resolve-cwd/-/resolve-cwd-3.0.0.tgz";
         sha512 = "OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==";
       };
     }
@@ -2661,7 +2667,7 @@
       name = "resolve_from___resolve_from_4.0.0.tgz";
       path = fetchurl {
         name = "resolve_from___resolve_from_4.0.0.tgz";
-        url  = "https://registry.yarnpkg.com/resolve-from/-/resolve-from-4.0.0.tgz";
+        url = "https://registry.yarnpkg.com/resolve-from/-/resolve-from-4.0.0.tgz";
         sha512 = "pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==";
       };
     }
@@ -2669,7 +2675,7 @@
       name = "resolve_from___resolve_from_5.0.0.tgz";
       path = fetchurl {
         name = "resolve_from___resolve_from_5.0.0.tgz";
-        url  = "https://registry.yarnpkg.com/resolve-from/-/resolve-from-5.0.0.tgz";
+        url = "https://registry.yarnpkg.com/resolve-from/-/resolve-from-5.0.0.tgz";
         sha512 = "qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==";
       };
     }
@@ -2677,7 +2683,7 @@
       name = "resolve___resolve_1.22.8.tgz";
       path = fetchurl {
         name = "resolve___resolve_1.22.8.tgz";
-        url  = "https://registry.yarnpkg.com/resolve/-/resolve-1.22.8.tgz";
+        url = "https://registry.yarnpkg.com/resolve/-/resolve-1.22.8.tgz";
         sha512 = "oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==";
       };
     }
@@ -2685,7 +2691,7 @@
       name = "reusify___reusify_1.0.4.tgz";
       path = fetchurl {
         name = "reusify___reusify_1.0.4.tgz";
-        url  = "https://registry.yarnpkg.com/reusify/-/reusify-1.0.4.tgz";
+        url = "https://registry.yarnpkg.com/reusify/-/reusify-1.0.4.tgz";
         sha512 = "U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==";
       };
     }
@@ -2693,7 +2699,7 @@
       name = "rimraf___rimraf_3.0.2.tgz";
       path = fetchurl {
         name = "rimraf___rimraf_3.0.2.tgz";
-        url  = "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz";
+        url = "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz";
         sha512 = "JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==";
       };
     }
@@ -2701,7 +2707,7 @@
       name = "run_parallel___run_parallel_1.2.0.tgz";
       path = fetchurl {
         name = "run_parallel___run_parallel_1.2.0.tgz";
-        url  = "https://registry.yarnpkg.com/run-parallel/-/run-parallel-1.2.0.tgz";
+        url = "https://registry.yarnpkg.com/run-parallel/-/run-parallel-1.2.0.tgz";
         sha512 = "5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==";
       };
     }
@@ -2709,7 +2715,7 @@
       name = "safe_buffer___safe_buffer_5.2.1.tgz";
       path = fetchurl {
         name = "safe_buffer___safe_buffer_5.2.1.tgz";
-        url  = "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz";
+        url = "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz";
         sha512 = "rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==";
       };
     }
@@ -2717,7 +2723,7 @@
       name = "safe_buffer___safe_buffer_5.1.2.tgz";
       path = fetchurl {
         name = "safe_buffer___safe_buffer_5.1.2.tgz";
-        url  = "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz";
+        url = "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz";
         sha512 = "Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==";
       };
     }
@@ -2725,7 +2731,7 @@
       name = "sax___sax_1.3.0.tgz";
       path = fetchurl {
         name = "sax___sax_1.3.0.tgz";
-        url  = "https://registry.yarnpkg.com/sax/-/sax-1.3.0.tgz";
+        url = "https://registry.yarnpkg.com/sax/-/sax-1.3.0.tgz";
         sha512 = "0s+oAmw9zLl1V1cS9BtZN7JAd0cW5e0QH4W3LWEK6a4LaLEA2OTpGYWDY+6XasBLtz6wkm3u1xRw95mRuJ59WA==";
       };
     }
@@ -2733,7 +2739,7 @@
       name = "schema_utils___schema_utils_3.3.0.tgz";
       path = fetchurl {
         name = "schema_utils___schema_utils_3.3.0.tgz";
-        url  = "https://registry.yarnpkg.com/schema-utils/-/schema-utils-3.3.0.tgz";
+        url = "https://registry.yarnpkg.com/schema-utils/-/schema-utils-3.3.0.tgz";
         sha512 = "pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==";
       };
     }
@@ -2741,7 +2747,7 @@
       name = "semver___semver_5.7.2.tgz";
       path = fetchurl {
         name = "semver___semver_5.7.2.tgz";
-        url  = "https://registry.yarnpkg.com/semver/-/semver-5.7.2.tgz";
+        url = "https://registry.yarnpkg.com/semver/-/semver-5.7.2.tgz";
         sha512 = "cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==";
       };
     }
@@ -2749,7 +2755,7 @@
       name = "semver___semver_7.5.4.tgz";
       path = fetchurl {
         name = "semver___semver_7.5.4.tgz";
-        url  = "https://registry.yarnpkg.com/semver/-/semver-7.5.4.tgz";
+        url = "https://registry.yarnpkg.com/semver/-/semver-7.5.4.tgz";
         sha512 = "1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==";
       };
     }
@@ -2757,7 +2763,7 @@
       name = "serialize_javascript___serialize_javascript_6.0.0.tgz";
       path = fetchurl {
         name = "serialize_javascript___serialize_javascript_6.0.0.tgz";
-        url  = "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-6.0.0.tgz";
+        url = "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-6.0.0.tgz";
         sha512 = "Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==";
       };
     }
@@ -2765,7 +2771,7 @@
       name = "serialize_javascript___serialize_javascript_6.0.2.tgz";
       path = fetchurl {
         name = "serialize_javascript___serialize_javascript_6.0.2.tgz";
-        url  = "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-6.0.2.tgz";
+        url = "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-6.0.2.tgz";
         sha512 = "Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==";
       };
     }
@@ -2773,7 +2779,7 @@
       name = "set_function_length___set_function_length_1.2.0.tgz";
       path = fetchurl {
         name = "set_function_length___set_function_length_1.2.0.tgz";
-        url  = "https://registry.yarnpkg.com/set-function-length/-/set-function-length-1.2.0.tgz";
+        url = "https://registry.yarnpkg.com/set-function-length/-/set-function-length-1.2.0.tgz";
         sha512 = "4DBHDoyHlM1IRPGYcoxexgh67y4ueR53FKV1yyxwFMY7aCqcN/38M1+SwZ/qJQ8iLv7+ck385ot4CcisOAPT9w==";
       };
     }
@@ -2781,7 +2787,7 @@
       name = "setimmediate___setimmediate_1.0.5.tgz";
       path = fetchurl {
         name = "setimmediate___setimmediate_1.0.5.tgz";
-        url  = "https://registry.yarnpkg.com/setimmediate/-/setimmediate-1.0.5.tgz";
+        url = "https://registry.yarnpkg.com/setimmediate/-/setimmediate-1.0.5.tgz";
         sha512 = "MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==";
       };
     }
@@ -2789,7 +2795,7 @@
       name = "shallow_clone___shallow_clone_3.0.1.tgz";
       path = fetchurl {
         name = "shallow_clone___shallow_clone_3.0.1.tgz";
-        url  = "https://registry.yarnpkg.com/shallow-clone/-/shallow-clone-3.0.1.tgz";
+        url = "https://registry.yarnpkg.com/shallow-clone/-/shallow-clone-3.0.1.tgz";
         sha512 = "/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==";
       };
     }
@@ -2797,7 +2803,7 @@
       name = "shebang_command___shebang_command_2.0.0.tgz";
       path = fetchurl {
         name = "shebang_command___shebang_command_2.0.0.tgz";
-        url  = "https://registry.yarnpkg.com/shebang-command/-/shebang-command-2.0.0.tgz";
+        url = "https://registry.yarnpkg.com/shebang-command/-/shebang-command-2.0.0.tgz";
         sha512 = "kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==";
       };
     }
@@ -2805,7 +2811,7 @@
       name = "shebang_regex___shebang_regex_3.0.0.tgz";
       path = fetchurl {
         name = "shebang_regex___shebang_regex_3.0.0.tgz";
-        url  = "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-3.0.0.tgz";
+        url = "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-3.0.0.tgz";
         sha512 = "7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==";
       };
     }
@@ -2813,7 +2819,7 @@
       name = "side_channel___side_channel_1.0.4.tgz";
       path = fetchurl {
         name = "side_channel___side_channel_1.0.4.tgz";
-        url  = "https://registry.yarnpkg.com/side-channel/-/side-channel-1.0.4.tgz";
+        url = "https://registry.yarnpkg.com/side-channel/-/side-channel-1.0.4.tgz";
         sha512 = "q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==";
       };
     }
@@ -2821,7 +2827,7 @@
       name = "simple_concat___simple_concat_1.0.1.tgz";
       path = fetchurl {
         name = "simple_concat___simple_concat_1.0.1.tgz";
-        url  = "https://registry.yarnpkg.com/simple-concat/-/simple-concat-1.0.1.tgz";
+        url = "https://registry.yarnpkg.com/simple-concat/-/simple-concat-1.0.1.tgz";
         sha512 = "cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==";
       };
     }
@@ -2829,7 +2835,7 @@
       name = "simple_get___simple_get_4.0.1.tgz";
       path = fetchurl {
         name = "simple_get___simple_get_4.0.1.tgz";
-        url  = "https://registry.yarnpkg.com/simple-get/-/simple-get-4.0.1.tgz";
+        url = "https://registry.yarnpkg.com/simple-get/-/simple-get-4.0.1.tgz";
         sha512 = "brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==";
       };
     }
@@ -2837,7 +2843,7 @@
       name = "slash___slash_3.0.0.tgz";
       path = fetchurl {
         name = "slash___slash_3.0.0.tgz";
-        url  = "https://registry.yarnpkg.com/slash/-/slash-3.0.0.tgz";
+        url = "https://registry.yarnpkg.com/slash/-/slash-3.0.0.tgz";
         sha512 = "g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==";
       };
     }
@@ -2845,7 +2851,7 @@
       name = "source_map_support___source_map_support_0.5.21.tgz";
       path = fetchurl {
         name = "source_map_support___source_map_support_0.5.21.tgz";
-        url  = "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.21.tgz";
+        url = "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.21.tgz";
         sha512 = "uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==";
       };
     }
@@ -2853,7 +2859,7 @@
       name = "source_map___source_map_0.6.1.tgz";
       path = fetchurl {
         name = "source_map___source_map_0.6.1.tgz";
-        url  = "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz";
+        url = "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz";
         sha512 = "UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==";
       };
     }
@@ -2861,7 +2867,7 @@
       name = "source_map___source_map_0.7.4.tgz";
       path = fetchurl {
         name = "source_map___source_map_0.7.4.tgz";
-        url  = "https://registry.yarnpkg.com/source-map/-/source-map-0.7.4.tgz";
+        url = "https://registry.yarnpkg.com/source-map/-/source-map-0.7.4.tgz";
         sha512 = "l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==";
       };
     }
@@ -2869,7 +2875,7 @@
       name = "stack_utils___stack_utils_2.0.6.tgz";
       path = fetchurl {
         name = "stack_utils___stack_utils_2.0.6.tgz";
-        url  = "https://registry.yarnpkg.com/stack-utils/-/stack-utils-2.0.6.tgz";
+        url = "https://registry.yarnpkg.com/stack-utils/-/stack-utils-2.0.6.tgz";
         sha512 = "XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==";
       };
     }
@@ -2877,7 +2883,7 @@
       name = "string_width___string_width_4.2.3.tgz";
       path = fetchurl {
         name = "string_width___string_width_4.2.3.tgz";
-        url  = "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz";
+        url = "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz";
         sha512 = "wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==";
       };
     }
@@ -2885,7 +2891,7 @@
       name = "string_decoder___string_decoder_1.3.0.tgz";
       path = fetchurl {
         name = "string_decoder___string_decoder_1.3.0.tgz";
-        url  = "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.3.0.tgz";
+        url = "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.3.0.tgz";
         sha512 = "hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==";
       };
     }
@@ -2893,7 +2899,7 @@
       name = "string_decoder___string_decoder_1.1.1.tgz";
       path = fetchurl {
         name = "string_decoder___string_decoder_1.1.1.tgz";
-        url  = "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.1.1.tgz";
+        url = "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.1.1.tgz";
         sha512 = "n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==";
       };
     }
@@ -2901,7 +2907,7 @@
       name = "strip_ansi___strip_ansi_6.0.1.tgz";
       path = fetchurl {
         name = "strip_ansi___strip_ansi_6.0.1.tgz";
-        url  = "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz";
+        url = "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz";
         sha512 = "Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==";
       };
     }
@@ -2909,7 +2915,7 @@
       name = "strip_json_comments___strip_json_comments_3.1.1.tgz";
       path = fetchurl {
         name = "strip_json_comments___strip_json_comments_3.1.1.tgz";
-        url  = "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz";
+        url = "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz";
         sha512 = "6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==";
       };
     }
@@ -2917,7 +2923,7 @@
       name = "strip_json_comments___strip_json_comments_2.0.1.tgz";
       path = fetchurl {
         name = "strip_json_comments___strip_json_comments_2.0.1.tgz";
-        url  = "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz";
+        url = "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz";
         sha512 = "4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==";
       };
     }
@@ -2925,7 +2931,7 @@
       name = "supports_color___supports_color_8.1.1.tgz";
       path = fetchurl {
         name = "supports_color___supports_color_8.1.1.tgz";
-        url  = "https://registry.yarnpkg.com/supports-color/-/supports-color-8.1.1.tgz";
+        url = "https://registry.yarnpkg.com/supports-color/-/supports-color-8.1.1.tgz";
         sha512 = "MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==";
       };
     }
@@ -2933,7 +2939,7 @@
       name = "supports_color___supports_color_5.5.0.tgz";
       path = fetchurl {
         name = "supports_color___supports_color_5.5.0.tgz";
-        url  = "https://registry.yarnpkg.com/supports-color/-/supports-color-5.5.0.tgz";
+        url = "https://registry.yarnpkg.com/supports-color/-/supports-color-5.5.0.tgz";
         sha512 = "QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==";
       };
     }
@@ -2941,7 +2947,7 @@
       name = "supports_color___supports_color_7.2.0.tgz";
       path = fetchurl {
         name = "supports_color___supports_color_7.2.0.tgz";
-        url  = "https://registry.yarnpkg.com/supports-color/-/supports-color-7.2.0.tgz";
+        url = "https://registry.yarnpkg.com/supports-color/-/supports-color-7.2.0.tgz";
         sha512 = "qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==";
       };
     }
@@ -2949,7 +2955,7 @@
       name = "supports_preserve_symlinks_flag___supports_preserve_symlinks_flag_1.0.0.tgz";
       path = fetchurl {
         name = "supports_preserve_symlinks_flag___supports_preserve_symlinks_flag_1.0.0.tgz";
-        url  = "https://registry.yarnpkg.com/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz";
+        url = "https://registry.yarnpkg.com/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz";
         sha512 = "ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==";
       };
     }
@@ -2957,7 +2963,7 @@
       name = "tapable___tapable_2.2.1.tgz";
       path = fetchurl {
         name = "tapable___tapable_2.2.1.tgz";
-        url  = "https://registry.yarnpkg.com/tapable/-/tapable-2.2.1.tgz";
+        url = "https://registry.yarnpkg.com/tapable/-/tapable-2.2.1.tgz";
         sha512 = "GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==";
       };
     }
@@ -2965,7 +2971,7 @@
       name = "tar_fs___tar_fs_2.1.1.tgz";
       path = fetchurl {
         name = "tar_fs___tar_fs_2.1.1.tgz";
-        url  = "https://registry.yarnpkg.com/tar-fs/-/tar-fs-2.1.1.tgz";
+        url = "https://registry.yarnpkg.com/tar-fs/-/tar-fs-2.1.1.tgz";
         sha512 = "V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==";
       };
     }
@@ -2973,7 +2979,7 @@
       name = "tar_stream___tar_stream_2.2.0.tgz";
       path = fetchurl {
         name = "tar_stream___tar_stream_2.2.0.tgz";
-        url  = "https://registry.yarnpkg.com/tar-stream/-/tar-stream-2.2.0.tgz";
+        url = "https://registry.yarnpkg.com/tar-stream/-/tar-stream-2.2.0.tgz";
         sha512 = "ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==";
       };
     }
@@ -2981,7 +2987,7 @@
       name = "terser_webpack_plugin___terser_webpack_plugin_5.3.10.tgz";
       path = fetchurl {
         name = "terser_webpack_plugin___terser_webpack_plugin_5.3.10.tgz";
-        url  = "https://registry.yarnpkg.com/terser-webpack-plugin/-/terser-webpack-plugin-5.3.10.tgz";
+        url = "https://registry.yarnpkg.com/terser-webpack-plugin/-/terser-webpack-plugin-5.3.10.tgz";
         sha512 = "BKFPWlPDndPs+NGGCr1U59t0XScL5317Y0UReNrHaw9/FwhPENlq6bfgs+4yPfyP51vqC1bQ4rp1EfXW5ZSH9w==";
       };
     }
@@ -2989,7 +2995,7 @@
       name = "terser___terser_5.27.0.tgz";
       path = fetchurl {
         name = "terser___terser_5.27.0.tgz";
-        url  = "https://registry.yarnpkg.com/terser/-/terser-5.27.0.tgz";
+        url = "https://registry.yarnpkg.com/terser/-/terser-5.27.0.tgz";
         sha512 = "bi1HRwVRskAjheeYl291n3JC4GgO/Ty4z1nVs5AAsmonJulGxpSektecnNedrwK9C7vpvVtcX3cw00VSLt7U2A==";
       };
     }
@@ -2997,7 +3003,7 @@
       name = "text_table___text_table_0.2.0.tgz";
       path = fetchurl {
         name = "text_table___text_table_0.2.0.tgz";
-        url  = "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz";
+        url = "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz";
         sha512 = "N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==";
       };
     }
@@ -3005,7 +3011,7 @@
       name = "tmp_promise___tmp_promise_3.0.3.tgz";
       path = fetchurl {
         name = "tmp_promise___tmp_promise_3.0.3.tgz";
-        url  = "https://registry.yarnpkg.com/tmp-promise/-/tmp-promise-3.0.3.tgz";
+        url = "https://registry.yarnpkg.com/tmp-promise/-/tmp-promise-3.0.3.tgz";
         sha512 = "RwM7MoPojPxsOBYnyd2hy0bxtIlVrihNs9pj5SUvY8Zz1sQcQG2tG1hSr8PDxfgEB8RNKDhqbIlroIarSNDNsQ==";
       };
     }
@@ -3013,7 +3019,7 @@
       name = "tmp___tmp_0.2.1.tgz";
       path = fetchurl {
         name = "tmp___tmp_0.2.1.tgz";
-        url  = "https://registry.yarnpkg.com/tmp/-/tmp-0.2.1.tgz";
+        url = "https://registry.yarnpkg.com/tmp/-/tmp-0.2.1.tgz";
         sha512 = "76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==";
       };
     }
@@ -3021,7 +3027,7 @@
       name = "to_regex_range___to_regex_range_5.0.1.tgz";
       path = fetchurl {
         name = "to_regex_range___to_regex_range_5.0.1.tgz";
-        url  = "https://registry.yarnpkg.com/to-regex-range/-/to-regex-range-5.0.1.tgz";
+        url = "https://registry.yarnpkg.com/to-regex-range/-/to-regex-range-5.0.1.tgz";
         sha512 = "65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==";
       };
     }
@@ -3029,7 +3035,7 @@
       name = "ts_loader___ts_loader_9.5.1.tgz";
       path = fetchurl {
         name = "ts_loader___ts_loader_9.5.1.tgz";
-        url  = "https://registry.yarnpkg.com/ts-loader/-/ts-loader-9.5.1.tgz";
+        url = "https://registry.yarnpkg.com/ts-loader/-/ts-loader-9.5.1.tgz";
         sha512 = "rNH3sK9kGZcH9dYzC7CewQm4NtxJTjSEVRJ2DyBZR7f8/wcta+iV44UPCXc5+nzDzivKtlzV6c9P4e+oFhDLYg==";
       };
     }
@@ -3037,7 +3043,7 @@
       name = "tslib___tslib_1.14.1.tgz";
       path = fetchurl {
         name = "tslib___tslib_1.14.1.tgz";
-        url  = "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz";
+        url = "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz";
         sha512 = "Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==";
       };
     }
@@ -3045,7 +3051,7 @@
       name = "tsutils___tsutils_3.21.0.tgz";
       path = fetchurl {
         name = "tsutils___tsutils_3.21.0.tgz";
-        url  = "https://registry.yarnpkg.com/tsutils/-/tsutils-3.21.0.tgz";
+        url = "https://registry.yarnpkg.com/tsutils/-/tsutils-3.21.0.tgz";
         sha512 = "mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==";
       };
     }
@@ -3053,7 +3059,7 @@
       name = "tunnel_agent___tunnel_agent_0.6.0.tgz";
       path = fetchurl {
         name = "tunnel_agent___tunnel_agent_0.6.0.tgz";
-        url  = "https://registry.yarnpkg.com/tunnel-agent/-/tunnel-agent-0.6.0.tgz";
+        url = "https://registry.yarnpkg.com/tunnel-agent/-/tunnel-agent-0.6.0.tgz";
         sha512 = "McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==";
       };
     }
@@ -3061,7 +3067,7 @@
       name = "tunnel___tunnel_0.0.6.tgz";
       path = fetchurl {
         name = "tunnel___tunnel_0.0.6.tgz";
-        url  = "https://registry.yarnpkg.com/tunnel/-/tunnel-0.0.6.tgz";
+        url = "https://registry.yarnpkg.com/tunnel/-/tunnel-0.0.6.tgz";
         sha512 = "1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==";
       };
     }
@@ -3069,7 +3075,7 @@
       name = "type_check___type_check_0.4.0.tgz";
       path = fetchurl {
         name = "type_check___type_check_0.4.0.tgz";
-        url  = "https://registry.yarnpkg.com/type-check/-/type-check-0.4.0.tgz";
+        url = "https://registry.yarnpkg.com/type-check/-/type-check-0.4.0.tgz";
         sha512 = "XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==";
       };
     }
@@ -3077,7 +3083,7 @@
       name = "type_fest___type_fest_0.20.2.tgz";
       path = fetchurl {
         name = "type_fest___type_fest_0.20.2.tgz";
-        url  = "https://registry.yarnpkg.com/type-fest/-/type-fest-0.20.2.tgz";
+        url = "https://registry.yarnpkg.com/type-fest/-/type-fest-0.20.2.tgz";
         sha512 = "Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==";
       };
     }
@@ -3085,7 +3091,7 @@
       name = "typed_rest_client___typed_rest_client_1.8.11.tgz";
       path = fetchurl {
         name = "typed_rest_client___typed_rest_client_1.8.11.tgz";
-        url  = "https://registry.yarnpkg.com/typed-rest-client/-/typed-rest-client-1.8.11.tgz";
+        url = "https://registry.yarnpkg.com/typed-rest-client/-/typed-rest-client-1.8.11.tgz";
         sha512 = "5UvfMpd1oelmUPRbbaVnq+rHP7ng2cE4qoQkQeAqxRL6PklkxsM0g32/HL0yfvruK6ojQ5x8EE+HF4YV6DtuCA==";
       };
     }
@@ -3093,7 +3099,7 @@
       name = "typescript___typescript_4.9.5.tgz";
       path = fetchurl {
         name = "typescript___typescript_4.9.5.tgz";
-        url  = "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz";
+        url = "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz";
         sha512 = "1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==";
       };
     }
@@ -3101,7 +3107,7 @@
       name = "uc.micro___uc.micro_1.0.6.tgz";
       path = fetchurl {
         name = "uc.micro___uc.micro_1.0.6.tgz";
-        url  = "https://registry.yarnpkg.com/uc.micro/-/uc.micro-1.0.6.tgz";
+        url = "https://registry.yarnpkg.com/uc.micro/-/uc.micro-1.0.6.tgz";
         sha512 = "8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==";
       };
     }
@@ -3109,7 +3115,7 @@
       name = "underscore___underscore_1.13.6.tgz";
       path = fetchurl {
         name = "underscore___underscore_1.13.6.tgz";
-        url  = "https://registry.yarnpkg.com/underscore/-/underscore-1.13.6.tgz";
+        url = "https://registry.yarnpkg.com/underscore/-/underscore-1.13.6.tgz";
         sha512 = "+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A==";
       };
     }
@@ -3117,7 +3123,7 @@
       name = "undici_types___undici_types_5.26.5.tgz";
       path = fetchurl {
         name = "undici_types___undici_types_5.26.5.tgz";
-        url  = "https://registry.yarnpkg.com/undici-types/-/undici-types-5.26.5.tgz";
+        url = "https://registry.yarnpkg.com/undici-types/-/undici-types-5.26.5.tgz";
         sha512 = "JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==";
       };
     }
@@ -3125,7 +3131,7 @@
       name = "update_browserslist_db___update_browserslist_db_1.0.13.tgz";
       path = fetchurl {
         name = "update_browserslist_db___update_browserslist_db_1.0.13.tgz";
-        url  = "https://registry.yarnpkg.com/update-browserslist-db/-/update-browserslist-db-1.0.13.tgz";
+        url = "https://registry.yarnpkg.com/update-browserslist-db/-/update-browserslist-db-1.0.13.tgz";
         sha512 = "xebP81SNcPuNpPP3uzeW1NYXxI3rxyJzF3pD6sH4jE7o/IX+WtSpwnVU+qIsDPyk0d3hmFQ7mjqc6AtV604hbg==";
       };
     }
@@ -3133,7 +3139,7 @@
       name = "uri_js___uri_js_4.4.1.tgz";
       path = fetchurl {
         name = "uri_js___uri_js_4.4.1.tgz";
-        url  = "https://registry.yarnpkg.com/uri-js/-/uri-js-4.4.1.tgz";
+        url = "https://registry.yarnpkg.com/uri-js/-/uri-js-4.4.1.tgz";
         sha512 = "7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==";
       };
     }
@@ -3141,7 +3147,7 @@
       name = "url_join___url_join_4.0.1.tgz";
       path = fetchurl {
         name = "url_join___url_join_4.0.1.tgz";
-        url  = "https://registry.yarnpkg.com/url-join/-/url-join-4.0.1.tgz";
+        url = "https://registry.yarnpkg.com/url-join/-/url-join-4.0.1.tgz";
         sha512 = "jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==";
       };
     }
@@ -3149,7 +3155,7 @@
       name = "util_deprecate___util_deprecate_1.0.2.tgz";
       path = fetchurl {
         name = "util_deprecate___util_deprecate_1.0.2.tgz";
-        url  = "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz";
+        url = "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz";
         sha512 = "EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==";
       };
     }
@@ -3157,7 +3163,7 @@
       name = "vsce___vsce_2.15.0.tgz";
       path = fetchurl {
         name = "vsce___vsce_2.15.0.tgz";
-        url  = "https://registry.yarnpkg.com/vsce/-/vsce-2.15.0.tgz";
+        url = "https://registry.yarnpkg.com/vsce/-/vsce-2.15.0.tgz";
         sha512 = "P8E9LAZvBCQnoGoizw65JfGvyMqNGlHdlUXD1VAuxtvYAaHBKLBdKPnpy60XKVDAkQCfmMu53g+gq9FM+ydepw==";
       };
     }
@@ -3165,7 +3171,7 @@
       name = "vscode_jsonrpc___vscode_jsonrpc_8.2.0.tgz";
       path = fetchurl {
         name = "vscode_jsonrpc___vscode_jsonrpc_8.2.0.tgz";
-        url  = "https://registry.yarnpkg.com/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz";
+        url = "https://registry.yarnpkg.com/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz";
         sha512 = "C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==";
       };
     }
@@ -3173,7 +3179,7 @@
       name = "vscode_languageclient___vscode_languageclient_9.0.1.tgz";
       path = fetchurl {
         name = "vscode_languageclient___vscode_languageclient_9.0.1.tgz";
-        url  = "https://registry.yarnpkg.com/vscode-languageclient/-/vscode-languageclient-9.0.1.tgz";
+        url = "https://registry.yarnpkg.com/vscode-languageclient/-/vscode-languageclient-9.0.1.tgz";
         sha512 = "JZiimVdvimEuHh5olxhxkht09m3JzUGwggb5eRUkzzJhZ2KjCN0nh55VfiED9oez9DyF8/fz1g1iBV3h+0Z2EA==";
       };
     }
@@ -3181,7 +3187,7 @@
       name = "vscode_languageserver_protocol___vscode_languageserver_protocol_3.17.5.tgz";
       path = fetchurl {
         name = "vscode_languageserver_protocol___vscode_languageserver_protocol_3.17.5.tgz";
-        url  = "https://registry.yarnpkg.com/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.5.tgz";
+        url = "https://registry.yarnpkg.com/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.5.tgz";
         sha512 = "mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==";
       };
     }
@@ -3189,7 +3195,7 @@
       name = "vscode_languageserver_types___vscode_languageserver_types_3.17.5.tgz";
       path = fetchurl {
         name = "vscode_languageserver_types___vscode_languageserver_types_3.17.5.tgz";
-        url  = "https://registry.yarnpkg.com/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz";
+        url = "https://registry.yarnpkg.com/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz";
         sha512 = "Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==";
       };
     }
@@ -3197,7 +3203,7 @@
       name = "watchpack___watchpack_2.4.0.tgz";
       path = fetchurl {
         name = "watchpack___watchpack_2.4.0.tgz";
-        url  = "https://registry.yarnpkg.com/watchpack/-/watchpack-2.4.0.tgz";
+        url = "https://registry.yarnpkg.com/watchpack/-/watchpack-2.4.0.tgz";
         sha512 = "Lcvm7MGST/4fup+ifyKi2hjyIAwcdI4HRgtvTpIUxBRhB+RFtUh8XtDOxUfctVCnhVi+QQj49i91OyvzkJl6cg==";
       };
     }
@@ -3205,7 +3211,7 @@
       name = "webpack_cli___webpack_cli_5.1.4.tgz";
       path = fetchurl {
         name = "webpack_cli___webpack_cli_5.1.4.tgz";
-        url  = "https://registry.yarnpkg.com/webpack-cli/-/webpack-cli-5.1.4.tgz";
+        url = "https://registry.yarnpkg.com/webpack-cli/-/webpack-cli-5.1.4.tgz";
         sha512 = "pIDJHIEI9LR0yxHXQ+Qh95k2EvXpWzZ5l+d+jIo+RdSm9MiHfzazIxwwni/p7+x4eJZuvG1AJwgC4TNQ7NRgsg==";
       };
     }
@@ -3213,7 +3219,7 @@
       name = "webpack_merge___webpack_merge_5.10.0.tgz";
       path = fetchurl {
         name = "webpack_merge___webpack_merge_5.10.0.tgz";
-        url  = "https://registry.yarnpkg.com/webpack-merge/-/webpack-merge-5.10.0.tgz";
+        url = "https://registry.yarnpkg.com/webpack-merge/-/webpack-merge-5.10.0.tgz";
         sha512 = "+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==";
       };
     }
@@ -3221,7 +3227,7 @@
       name = "webpack_sources___webpack_sources_3.2.3.tgz";
       path = fetchurl {
         name = "webpack_sources___webpack_sources_3.2.3.tgz";
-        url  = "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-3.2.3.tgz";
+        url = "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-3.2.3.tgz";
         sha512 = "/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==";
       };
     }
@@ -3229,7 +3235,7 @@
       name = "webpack___webpack_5.89.0.tgz";
       path = fetchurl {
         name = "webpack___webpack_5.89.0.tgz";
-        url  = "https://registry.yarnpkg.com/webpack/-/webpack-5.89.0.tgz";
+        url = "https://registry.yarnpkg.com/webpack/-/webpack-5.89.0.tgz";
         sha512 = "qyfIC10pOr70V+jkmud8tMfajraGCZMBWJtrmuBymQKCrLTRejBI8STDp1MCyZu/QTdZSeacCQYpYNQVOzX5kw==";
       };
     }
@@ -3237,7 +3243,7 @@
       name = "which___which_2.0.2.tgz";
       path = fetchurl {
         name = "which___which_2.0.2.tgz";
-        url  = "https://registry.yarnpkg.com/which/-/which-2.0.2.tgz";
+        url = "https://registry.yarnpkg.com/which/-/which-2.0.2.tgz";
         sha512 = "BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==";
       };
     }
@@ -3245,7 +3251,7 @@
       name = "wildcard___wildcard_2.0.1.tgz";
       path = fetchurl {
         name = "wildcard___wildcard_2.0.1.tgz";
-        url  = "https://registry.yarnpkg.com/wildcard/-/wildcard-2.0.1.tgz";
+        url = "https://registry.yarnpkg.com/wildcard/-/wildcard-2.0.1.tgz";
         sha512 = "CC1bOL87PIWSBhDcTrdeLo6eGT7mCFtrg0uIJtqJUFyK+eJnzl8A1niH56uu7KMa5XFrtiV+AQuHO3n7DsHnLQ==";
       };
     }
@@ -3253,7 +3259,7 @@
       name = "workerpool___workerpool_6.2.1.tgz";
       path = fetchurl {
         name = "workerpool___workerpool_6.2.1.tgz";
-        url  = "https://registry.yarnpkg.com/workerpool/-/workerpool-6.2.1.tgz";
+        url = "https://registry.yarnpkg.com/workerpool/-/workerpool-6.2.1.tgz";
         sha512 = "ILEIE97kDZvF9Wb9f6h5aXK4swSlKGUcOEGiIYb2OOu/IrDU9iwj0fD//SsA6E5ibwJxpEvhullJY4Sl4GcpAw==";
       };
     }
@@ -3261,7 +3267,7 @@
       name = "wrap_ansi___wrap_ansi_7.0.0.tgz";
       path = fetchurl {
         name = "wrap_ansi___wrap_ansi_7.0.0.tgz";
-        url  = "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz";
+        url = "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz";
         sha512 = "YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==";
       };
     }
@@ -3269,7 +3275,7 @@
       name = "wrappy___wrappy_1.0.2.tgz";
       path = fetchurl {
         name = "wrappy___wrappy_1.0.2.tgz";
-        url  = "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz";
+        url = "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz";
         sha512 = "l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==";
       };
     }
@@ -3277,7 +3283,7 @@
       name = "xml2js___xml2js_0.4.23.tgz";
       path = fetchurl {
         name = "xml2js___xml2js_0.4.23.tgz";
-        url  = "https://registry.yarnpkg.com/xml2js/-/xml2js-0.4.23.tgz";
+        url = "https://registry.yarnpkg.com/xml2js/-/xml2js-0.4.23.tgz";
         sha512 = "ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==";
       };
     }
@@ -3285,7 +3291,7 @@
       name = "xml2js___xml2js_0.5.0.tgz";
       path = fetchurl {
         name = "xml2js___xml2js_0.5.0.tgz";
-        url  = "https://registry.yarnpkg.com/xml2js/-/xml2js-0.5.0.tgz";
+        url = "https://registry.yarnpkg.com/xml2js/-/xml2js-0.5.0.tgz";
         sha512 = "drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==";
       };
     }
@@ -3293,7 +3299,7 @@
       name = "xmlbuilder___xmlbuilder_11.0.1.tgz";
       path = fetchurl {
         name = "xmlbuilder___xmlbuilder_11.0.1.tgz";
-        url  = "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-11.0.1.tgz";
+        url = "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-11.0.1.tgz";
         sha512 = "fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==";
       };
     }
@@ -3301,7 +3307,7 @@
       name = "y18n___y18n_5.0.8.tgz";
       path = fetchurl {
         name = "y18n___y18n_5.0.8.tgz";
-        url  = "https://registry.yarnpkg.com/y18n/-/y18n-5.0.8.tgz";
+        url = "https://registry.yarnpkg.com/y18n/-/y18n-5.0.8.tgz";
         sha512 = "0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==";
       };
     }
@@ -3309,7 +3315,7 @@
       name = "yallist___yallist_4.0.0.tgz";
       path = fetchurl {
         name = "yallist___yallist_4.0.0.tgz";
-        url  = "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz";
+        url = "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz";
         sha512 = "3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==";
       };
     }
@@ -3317,7 +3323,7 @@
       name = "yargs_parser___yargs_parser_20.2.4.tgz";
       path = fetchurl {
         name = "yargs_parser___yargs_parser_20.2.4.tgz";
-        url  = "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.4.tgz";
+        url = "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.4.tgz";
         sha512 = "WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==";
       };
     }
@@ -3325,7 +3331,7 @@
       name = "yargs_parser___yargs_parser_20.2.9.tgz";
       path = fetchurl {
         name = "yargs_parser___yargs_parser_20.2.9.tgz";
-        url  = "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.9.tgz";
+        url = "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.9.tgz";
         sha512 = "y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==";
       };
     }
@@ -3333,7 +3339,7 @@
       name = "yargs_unparser___yargs_unparser_2.0.0.tgz";
       path = fetchurl {
         name = "yargs_unparser___yargs_unparser_2.0.0.tgz";
-        url  = "https://registry.yarnpkg.com/yargs-unparser/-/yargs-unparser-2.0.0.tgz";
+        url = "https://registry.yarnpkg.com/yargs-unparser/-/yargs-unparser-2.0.0.tgz";
         sha512 = "7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==";
       };
     }
@@ -3341,7 +3347,7 @@
       name = "yargs___yargs_16.2.0.tgz";
       path = fetchurl {
         name = "yargs___yargs_16.2.0.tgz";
-        url  = "https://registry.yarnpkg.com/yargs/-/yargs-16.2.0.tgz";
+        url = "https://registry.yarnpkg.com/yargs/-/yargs-16.2.0.tgz";
         sha512 = "D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==";
       };
     }
@@ -3349,7 +3355,7 @@
       name = "yauzl___yauzl_2.10.0.tgz";
       path = fetchurl {
         name = "yauzl___yauzl_2.10.0.tgz";
-        url  = "https://registry.yarnpkg.com/yauzl/-/yauzl-2.10.0.tgz";
+        url = "https://registry.yarnpkg.com/yauzl/-/yauzl-2.10.0.tgz";
         sha512 = "p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==";
       };
     }
@@ -3357,7 +3363,7 @@
       name = "yazl___yazl_2.5.1.tgz";
       path = fetchurl {
         name = "yazl___yazl_2.5.1.tgz";
-        url  = "https://registry.yarnpkg.com/yazl/-/yazl-2.5.1.tgz";
+        url = "https://registry.yarnpkg.com/yazl/-/yazl-2.5.1.tgz";
         sha512 = "phENi2PLiHnHb6QBVot+dJnaAZ0xosj7p3fWl+znIjBDlnMI2PsZCJZ306BPTFOaHf5qdDEI8x5qFrSOBN5vrw==";
       };
     }
@@ -3365,7 +3371,7 @@
       name = "yocto_queue___yocto_queue_0.1.0.tgz";
       path = fetchurl {
         name = "yocto_queue___yocto_queue_0.1.0.tgz";
-        url  = "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz";
+        url = "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz";
         sha512 = "rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==";
       };
     }

--- a/flake.nix
+++ b/flake.nix
@@ -2,228 +2,274 @@
   description = "VsCoq 2, a language server for Coq based on LSP";
 
   inputs = {
-
     flake-utils.url = "github:numtide/flake-utils";
 
-    coq-master = { url = "github:coq/coq/8152d125abb0fb7e8cbecf4bd6cd51d8d3e70d78"; }; # Should be kept in sync with PIN_COQ in CI workflow
-    coq-master.inputs.nixpkgs.follows = "nixpkgs";
-
+    coq-master = {
+      url = "github:coq/coq/8152d125abb0fb7e8cbecf4bd6cd51d8d3e70d78";
+      inputs.nixpkgs.follows = "nixpkgs";
+    }; # Should be kept in sync with PIN_COQ in CI workflow
   };
 
-  outputs = { self, nixpkgs, flake-utils, coq-master }:
-    flake-utils.lib.eachDefaultSystem (system:
-  
-   let vscoq_version = "2.1.2"; in
-   let coq = coq-master.packages.${system}; in
-   rec {
+  outputs = {
+    self,
+    nixpkgs,
+    flake-utils,
+    coq-master,
+  }:
+    flake-utils.lib.eachDefaultSystem (system: let
+      name = "vscoq-client";
+      vscodeExtPublisher = "maximedenes";
+      vscodeExtName = "vscoq";
+      vscodeExtUniqueId = "maximedenes.vscoq";
+      vscoq_version = "2.1.2";
+      coq = coq-master.packages.${system};
+    in rec {
+      formatter = nixpkgs.legacyPackages.${system}.alejandra;
 
-    packages.default = self.packages.${system}.vscoq-language-server-coq-8-19;
+      packages = {
+        default = self.packages.${system}.vscoq-language-server-coq-8-19;
 
-    packages.vscoq-language-server-coq-8-18 =
-      # Notice the reference to nixpkgs here.
-      with import nixpkgs { inherit system; };
-      let ocamlPackages = ocaml-ng.ocamlPackages_4_14; in
+        vscoq-language-server-coq-8-18 =
+          # Notice the reference to nixpkgs here.
+          with import nixpkgs {inherit system;}; let
+            ocamlPackages = ocaml-ng.ocamlPackages_4_14;
+          in
+            ocamlPackages.buildDunePackage {
+              duneVersion = "3";
+              pname = "vscoq-language-server";
+              version = vscoq_version;
+              src = ./language-server;
+              nativeBuildInputs = [
+                coq_8_18
+              ];
+              buildInputs =
+                [
+                  coq_8_18
+                  dune_3
+                ]
+                ++ (with coq.ocamlPackages; [
+                  lablgtk3-sourceview3
+                  glib
+                  gnome.adwaita-icon-theme
+                  wrapGAppsHook
+                  ocaml
+                  yojson
+                  zarith
+                  findlib
+                  ppx_inline_test
+                  ppx_assert
+                  ppx_sexp_conv
+                  ppx_deriving
+                  ppx_optcomp
+                  ppx_import
+                  sexplib
+                  ppx_yojson_conv
+                  lsp
+                  sel
+                ]);
+            };
 
-      ocamlPackages.buildDunePackage {
-        duneVersion = "3";
-        pname = "vscoq-language-server";
-        version = vscoq_version;
-        src = ./language-server;
-        nativeBuildInputs = [
-          coq_8_18
-        ];
-        buildInputs = [
-          coq_8_18
-          dune_3
-        ] ++ (with coq.ocamlPackages; [
-          lablgtk3-sourceview3
-          glib
-          gnome.adwaita-icon-theme
-          wrapGAppsHook
-          ocaml
-          yojson
-          zarith
-          findlib
-          ppx_inline_test
-          ppx_assert
-          ppx_sexp_conv
-          ppx_deriving
-          ppx_optcomp
-          ppx_import
-          sexplib
-          ppx_yojson_conv
-          lsp
-          sel
-        ]);
-      };
+        vscoq-language-server-coq-8-19 =
+          # Notice the reference to nixpkgs here.
+          with import nixpkgs {inherit system;}; let
+            ocamlPackages = ocaml-ng.ocamlPackages_4_14;
+          in
+            ocamlPackages.buildDunePackage {
+              duneVersion = "3";
+              pname = "vscoq-language-server";
+              version = vscoq_version;
+              src = ./language-server;
+              nativeBuildInputs = [
+                coq_8_19
+              ];
+              buildInputs =
+                [
+                  coq_8_19
+                  dune_3
+                ]
+                ++ (with coq.ocamlPackages; [
+                  lablgtk3-sourceview3
+                  glib
+                  gnome.adwaita-icon-theme
+                  wrapGAppsHook
+                  ocaml
+                  yojson
+                  zarith
+                  findlib
+                  ppx_inline_test
+                  ppx_assert
+                  ppx_sexp_conv
+                  ppx_deriving
+                  ppx_optcomp
+                  ppx_import
+                  sexplib
+                  ppx_yojson_conv
+                  lsp
+                  sel
+                ]);
+            };
 
-      packages.vscoq-language-server-coq-8-19 =
-      # Notice the reference to nixpkgs here.
-      with import nixpkgs { inherit system; };
-      let ocamlPackages = ocaml-ng.ocamlPackages_4_14; in
-      ocamlPackages.buildDunePackage {
-        duneVersion = "3";
-        pname = "vscoq-language-server";
-        version = vscoq_version;
-        src = ./language-server;
-        nativeBuildInputs = [
-          coq_8_19
-        ];
-        buildInputs = [
-          coq_8_19
-          dune_3
-        ] ++ (with coq.ocamlPackages; [
-          lablgtk3-sourceview3
-          glib
-          gnome.adwaita-icon-theme
-          wrapGAppsHook
-          ocaml
-          yojson
-          zarith
-          findlib
-          ppx_inline_test
-          ppx_assert
-          ppx_sexp_conv
-          ppx_deriving
-          ppx_optcomp
-          ppx_import
-          sexplib
-          ppx_yojson_conv
-          lsp
-          sel
-        ]);
-      };
+        vscoq-language-server-coq-master =
+          # Notice the reference to nixpkgs here.
+          with import nixpkgs {inherit system;}; let
+            ocamlPackages = ocaml-ng.ocamlPackages_4_14;
+          in
+            ocamlPackages.buildDunePackage {
+              duneVersion = "3";
+              pname = "vscoq-language-server";
+              version = vscoq_version;
+              src = ./language-server;
+              nativeBuildInputs = [
+                coq
+              ];
+              buildInputs =
+                [
+                  coq
+                  dune_3
+                ]
+                ++ (with coq.ocamlPackages; [
+                  lablgtk3-sourceview3
+                  glib
+                  gnome.adwaita-icon-theme
+                  wrapGAppsHook
+                  ocaml
+                  yojson
+                  zarith
+                  findlib
+                  ppx_inline_test
+                  ppx_assert
+                  ppx_sexp_conv
+                  ppx_deriving
+                  ppx_optcomp
+                  ppx_import
+                  sexplib
+                  ppx_yojson_conv
+                  lsp
+                  sel
+                ]);
+            };
 
-    packages.vscoq-language-server-coq-master =
-      # Notice the reference to nixpkgs here.
-      with import nixpkgs { inherit system; };
-      let ocamlPackages = ocaml-ng.ocamlPackages_4_14; in
-      ocamlPackages.buildDunePackage {
-        duneVersion = "3";
-        pname = "vscoq-language-server";
-        version = vscoq_version;
-        src = ./language-server;
-        nativeBuildInputs = [
-          coq
-        ];
-        buildInputs = [
-          coq
-          dune_3
-        ] ++ (with coq.ocamlPackages; [
-          lablgtk3-sourceview3
-          glib
-          gnome.adwaita-icon-theme
-          wrapGAppsHook
-          ocaml
-          yojson
-          zarith
-          findlib
-          ppx_inline_test
-          ppx_assert
-          ppx_sexp_conv
-          ppx_deriving
-          ppx_optcomp
-          ppx_import
-          sexplib
-          ppx_yojson_conv
-          lsp
-          sel
-        ]);
-      };
+        vscoq-client = with import nixpkgs {inherit system;}; let
+          yarn_deps = name: (path: (mkYarnModules {
+            pname = "${name}_yarn_deps";
+            version = vscoq_version;
+            packageJSON = ./${path}/package.json;
+            yarnLock = ./${path}/yarn.lock;
+            yarnNix = ./${path}/yarn.nix;
+          }));
 
-    packages.vscoq-client =
-      with import nixpkgs { inherit system; };
+          client_deps = yarn_deps "client" /client;
+          goal_view_ui_deps = yarn_deps "goal_ui" /client/goal-view-ui;
+          search_ui_deps = yarn_deps "search_ui" /client/search-ui;
 
-      let yarn_deps = (name: (path: (mkYarnModules {
-        pname = "${name}_yarn_deps";
-        version = vscoq_version;
-        packageJSON = ./${path}/package.json;
-        yarnLock = ./${path}/yarn.lock;
-        yarnNix = ./${path}/yarn.nix;
-      }))); in
+          link_deps = x: (p: ''
+            ln -s ${x}/node_modules ${p}
+            export PATH=${x}/node_modules/.bin:$PATH
+          '');
 
-      let client_deps = yarn_deps "client" /client; in
-      let goal_view_ui_deps = yarn_deps "goal_ui" /client/goal-view-ui; in
-      let search_ui_deps = yarn_deps "search_ui" /client/search-ui; in
-      let link_deps = (x: (p: (''
-        ln -s ${x}/node_modules ${p}
-        export PATH=${x}/node_modules/.bin:$PATH
-      ''))); in
-      let links = [
-        (link_deps client_deps ".")
-        (link_deps goal_view_ui_deps "./goal-view-ui")
-        (link_deps search_ui_deps "./search-ui")
-      ]; in
-      let cmds = builtins.concatStringsSep "\n" links; in
+          links = [
+            (link_deps client_deps ".")
+            (link_deps goal_view_ui_deps "./goal-view-ui")
+            (link_deps search_ui_deps "./search-ui")
+          ];
 
-      stdenv.mkDerivation rec {
+          cmds = builtins.concatStringsSep "\n" links;
 
-        name = "vscoq-client";
-        src = ./client;
+          src = ./client;
 
-        nativeBuildInputs = [
-          nodejs
-          yarn
-        ] ++ [client_deps goal_view_ui_deps search_ui_deps];
+          nativeBuildInputs =
+            [
+              nodejs
+              yarn
+            ]
+            ++ [client_deps goal_view_ui_deps search_ui_deps];
 
-        buildPhase = cmds + ''
-          cd goal-view-ui
-          yarn run build
-          cd ../search-ui
-          yarn run build
-          cd ..
-          webpack --mode=production --devtool hidden-source-map
-          bash -c "yes y | vsce package"
-          mv *.vsix vscoq-client.vsix
-          mkdir -p $out/bin
-          cp ./vscoq-client.vsix $out/bin
-        '';
+          installPrefix = "share/vscode/extensions/${vscodeExtUniqueId}";
+        in {
+          extension = pkgs.vscode-utils.buildVscodeExtension {
+            inherit name vscodeExtName vscodeExtPublisher vscodeExtUniqueId src nativeBuildInputs;
+            version = vscoq_version;
 
-    };
+            buildPhase =
+              cmds
+              + ''
+                cd goal-view-ui
+                yarn run build
+                cd ../search-ui
+                yarn run build
+                cd ..
+                webpack --mode=production --devtool hidden-source-map
+              '';
+          };
+          vsix_archive = stdenv.mkDerivation {
+            name = "vscoq-client-vsix";
 
-    devShells.vscoq-client = 
-      with import nixpkgs { inherit system; };
-      mkShell {
-        buildInputs = self.packages.${system}.vscoq-client.buildInputs;
-      };
+            unpackPhase = ''
+              cp -r ${self.packages.${system}.vscoq-client.extension}/share/vscode/extensions/${vscodeExtUniqueId}/* .
+              ls -alt
+              pwd
+            '';
 
-    devShells.vscoq-language-server-coq-8-18 = 
-        with import nixpkgs { inherit system; };
-        let ocamlPackages = ocaml-ng.ocamlPackages_4_14; in
-        mkShell {
-            buildInputs =
-            self.packages.${system}.vscoq-language-server-coq-8-18.buildInputs;
+            nativeBuildInputs = [
+              self.packages.${system}.vscoq-client.extension
+              client_deps
+              nodejs
+              yarn
+            ];
+
+            buildPhase = ''
+              export PATH=${client_deps}/node_modules/.bin:$PATH
+              bash -c "yes y | vsce package"
+              mkdir -p $out/share/vscode/extensions
+              cp *.vsix $out/share/vscode/extensions
+            '';
+          };
         };
-        
-    devShells.vscoq-language-server-coq-8-19 = 
-      with import nixpkgs { inherit system; };
-      let ocamlPackages = ocaml-ng.ocamlPackages_4_14; in
-      mkShell {
-        buildInputs =
-          self.packages.${system}.vscoq-language-server-coq-8-19.buildInputs;
-      };
-    
-    devShells.vscoq-language-server-coq-master = 
-      with import nixpkgs { inherit system; };
-      let ocamlPackages = ocaml-ng.ocamlPackages_4_14; in
-      mkShell {
-        buildInputs =
-          self.packages.${system}.vscoq-language-server-coq-master.buildInputs
-          ++ (with ocamlPackages; [
-            ocaml-lsp
-          ]);
       };
 
-    devShells.default = 
-      with import nixpkgs { inherit system; };
-      let ocamlPackages = ocaml-ng.ocamlPackages_4_14; in
-      mkShell {
-        buildInputs =
-          self.packages.${system}.vscoq-language-server-coq-8-19.buildInputs
-          ++ (with ocamlPackages; [
-            ocaml-lsp
-          ]);
-      };
+      devShells = {
+        vscoq-client = with import nixpkgs {inherit system;};
+          mkShell {
+            buildInputs = self.packages.${system}.vscoq-client.extension.buildInputs;
+          };
 
-  });
+        vscoq-language-server-coq-8-18 = with import nixpkgs {inherit system;}; let
+          ocamlPackages = ocaml-ng.ocamlPackages_4_14;
+        in
+          mkShell {
+            buildInputs =
+              self.packages.${system}.vscoq-language-server-coq-8-18.buildInputs;
+          };
+
+        vscoq-language-server-coq-8-19 = with import nixpkgs {inherit system;}; let
+          ocamlPackages = ocaml-ng.ocamlPackages_4_14;
+        in
+          mkShell {
+            buildInputs =
+              self.packages.${system}.vscoq-language-server-coq-8-19.buildInputs;
+          };
+
+        vscoq-language-server-coq-master = with import nixpkgs {inherit system;}; let
+          ocamlPackages = ocaml-ng.ocamlPackages_4_14;
+        in
+          mkShell {
+            buildInputs =
+              self.packages.${system}.vscoq-language-server-coq-master.buildInputs
+              ++ (with ocamlPackages; [
+                ocaml-lsp
+              ]);
+          };
+
+        default = with import nixpkgs {inherit system;}; let
+          ocamlPackages = ocaml-ng.ocamlPackages_4_14;
+        in
+          mkShell {
+            buildInputs =
+              self.packages.${system}.vscoq-language-server-coq-8-19.buildInputs
+              ++ (with ocamlPackages; [
+                ocaml-lsp
+              ]);
+          };
+      };
+    });
 }


### PR DESCRIPTION
This pull request adds two new outputs, packages.${system}.vscoq-client.[extension, vsix_archive].

The `extension` derivation builds the out folder in such a way that this derivation can be passed to vscode in Nix to automatically load it as an extension. Specifically, the source (including webpack results in the dist folder) are placed in $out/share/vscode/extensions/maximedenes.vscoq.
This is very useful for NixOS users or even people who use a shell.nix to configure their development environment.

The `vsix_archive` derivation builds the .vsix and places it in $out/share/vscode/extensions.

This PR also adds the lightweight Alejandra formatter output in flake.nix, which is automatically picked up by nix when running the command `nix fmt`. This is useful for two reasons:
1. It helps keep the code style consistent in the long flake.nix file.
2. It lets us use `nix fmt` in CI, which avoids failing CI when whitespace or other insignificant changes occur in the generated yarn.nix files.