### PR TITLE
build: we only support 64 bit arch

### DIFF
--- a/language-server/vscoq-language-server.opam
+++ b/language-server/vscoq-language-server.opam
@@ -31,6 +31,7 @@ depends: [
   "sel" {>= "0.4.0"}
 ]
 synopsis: "VSCoq language server"
+available: arch != "arm32" & arch != "x86_32"
 description: """
 LSP based language server for Coq and its VSCoq user interface
 """


### PR DESCRIPTION
Currently 32 bit architectures fail because of our representation of max memory in the server (see https://github.com/ocaml/opam-repository/pull/26506). We will not support it from now on. 