### PR TITLE
[parser] use the loc of the prev sentence to feed the parser

### DIFF
--- a/language-server/dm/document.ml
+++ b/language-server/dm/document.ml
@@ -348,7 +348,8 @@ let rec parse_more ?loc synterp_state stream raw parsed parsed_comments errors =
     let stop = Stream.count stream in
     let parsing_error = { msg; start; stop; qf} in
     let errors = parsing_error :: errors in
-    parse_more synterp_state stream raw parsed parsed_comments errors
+    (* TODO: we could count the \n between start and stop and increase Loc.line_nb *)
+    parse_more ?loc synterp_state stream raw parsed parsed_comments errors
   in
   let start = Stream.count stream in
   log @@ "Start of parse is: " ^ (string_of_int start);


### PR DESCRIPTION
In this way the line number in the loc is not reset to 0. This has no use internally, since the document holds the text and computes line number correctly, but Coq code and plugins may want to display a loc (with a correct line number).

Note that the char-number is correct, since it comes from the stream, apparently.

This makes errors reported by Coq-Elpi more precise.