### PR TITLE
[outline] list alien, named, symbols

### DIFF
--- a/language-server/dm/document.ml
+++ b/language-server/dm/document.ml
@@ -25,6 +25,7 @@ module SM = Map.Make (Stateid)
 type proof_block_type =
   | TheoremKind of Decls.theorem_kind
   | DefinitionType of Decls.definition_object_kind
+  | Other
 
 type outline_element = {
   id: sentence_id;
@@ -140,6 +141,7 @@ let record_outline document id (ast : Synterp.vernac_control_entry) classif (out
   | VtSideff (names, _) ->
     let vernac_gen_expr = ast.v.expr in
     let type_ = match vernac_gen_expr with
+      | VernacSynterp (Synterp.EVernacExtend _) when names <> [] -> Some Other
       | VernacSynterp _ -> None
       | VernacSynPure pure -> 
         match pure with

--- a/language-server/dm/document.ml
+++ b/language-server/dm/document.ml
@@ -118,19 +118,18 @@ let record_outline document id (ast : Synterp.vernac_control_entry) classif (out
   match classif with
   | VtStartProof (_, names) ->
     let vernac_gen_expr = ast.v.expr in
-    let type_ = match vernac_gen_expr with
-      | VernacSynterp _ -> None
+    let type_, statement = match vernac_gen_expr with
+      | VernacSynterp _ -> None, ""
       | VernacSynPure pure -> 
         match pure with
-        | Vernacexpr.VernacStartTheoremProof (kind, _) -> Some (TheoremKind kind)
-        | Vernacexpr.VernacDefinition ((_, def), _, _) -> Some (DefinitionType def)
-        | _ -> None
+        | Vernacexpr.VernacStartTheoremProof (kind, _) -> Some (TheoremKind kind), "theorem"
+        | Vernacexpr.VernacDefinition ((_, def), _, _) -> Some (DefinitionType def), "definition"
+        | _ -> None, ""
     in
     let name = match names with
     |[] -> "default"
     | n :: _ -> Names.Id.to_string n 
     in
-    let statement = "" in
     begin match type_ with
     | None -> outline
     | Some type_ ->
@@ -140,20 +139,19 @@ let record_outline document id (ast : Synterp.vernac_control_entry) classif (out
     end
   | VtSideff (names, _) ->
     let vernac_gen_expr = ast.v.expr in
-    let type_ = match vernac_gen_expr with
-      | VernacSynterp (Synterp.EVernacExtend _) when names <> [] -> Some Other
-      | VernacSynterp _ -> None
+    let type_, statement = match vernac_gen_expr with
+      | VernacSynterp (Synterp.EVernacExtend _) when names <> [] -> Some Other, "external"
+      | VernacSynterp _ -> None, ""
       | VernacSynPure pure -> 
         match pure with
-        | Vernacexpr.VernacStartTheoremProof (kind, _) -> Some (TheoremKind kind)
-        | Vernacexpr.VernacDefinition ((_, def), _, _) -> Some (DefinitionType def)
-        | _ -> None
+        | Vernacexpr.VernacStartTheoremProof (kind, _) -> Some (TheoremKind kind), "theroem"
+        | Vernacexpr.VernacDefinition ((_, def), _, _) -> Some (DefinitionType def), "definition"
+        | _ -> None, ""
     in
     let name = match names with
     |[] -> "default"
     | n :: _ -> Names.Id.to_string n 
     in
-    let statement = "" in
     begin match type_ with
     | None -> outline
     | Some type_ ->

--- a/language-server/dm/document.mli
+++ b/language-server/dm/document.mli
@@ -25,6 +25,7 @@ type document
 type proof_block_type =
   | TheoremKind of Decls.theorem_kind
   | DefinitionType of Decls.definition_object_kind
+  | Other
 
 type outline_element = {
     id: sentence_id;

--- a/language-server/dm/documentManager.ml
+++ b/language-server/dm/documentManager.ml
@@ -252,7 +252,8 @@ let get_document_symbols st =
     let Document.{name; statement; range; type_} = elem in
     let kind = begin match type_ with
     | TheoremKind _ -> SymbolKind.Function
-    | DefinitionType _ ->SymbolKind.Variable
+    | DefinitionType _ -> SymbolKind.Variable
+    | Other -> SymbolKind.Null
     end in
     DocumentSymbol.{name; detail=(Some statement); kind; range; selectionRange=range; children=None; deprecated=None; tags=None;}
   in


### PR DESCRIPTION
Coq has a framework to add vernacular commands and give their classification. The classification can carry names.
This PR displays "named side effects" in the outline.

In the screenshots we see commands defined in Elpi.

![Screenshot from 2024-07-16 14-42-39](https://github.com/user-attachments/assets/a66d119b-e533-4bfc-9c0f-188663f80412)
![Screenshot from 2024-07-16 14-42-56](https://github.com/user-attachments/assets/bc4a1836-a005-4af7-8522-814a7717efe2)
