### PR TITLE
More complete document state request

### DIFF
--- a/language-server/dm/document.ml
+++ b/language-server/dm/document.ml
@@ -220,6 +220,13 @@ let code_lines_sorted_by_loc parsed =
     []  (* todo comments *)
    ]
 
+let code_lines_by_end_sorted_by_loc parsed =
+  List.sort compare_code_line @@ List.concat [
+    (List.map (fun (_,x) -> Sentence x) @@ LM.bindings parsed.sentences_by_end) ;
+    (List.map (fun (_,x) -> ParsingError x) @@ LM.bindings parsed.parsing_errors_by_end) ;
+    []  (* todo comments *)
+   ]
+
 let sentences_sorted_by_loc parsed =
   List.sort (fun ({start = s1} : sentence) {start = s2} -> s1 - s2) @@ List.map snd @@ SM.bindings parsed.sentences_by_id
 

--- a/language-server/dm/document.mli
+++ b/language-server/dm/document.mli
@@ -102,6 +102,7 @@ type code_line =
 
 val sentences : document -> sentence list
 val code_lines_sorted_by_loc : document -> code_line list
+val code_lines_by_end_sorted_by_loc : document -> code_line list
 val sentences_sorted_by_loc : document -> sentence list
 
 val get_sentence : document -> sentence_id -> sentence option

--- a/language-server/dm/documentManager.ml
+++ b/language-server/dm/documentManager.ml
@@ -613,7 +613,8 @@ module Internal = struct
     validate_document st
 
   let string_of_state st =
-    let code_lines = Document.code_lines_sorted_by_loc st.document in
+    let code_lines_by_id = Document.code_lines_sorted_by_loc st.document in
+    let code_lines_by_end = Document.code_lines_by_end_sorted_by_loc st.document in
     let string_of_state id =
       if ExecutionManager.is_executed st.execution_state id then "(executed)"
       else if ExecutionManager.is_remotely_executed st.execution_state id then "(executed in worker)"
@@ -626,6 +627,8 @@ module Internal = struct
         | ParsingError _ -> "(error)"
         | Comment _ -> "(comment)"
     in
-    String.concat "\n" @@ List.map string_of_item code_lines
+    let string_by_id = String.concat "\n" @@ List.map string_of_item code_lines_by_id in
+    let string_by_end = String.concat "\n" @@ List.map string_of_item code_lines_by_end in
+    String.concat "\n" ["Document using sentences_by_id map\n"; string_by_id; "\nDocument using sentences_by_end map\n"; string_by_end]
 
 end


### PR DESCRIPTION
Sometimes only one of the two data structures for sentences (sentences_by_id, sentences_by_end) is corrupted and causes bugs. It is helpful to display them both