### PR TITLE
feat: adding alt + shift click to expand all ellipsis goals

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,9 @@ We now support a document outline, which displays theorems and definitions in th
 
 Goals can now be ellided. First through the `"vscoq.goals.maxDepth"` setting which ellides a goal if the display becomes to large.
 Finally by clicking on the goal view as showcased here.
+The following modifiers can be used: 
+- ```Alt + Click```: open/close an ellipsis (only opens partially).
+- ```Shift + Alt + Click```: fully open an ellipsis (all children are also opened).
 
 ![](gif/goal-ellipsis.gif)
 

--- a/client/pp-display/src/pp.tsx
+++ b/client/pp-display/src/pp.tsx
@@ -3,7 +3,7 @@ import useResizeObserver from '@react-hook/resize-observer';
 import {ResizeObserverEntry} from '@juggle/resize-observer';
 import { v4 as uuid } from 'uuid';
 
-import { PpString, PpMode, BoxDisplay, Term, Break, Box, DisplayType, BreakInfo } from './types';
+import { PpString, PpMode, BoxDisplay, Term, Break, Box, DisplayType, BreakInfo, HideStates } from './types';
 import PpBox from './pp-box';
 
 import classes from './Pp.module.css';
@@ -105,7 +105,7 @@ const ppDisplay : FunctionComponent<PpProps> = (props) => {
         const id = uuid();
         switch(pp[0]) {
             case 'Ppcmd_empty':
-                console.error('Recieved PpTag with empty');
+                console.error('Received PpTag with empty');
                 return null;
             case 'Ppcmd_string':
                 return {
@@ -123,10 +123,10 @@ const ppDisplay : FunctionComponent<PpProps> = (props) => {
                     boxChildren: flattenGlue(pp[1], mode, indent, id, depth + 1)
                 } as Box;
             case 'Ppcmd_force_newline':
-                console.error('Recieved PpTag with fnl');
+                console.error('Received PpTag with fnl');
                 return null;
             case 'Ppcmd_comment':
-                console.error('Recieved PpTag with comment');
+                console.error('Received PpTag with comment');
                 return null;
             case 'Ppcmd_box':
                 const m = pp[1][0];
@@ -140,10 +140,10 @@ const ppDisplay : FunctionComponent<PpProps> = (props) => {
                     boxChildren: getBoxChildren(pp[2], m, i, id, depth + 1)
                 } as Box;
             case 'Ppcmd_tag':
-                console.error('Recieved PpTag with tag');
+                console.error('Received PpTag with tag');
                 return null;
             case 'Ppcmd_print_break':
-                console.error('Recieved PpTag with br');
+                console.error('Received PpTag with br');
                 return null;
         }
     };
@@ -349,7 +349,7 @@ const ppDisplay : FunctionComponent<PpProps> = (props) => {
                         id={displayState.display.id}
                         coqCss={coqCss}
                         depth={0}
-                        hide={false}
+                        parentHide={HideStates.UNHIDE}
                         hovered={hovered}
                         maxDepth={maxDepth}
                         classList={[]}

--- a/client/pp-display/src/types.ts
+++ b/client/pp-display/src/types.ts
@@ -8,6 +8,12 @@ export enum PpMode {
     hovBox = "Pp_hovbox"
 }
 
+export enum HideStates {
+  HIDE, // Hide self and all below
+  UNHIDE, // Do not hide self, but set nothing for children
+  EXPAND_ALL, // Unhide self and all below
+}
+
 export type BlockType =
   | [PpMode.horizontal]
   | [PpMode.vertical, integer]

--- a/client/src/panels/GoalPanel.ts
+++ b/client/src/panels/GoalPanel.ts
@@ -153,7 +153,7 @@ export default class GoalPanel {
   // /////////////////////////////////////////////////////////////////////////////
   public static proofViewNotification(extensionUri: Uri, editor: TextEditor, pv: ProofViewNotification) {
     
-    Client.writeToVscoq2Channel("[GoalPanel] Recieved proofview notification");
+    Client.writeToVscoq2Channel("[GoalPanel] Received proofview notification");
 
     if(!GoalPanel.currentPanel) {
         GoalPanel.render(editor, extensionUri, (goalPanel) => {
@@ -227,7 +227,7 @@ export default class GoalPanel {
 
   /**
    * Sets up an event listener to listen for messages passed from the webview context and
-   * executes code based on the message that is recieved.
+   * executes code based on the message that is received.
    *
    * @param webview A reference to the extension webview
    */

--- a/client/src/panels/SearchViewProvider.ts
+++ b/client/src/panels/SearchViewProvider.ts
@@ -129,7 +129,7 @@ export default class SearchViewProvider implements vscode.WebviewViewProvider {
 
   /**
    * Sets up an event listener to listen for messages passed from the webview context and
-   * executes code based on the message that is recieved.
+   * executes code based on the message that is received.
    *
    * @param webview A reference to the extension webview
    * @param context A reference to the extension context

--- a/client/src/utilities/versioning.ts
+++ b/client/src/utilities/versioning.ts
@@ -18,7 +18,7 @@ export const checkVersion = (client: Client, context: ExtensionContext) => {
             Client.writeToVscoq2Channel("Could not run compatibility tests: failed to get serverInfo");
         }  
     } else {
-        Client.writeToVscoq2Channel("Could not run compatibility tests: failed to recieve initializeResult");
+        Client.writeToVscoq2Channel("Could not run compatibility tests: failed to receive initializeResult");
     }
 
 };

--- a/language-server/vscoqtop/lspManager.ml
+++ b/language-server/vscoqtop/lspManager.ml
@@ -595,17 +595,17 @@ let dispatch_request : type a. Jsonrpc.Id.t -> a Request.Client.t -> (a,string) 
 
 let dispatch_std_notification = 
   let open Lsp.Client_notification in function
-  | TextDocumentDidOpen params -> log "Recieved notification: textDocument/didOpen";
+  | TextDocumentDidOpen params -> log "Received notification: textDocument/didOpen";
     begin try textDocumentDidOpen params with
       exn -> let info = Exninfo.capture exn in
       let message = "Error while opening document. " ^ Pp.string_of_ppcmds @@ CErrors.iprint_no_report info in
       send_error_notification message; []
     end
-  | TextDocumentDidChange params -> log "Recieved notification: textDocument/didChange";
+  | TextDocumentDidChange params -> log "Received notification: textDocument/didChange";
     textDocumentDidChange params
-  | TextDocumentDidClose params ->  log "Recieved notification: textDocument/didClose";
+  | TextDocumentDidClose params ->  log "Received notification: textDocument/didClose";
     textDocumentDidClose params
-  | ChangeConfiguration params -> log "Recieved notification: workspace/didChangeConfiguration";
+  | ChangeConfiguration params -> log "Received notification: workspace/didChangeConfiguration";
     workspaceDidChangeConfiguration params
   | Initialized -> []
   | Exit ->


### PR DESCRIPTION
Given the following case where you have a goal that is collapsed:
![image](https://github.com/user-attachments/assets/fbcabd67-4e9c-41fc-bab8-d741a2df673e)

You can use `alt + click` to expand it to something like this:
![image](https://github.com/user-attachments/assets/503994a1-8348-4a7a-bff1-d8b1e934aed8)

However, I frequently find myself wanting to expand all the way if I am doing expanding, so I added a feature such that `alt + shift + click` will expand the original to this instead (note that no ellipsis remain as it will expand everything below the clicked on ellipsis):
![image](https://github.com/user-attachments/assets/b6279f7b-e894-424d-a555-6ef734584715)


Additionally, I found some typos while adding this feature and fixing them is included as well.