### PR TITLE
fix: make VsCoq activity bar logo appear only when Coq files present

### DIFF
--- a/client/coq-project.configuration.json
+++ b/client/coq-project.configuration.json
@@ -1,0 +1,5 @@
+{
+  "comments": {
+    "lineComment": "#"
+  }
+}

--- a/client/package.json
+++ b/client/package.json
@@ -29,7 +29,8 @@
   "bugs": "https://github.com/coq-community/vscoq/issues",
   "homepage": "https://github.com/coq-community/vscoq/blob/master/README.md",
   "activationEvents": [
-    "onLanguage:coq"
+    "workspaceContains:**/_CoqProject",
+    "workspaceContains:**/*.v"
   ],
   "main": "./dist/extension.js",
   "contributes": {
@@ -50,6 +51,21 @@
           "light": "./assets/logo.png",
           "dark": "./assets/logo.png"
         }
+      },
+      {
+        "id": "coq-project",
+        "aliases": [
+          "Coq Project",
+          "coq-project"
+        ],
+        "extensions": [
+          "_CoqProject"
+        ],
+        "configuration": "./coq-project.configuration.json",
+        "icon": {
+          "light": "./assets/logo.png",
+          "dark": "./assets/logo.png"
+        }
       }
     ],
     "grammars": [
@@ -57,6 +73,11 @@
         "language": "coq",
         "scopeName": "source.coq",
         "path": "./syntax/coq.tmLanguage.json"
+      },
+      {
+        "language": "coq-project",
+        "scopeName": "source.coq-project",
+        "path": "./syntax/coq-project.tmLanguage.json"
       }
     ],
     "viewsContainers": {
@@ -74,7 +95,7 @@
           "type": "webview",
           "id": "vscoq.search",
           "name": "Query",
-          "when": "coqFilesPresent"
+          "when": "inCoqProject"
         }
       ]
     },

--- a/client/package.json
+++ b/client/package.json
@@ -73,7 +73,8 @@
         {
           "type": "webview",
           "id": "vscoq.search",
-          "name": "Query"
+          "name": "Query",
+          "when": "coqFilesPresent"
         }
       ]
     },

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -52,6 +52,16 @@ let client: Client;
 
 export function activate(context: ExtensionContext) {
     commands.executeCommand('setContext', 'inCoqProject', true);
+
+    function checkInCoqProject() {
+        workspace.findFiles('**/{*.v,_CoqProject}').then(files => {
+            commands.executeCommand('setContext', 'inCoqProject', files.length > 0);
+        });
+    }
+
+    // Watch for files being added or removed
+    workspace.onDidCreateFiles(checkInCoqProject);
+    workspace.onDidDeleteFiles(checkInCoqProject);
     
     const coqTM = new VsCoqToolchainManager();
     coqTM.intialize().then(

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -51,27 +51,17 @@ import { QUICKFIX_COMMAND, CoqWarningQuickFix } from './QuickFixProvider';
 let client: Client;
 
 export function activate(context: ExtensionContext) {
+    commands.executeCommand('setContext', 'inCoqProject', true);
 
-    // Function to check for Coq files present in the workspace
-    function checkCoqFilesPresent() {
-      if (workspace.workspaceFolders) {
-        // Search for Coq files (*.v) in the current workspace
-        workspace.findFiles('**/*.v').then(files => {
-          const hasCoqFiles = files.length > 0;
-          commands.executeCommand('setContext', 'coqFilesPresent', hasCoqFiles);
+    function checkInCoqProject() {
+        workspace.findFiles('**/{*.v,_CoqProject}').then(files => {
+            commands.executeCommand('setContext', 'inCoqProject', files.length > 0);
         });
-      } else {
-        commands.executeCommand('setContext', 'coqFilesPresent', false);
-      }
     }
 
-    // Set initially on extension activation
-    checkCoqFilesPresent();
-
-    // Watch for changes to the workspace and files being added or removed
-    workspace.onDidChangeWorkspaceFolders(checkCoqFilesPresent);
-    workspace.onDidCreateFiles(checkCoqFilesPresent);
-    workspace.onDidDeleteFiles(checkCoqFilesPresent);
+    // Watch for files being added or removed
+    workspace.onDidCreateFiles(checkInCoqProject);
+    workspace.onDidDeleteFiles(checkInCoqProject);
     
     const coqTM = new VsCoqToolchainManager();
     coqTM.intialize().then(
@@ -403,4 +393,6 @@ Path: \`${coqTM.getVsCoqTopPath()}\`
 }
 
 // This method is called when your extension is deactivated
-export function deactivate() {}
+export function deactivate() {
+    commands.executeCommand('setContext', 'inCoqProject', undefined);
+}

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -51,6 +51,27 @@ import { QUICKFIX_COMMAND, CoqWarningQuickFix } from './QuickFixProvider';
 let client: Client;
 
 export function activate(context: ExtensionContext) {
+
+    // Function to check for Coq files present in the workspace
+    function checkCoqFilesPresent() {
+      if (workspace.workspaceFolders) {
+        // Search for Coq files (*.v) in the current workspace
+        workspace.findFiles('**/*.v').then(files => {
+          const hasCoqFiles = files.length > 0;
+          commands.executeCommand('setContext', 'coqFilesPresent', hasCoqFiles);
+        });
+      } else {
+        commands.executeCommand('setContext', 'coqFilesPresent', false);
+      }
+    }
+
+    // Set initially on extension activation
+    checkCoqFilesPresent();
+
+    // Watch for changes to the workspace and files being added or removed
+    workspace.onDidChangeWorkspaceFolders(checkCoqFilesPresent);
+    workspace.onDidCreateFiles(checkCoqFilesPresent);
+    workspace.onDidDeleteFiles(checkCoqFilesPresent);
     
     const coqTM = new VsCoqToolchainManager();
     coqTM.intialize().then(

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -52,16 +52,6 @@ let client: Client;
 
 export function activate(context: ExtensionContext) {
     commands.executeCommand('setContext', 'inCoqProject', true);
-
-    function checkInCoqProject() {
-        workspace.findFiles('**/{*.v,_CoqProject}').then(files => {
-            commands.executeCommand('setContext', 'inCoqProject', files.length > 0);
-        });
-    }
-
-    // Watch for files being added or removed
-    workspace.onDidCreateFiles(checkInCoqProject);
-    workspace.onDidDeleteFiles(checkInCoqProject);
     
     const coqTM = new VsCoqToolchainManager();
     coqTM.intialize().then(

--- a/client/syntax/coq-project.tmLanguage.json
+++ b/client/syntax/coq-project.tmLanguage.json
@@ -1,0 +1,32 @@
+{
+  "fileTypes": [
+    "_CoqProject"
+  ],
+  "name": "Coq Project",
+  "scopeName": "source.coq-project",
+  "patterns": [
+    {
+      "name": "comment.line.coq-project",
+      "match": "#.*$"
+    },
+    {
+      "name": "string.quoted.double.coq-project",
+      "begin": "\"",
+      "end": "\""
+    },
+    {
+      "name": "keyword.other.coq-project",
+      "match": "(-arg|-generate-meta-for-package|-docroot|-Q|-R|-I|-native-compiler)"
+    },
+    {
+      "name": "entity.name.file.coq-project",
+      "match": "(.*(\\|/))?(\\S+\\.v)"
+    },
+    {
+      "name": "entity.name.folder.coq-project",
+      "match": "(.*(\\|/))?(\\S+)"
+    }
+  ],
+  "repository": {},
+  "uuid": "94440acd-57c4-46ad-b59b-d05ab6902361"
+}


### PR DESCRIPTION
This adds a context to watch and track the presence of Coq files in the current workspace, and will dynamically display the activity bar logo only if Coq files are present.

Should fix #886 