### PR TITLE
Fix Hover for period qualifiers and single quotes in names

### DIFF
--- a/language-server/dm/rawDocument.ml
+++ b/language-server/dm/rawDocument.ml
@@ -87,7 +87,7 @@ let range_of_loc raw loc =
   }
 
 let word_at_position raw pos : string option =
-  let r = Str.regexp {|\([a-zA-Z_][a-zA-Z_0-9]*\)|} in
+  let r = Str.regexp {|\([a-zA-Z_.][a-zA-Z_0-9.']*\)|} in
   let start = ref (loc_of_position raw pos) in
   let word = ref None in
   while (start.contents >= 0 && Str.string_match r raw.text start.contents) do


### PR DESCRIPTION
This PR modified the `word_at_position` function to allow for `.` and `'` to appear in names.

This should fix #884 

One note: It does allow for "words" to begin with a `.`, however it is just handled by providing no hover information since it would not be a legal name in Coq.