### PR TITLE
allows newer ppx_yojson_conf version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        ocaml-compiler: [4.13.x]
+        ocaml-compiler: [4.14.x]
         coq: [8.18.0, 8.19.0, dev]
     runs-on: ${{ matrix.os }}
     steps:
@@ -136,7 +136,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        ocaml-compiler: [4.13.x]
+        ocaml-compiler: [4.14.x]
         profile: [dev, fatalwarnings]
     runs-on: ${{ matrix.os }}
     steps:

--- a/language-server/protocol/extProtocol.ml
+++ b/language-server/protocol/extProtocol.ml
@@ -15,6 +15,8 @@ open Lsp.Types
 open LspWrapper
 open Printing
 
+open Ppx_yojson_conv_lib.Yojson_conv.Primitives
+
 module Notification = struct
 
   module Client = struct

--- a/language-server/protocol/lspWrapper.ml
+++ b/language-server/protocol/lspWrapper.ml
@@ -15,6 +15,8 @@ open Lsp.Types
 open Sexplib.Std
 open Printing
 
+open Ppx_yojson_conv_lib.Yojson_conv.Primitives
+
 module Position = struct
 
   include Lsp.Types.Position

--- a/language-server/protocol/printing.ml
+++ b/language-server/protocol/printing.ml
@@ -13,6 +13,8 @@
 (**************************************************************************)
 open Util
 
+open Ppx_yojson_conv_lib.Yojson_conv.Primitives
+
 type pp_tag = string [@@deriving yojson]
 
 type block_type = Pp.block_type =

--- a/language-server/protocol/proofState.ml
+++ b/language-server/protocol/proofState.ml
@@ -14,6 +14,8 @@
 
 open Printing
 
+open Ppx_yojson_conv_lib.Yojson_conv.Primitives
+
 type goal = {
   id: int;
   hypotheses: pp list;

--- a/language-server/protocol/settings.ml
+++ b/language-server/protocol/settings.ml
@@ -12,6 +12,8 @@
 (*                                                                        *)
 (**************************************************************************)
 
+open Ppx_yojson_conv_lib.Yojson_conv.Primitives
+
 module DelegationMode = struct
 
 type t = 

--- a/language-server/vscoq-language-server.opam
+++ b/language-server/vscoq-language-server.opam
@@ -21,7 +21,6 @@ depends: [
   "ppx_inline_test"
   "ppx_assert"
   "ppx_sexp_conv"
-  "ppx_yojson_conv" {< "v0.16.0"}
   "ppx_deriving"
   "sexplib"
   "ppx_yojson_conv"

--- a/language-server/vscoq-language-server.opam
+++ b/language-server/vscoq-language-server.opam
@@ -11,7 +11,7 @@ build: [
   [ "dune" "build" "-p" name "-j" jobs ]
 ]
 depends: [
-  "ocaml" { >= "4.13.1" }
+  "ocaml" { >= "4.14" }
   "dune" { >= "3.5" }
   "coq-core" { ((>= "8.18" < "8.20") | (= "dev")) }
   "coq-stdlib" { ((>= "8.18" < "8.20") | (= "dev")) }


### PR DESCRIPTION
in newer ppx_yojson_conv versions apparently for deriving yojson types of primitives one has to include some declarations.
I was using v0.17 and this solved the compilation errors.

the opam file had a duplicate entry for the ppx_yojson_conv library. 🍤 
