### PR TITLE
feat: add config option to control whether Coq buttons are displayed

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,9 +151,6 @@ After installation and activation of the extension:
 * `"vscoq.args": []` -- an array of strings specifying additional command line arguments for `vscoqtop` (typically accepts the same flags as `coqtop`)
 * `"vscoq.trace.server": off | messages | verbose` -- Toggles the tracing of communications between the server and client
 
-### General
-* `"vscoq.general.display-buttons": bool` -- A toggle to control whether buttons related to Coq (step forward/back, reset, etc.) are displayed in the editor actions menu (defaults to `true`)
-
 #### Memory management (since >= 2.1.7)
 * `"vscoq.memory.limit: int` -- specifies the memory limit (in Gb) over which when a user closes a tab, the corresponding document state is discarded in the server to free up memory. Defaults to 4Gb.
 
@@ -171,6 +168,7 @@ After installation and activation of the extension:
   to delegate proofs. 
 * `"vscoq.proof.workers": int` -- Determines how many workers should be used for proof checking
 * `"vscoq.proof.block": bool` -- Determines if the the execution of a document should halt on first error.  Defaults to true (since version >= 2.1.7).
+* `"vscoq.proof.display-buttons": bool` -- A toggle to control whether buttons related to Coq (step forward/back, reset, etc.) are displayed in the editor actions menu (defaults to `true`)
 
 #### Code completion (experimental)
 * `"vscoq.completion.enable": bool` -- Toggle code completion (defaults to `false`)

--- a/README.md
+++ b/README.md
@@ -151,6 +151,9 @@ After installation and activation of the extension:
 * `"vscoq.args": []` -- an array of strings specifying additional command line arguments for `vscoqtop` (typically accepts the same flags as `coqtop`)
 * `"vscoq.trace.server": off | messages | verbose` -- Toggles the tracing of communications between the server and client
 
+### General
+* `"vscoq.general.display-buttons": bool` -- A toggle to control whether buttons related to Coq (step forward/back, reset, etc.) are displayed in the editor actions menu (defaults to `true`)
+
 #### Memory management (since >= 2.1.7)
 * `"vscoq.memory.limit: int` -- specifies the memory limit (in Gb) over which when a user closes a tab, the corresponding document state is discarded in the server to free up memory. Defaults to 4Gb.
 

--- a/client/package.json
+++ b/client/package.json
@@ -106,18 +106,6 @@
         }
       },
       {
-        "title": "General",
-        "type": "object",
-        "properties": {
-          "vscoq.general.display-buttons": {
-            "scope": "workspace",
-            "type": "boolean",
-            "default": true,
-            "description": "Toggles whether the Coq buttons are displayed in the editor actions tab menu."
-          }
-        }
-      },
-      {
         "title": "Memory management",
         "type": "object",
         "properties": {
@@ -222,6 +210,12 @@
             "type": "boolean",
             "default": true,
             "description": "Should execution be halted after reaching the first error ? "
+          },
+          "vscoq.proof.display-buttons": {
+            "scope": "workspace",
+            "type": "boolean",
+            "default": true,
+            "description": "Toggles whether the Coq buttons are displayed in the editor actions tab menu."
           }
         }
       },
@@ -391,37 +385,37 @@
     "menus": {
       "editor/title": [
         {
-          "when": "resourceLangId == coq && config.vscoq.general.display-buttons == true",
+          "when": "resourceLangId == coq && config.vscoq.proof.display-buttons == true",
           "command": "extension.coq.interpretToPoint",
           "group": "navigation@3"
         },
         {
-          "when": "resourceLangId == coq && config.vscoq.general.display-buttons == true",
+          "when": "resourceLangId == coq && config.vscoq.proof.display-buttons == true",
           "command": "extension.coq.stepForward",
           "group": "navigation@1"
         },
         {
-          "when": "resourceLangId == coq && config.vscoq.general.display-buttons == true",
+          "when": "resourceLangId == coq && config.vscoq.proof.display-buttons == true",
           "command": "extension.coq.stepBackward",
           "group": "navigation@2"
         },
         {
-          "when": "resourceLangId == coq && config.vscoq.general.display-buttons == true",
+          "when": "resourceLangId == coq && config.vscoq.proof.display-buttons == true",
           "command": "extension.coq.interpretToEnd",
           "group": "navigation@4"
         },
         {
-          "when": "resourceLangId == coq && config.vscoq.general.display-buttons == true",
+          "when": "resourceLangId == coq && config.vscoq.proof.display-buttons == true",
           "command": "extension.coq.reset",
           "group": "navigation@5"
         },
         {
-          "when": "resourceLangId == coq && config.vscoq.general.display-buttons == true && !config.vscoq.goals.auto",
+          "when": "resourceLangId == coq && config.vscoq.proof.display-buttons == true && !config.vscoq.goals.auto",
           "command": "extension.coq.displayProofView",
           "group": "navigation@0"
         },
         {
-          "when": "resourceLangId == coq && config.vscoq.general.display-buttons == true",
+          "when": "resourceLangId == coq && config.vscoq.proof.display-buttons == true",
           "submenu": "vscoq.menu",
           "group": "navigation@0"
         }

--- a/client/package.json
+++ b/client/package.json
@@ -106,6 +106,18 @@
         }
       },
       {
+        "title": "General",
+        "type": "object",
+        "properties": {
+          "vscoq.general.display-buttons": {
+            "scope": "workspace",
+            "type": "boolean",
+            "default": true,
+            "description": "Toggles whether the Coq buttons are displayed in the editor actions tab menu."
+          }
+        }
+      },
+      {
         "title": "Memory management",
         "type": "object",
         "properties": {
@@ -206,10 +218,10 @@
             "description": "Amount of workers assigned to proofs in delegation mode"
           },
           "vscoq.proof.block": {
-              "scope": "window",
-              "type": "boolean",
-              "default": true,
-              "description": "Should execution be halted after reaching the first error ? "
+            "scope": "window",
+            "type": "boolean",
+            "default": true,
+            "description": "Should execution be halted after reaching the first error ? "
           }
         }
       },
@@ -379,42 +391,42 @@
     "menus": {
       "editor/title": [
         {
-            "when": "resourceLangId == coq",
-            "command": "extension.coq.interpretToPoint",
-            "group": "navigation@3"
+          "when": "resourceLangId == coq && config.vscoq.general.display-buttons == true",
+          "command": "extension.coq.interpretToPoint",
+          "group": "navigation@3"
         },
         {
-          "when": "resourceLangId == coq",
+          "when": "resourceLangId == coq && config.vscoq.general.display-buttons == true",
           "command": "extension.coq.stepForward",
           "group": "navigation@1"
         },
         {
-          "when": "resourceLangId == coq",
+          "when": "resourceLangId == coq && config.vscoq.general.display-buttons == true",
           "command": "extension.coq.stepBackward",
           "group": "navigation@2"
         },
         {
-          "when": "resourceLangId == coq",
+          "when": "resourceLangId == coq && config.vscoq.general.display-buttons == true",
           "command": "extension.coq.interpretToEnd",
           "group": "navigation@4"
         },
         {
-          "when": "resourceLangId == coq",
+          "when": "resourceLangId == coq && config.vscoq.general.display-buttons == true",
           "command": "extension.coq.reset",
           "group": "navigation@5"
         },
         {
-          "when": "resourceLangId == coq && !config.vscoq.goals.auto",
+          "when": "resourceLangId == coq && config.vscoq.general.display-buttons == true && !config.vscoq.goals.auto",
           "command": "extension.coq.displayProofView",
           "group": "navigation@0"
         },
         {
-          "when": "resourceLangId == coq",
+          "when": "resourceLangId == coq && config.vscoq.general.display-buttons == true",
           "submenu": "vscoq.menu",
           "group": "navigation@0"
         }
       ],
-      "vscoq.menu":[
+      "vscoq.menu": [
         {
           "when": "resourceLangId == coq",
           "command": "extension.coq.documentState",
@@ -436,14 +448,14 @@
           "group": "2_documentation@0"
         }
       ],
-      "vscoq.menu.doc":[
+      "vscoq.menu.doc": [
         {
-            "when": "resourceLangId == coq",
-            "command": "extension.coq.walkthrough"
+          "when": "resourceLangId == coq",
+          "command": "extension.coq.walkthrough"
         },
         {
-            "when": "resourceLangId == coq",
-            "command": "extension.coq.showManual"
+          "when": "resourceLangId == coq",
+          "command": "extension.coq.showManual"
         }
       ],
       "editor/context": [
@@ -859,46 +871,46 @@
       }
     ],
     "walkthroughs": [
-        {
-            "id": "coq.welcome",
-            "title": "Coq Setup",
-            "description": "Getting started with Coq",
-            "steps": [
-                {
-                    "id": "coq.welcome.openHelpPage",
-                    "title": "Re-open the setup page",
-                    "description": "This page is accessible at any moment by opening an empty file, clicking on the Coq menu and selecting ``Documentation > Docs: Show Setup Guide`` from the drop down menu.",
-                    "media": {
-                        "image": "./media/open_walkthrough.png",
-                        "altText": "Click on the Coq symbol and go to ```Docs: Show Setup Guide``` to re-open this walkthrough."
-                    }
-                },
-                {
-                    "id": "coq.welcome.books",
-                    "title": "Ressources to get started in the Coq world",
-                    "description": "You can find helpful books, documentations, and tutorials on this page",
-                    "media": {
-                        "markdown": "./media/books.md"
-                    }
-                },
-                {
-                    "id": "coq.welcome.install",
-                    "title": "Install dependencies",
-                    "description": "How to install Coq, setup VsCoq and its dependencies",
-                    "media": {
-                        "markdown": "./media/install.md"
-                    }
-                },
-                {
-                    "id": "coq.welcome.troubleshooting",
-                    "title": "Getting help",
-                    "description": "If you have any questions or are having problem with any of the previous steps, please head over to the [Coq zulip chat](https://coq.zulipchat.com/) so we can help you.",
-                    "media": {
-                        "markdown": "./media/troubleshooting.md"
-                    }
-                }
-            ]
-        }
+      {
+        "id": "coq.welcome",
+        "title": "Coq Setup",
+        "description": "Getting started with Coq",
+        "steps": [
+          {
+            "id": "coq.welcome.openHelpPage",
+            "title": "Re-open the setup page",
+            "description": "This page is accessible at any moment by opening an empty file, clicking on the Coq menu and selecting ``Documentation > Docs: Show Setup Guide`` from the drop down menu.",
+            "media": {
+              "image": "./media/open_walkthrough.png",
+              "altText": "Click on the Coq symbol and go to ```Docs: Show Setup Guide``` to re-open this walkthrough."
+            }
+          },
+          {
+            "id": "coq.welcome.books",
+            "title": "Ressources to get started in the Coq world",
+            "description": "You can find helpful books, documentations, and tutorials on this page",
+            "media": {
+              "markdown": "./media/books.md"
+            }
+          },
+          {
+            "id": "coq.welcome.install",
+            "title": "Install dependencies",
+            "description": "How to install Coq, setup VsCoq and its dependencies",
+            "media": {
+              "markdown": "./media/install.md"
+            }
+          },
+          {
+            "id": "coq.welcome.troubleshooting",
+            "title": "Getting help",
+            "description": "If you have any questions or are having problem with any of the previous steps, please head over to the [Coq zulip chat](https://coq.zulipchat.com/) so we can help you.",
+            "media": {
+              "markdown": "./media/troubleshooting.md"
+            }
+          }
+        ]
+      }
     ]
   },
   "scripts": {


### PR DESCRIPTION
I personally don't like many buttons in the Editor Actions tab menu, so I think it would be nice to be able to disable them from appearing.
When `vscoq.general.display-buttons == true` (which it is by default) the buttons will be visible:
![image](https://github.com/user-attachments/assets/b35cbf8b-e974-4f02-8ea0-d426f38be3fb)
Otherwise, the buttons won't appear.

I could not really think of a good pre-existing setting scope to put them in, so I created one called `general`, but if anyone has renaming thoughts or a better place to put it just feel free.