### PR TITLE
fix: off by one error in Hover

### DIFF
--- a/language-server/dm/documentManager.ml
+++ b/language-server/dm/documentManager.ml
@@ -617,7 +617,7 @@ let hover st pos =
   match opattern with
   | None -> log "hover: no word found at cursor"; None
   | Some pattern ->
-    log ("hover: found word at cursor: " ^ pattern);
+    log ("hover: found word at cursor: \"" ^ pattern ^ "\"");
     let loc = RawDocument.loc_of_position (Document.raw_document st.document) pos in
     (* hover at previous sentence *)
     match hover_of_sentence st loc pattern (Document.find_sentence_before st.document loc) with

--- a/language-server/dm/rawDocument.ml
+++ b/language-server/dm/rawDocument.ml
@@ -99,7 +99,7 @@ let word_at_position raw pos : string option =
     (* we get the substring from the first word index to the last index for the word *)
     let word = String.sub raw.text first_word_ind (last_word_ind - first_word_ind) in
     Some word
-  with Not_found ->
+  with _ ->
     None
 
 let apply_text_edit raw (Range.{start; end_}, editText) =

--- a/language-server/dm/rawDocument.ml
+++ b/language-server/dm/rawDocument.ml
@@ -92,15 +92,15 @@ let word_at_position raw pos : string option =
     let start_ind = loc_of_position raw pos in
     (* Search backwards until we find a character that cannot be part of a word *)
     let first_non_word_ind = Str.search_backward back_reg raw.text start_ind in
+    let first_word_ind = first_non_word_ind + 1 in
     let forward_reg = Str.regexp {|[^a-zA-Z_0-9']|} in
     (* Search forwards ensuring that all characters are part of a well defined word. (Cannot start with [0-9'.] and cannot end with .)*)
     let last_word_ind = Str.search_forward forward_reg raw.text start_ind in
-    let word = String.sub raw.text first_non_word_ind (last_word_ind - first_non_word_ind) in
+    (* we get the substring from the first word index to the last index for the word *)
+    let word = String.sub raw.text first_word_ind (last_word_ind - first_word_ind) in
     Some word
   with Not_found ->
     None
-  (* then Some (Str.matched_string raw.text)
-  else None *)
 
 let apply_text_edit raw (Range.{start; end_}, editText) =
   let start = loc_of_position raw start in


### PR DESCRIPTION
Changes the string we are hovered on to be the start of the word index to end of word (does not include any period at the end)