### PR TITLE
Fix errors when recovering from interp-error

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -8,17 +8,17 @@
         ]
       },
       "locked": {
-        "lastModified": 1717586410,
-        "narHash": "sha256-LGzKrJkT8YSVxwvoC1zD4KFqqj3a8HIVBB5LCqxsxlU=",
+        "lastModified": 1719227091,
+        "narHash": "sha256-E+umUAkUuyLyK7L4b1vCddqZRKGZw6bL18IaOrJHsjo=",
         "owner": "coq",
         "repo": "coq",
-        "rev": "72b053e90e23c7085316fff809a60d5e195c3c32",
+        "rev": "e139cf972cf2a876583ebbf5a19ffd419828116b",
         "type": "github"
       },
       "original": {
         "owner": "coq",
         "repo": "coq",
-        "rev": "72b053e90e23c7085316fff809a60d5e195c3c32",
+        "rev": "e139cf972cf2a876583ebbf5a19ffd419828116b",
         "type": "github"
       }
     },

--- a/language-server/dm/executionManager.ml
+++ b/language-server/dm/executionManager.ml
@@ -168,11 +168,9 @@ let interp_error_recovery strategy st : Vernacstate.t =
           Vernacstate.Declare.set (lemmas,program) [@ocaml.warning "-3"];
           let interp = Vernacstate.Interp.freeze_interp_state () in
           { st with interp }
-        | Error(_,_) -> 
-          (* let loc = Loc.get_loc info in
-          let msg = CErrors.iprint (e, info) in
-          let status = error loc msg st in
-          let st = interp_error_recovery error_recovery st in *)
+        | Error (Sys.Break, _ as exn) ->
+          Exninfo.iraise exn
+        | Error(_,_) ->
           st
 
 (* just a wrapper around vernac interp *)


### PR DESCRIPTION
Just add an error guard, this prevents the full server from crashing but since I only send the original state could lead to some undesired effects.
See [here](https://coq.zulipchat.com/#narrow/stream/237662-VsCoq-devs-.26-users/topic/coq.20language.20server.20repeated.20crashes).

Closes #634 
