### PR TITLE
Remove display goals from package.json

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -254,12 +254,6 @@
         "title": "Reset"
       },
       {
-        "command": "extension.coq.displayGoals",
-        "category": "Coq",
-        "title": "Display Goals",
-        "description": "Displays the goal view"
-      },
-      {
         "command": "extension.coq.query.search",
         "category": "Coq",
         "title": "Search",


### PR DESCRIPTION
The command has effectively been removed from the extension. Let's stop declaring as it is confusing to users.
See #837 